### PR TITLE
fix: use custom release command to avoid duplicate tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,6 @@ jobs:
 
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
-      contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
 
     steps:
       # Set up
@@ -42,5 +41,9 @@ jobs:
           bundler-cache: true
           ruby-version: ruby
 
-      # Release
+      # Release - only push gem, skip git operations since release-please already tagged
       - uses: rubygems/release-gem@1c162a739e8b4cb21a676e97b087e8268d8fc40b
+        with:
+          release-command: |
+            bundle exec rake build
+            gem push pkg/*.gem


### PR DESCRIPTION
Release-please already creates and pushes the version tag when creating
the GitHub release. The default `rake release` command tries to push the
same tag again, causing a conflict.

Replace with `rake build` + `gem push` to only push the gem without
attempting git operations that are already handled by release-please.