### PR TITLE
Fix #39: Add support for mistral vibe

### DIFF
--- a/lib/agent_harness.rb
+++ b/lib/agent_harness.rb
@@ -157,6 +157,7 @@ require_relative "agent_harness/providers/cursor"
 require_relative "agent_harness/providers/gemini"
 require_relative "agent_harness/providers/github_copilot"
 require_relative "agent_harness/providers/kilocode"
+require_relative "agent_harness/providers/mistral_vibe"
 require_relative "agent_harness/providers/opencode"
 
 # Orchestration layer

--- a/lib/agent_harness/providers/mistral_vibe.rb
+++ b/lib/agent_harness/providers/mistral_vibe.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module AgentHarness
+  module Providers
+    # Mistral Vibe CLI provider
+    #
+    # Provides integration with the Mistral Vibe CLI agent tool.
+    class MistralVibe < Base
+      class << self
+        def provider_name
+          :mistral_vibe
+        end
+
+        def binary_name
+          "mistral-vibe"
+        end
+
+        def available?
+          executor = AgentHarness.configuration.command_executor
+          !!executor.which(binary_name)
+        end
+
+        def firewall_requirements
+          {
+            domains: [
+              "api.mistral.ai"
+            ],
+            ip_ranges: []
+          }
+        end
+
+        def instruction_file_paths
+          []
+        end
+
+        def discover_models
+          return [] unless available?
+          []
+        end
+      end
+
+      def name
+        "mistral_vibe"
+      end
+
+      def display_name
+        "Mistral Vibe CLI"
+      end
+
+      def capabilities
+        {
+          streaming: false,
+          file_upload: false,
+          vision: false,
+          tool_use: false,
+          json_mode: false,
+          mcp: false,
+          dangerous_mode: false
+        }
+      end
+
+      protected
+
+      def build_command(prompt, options)
+        cmd = [self.class.binary_name, "run"]
+        cmd << prompt
+        cmd
+      end
+
+      def default_timeout
+        300
+      end
+    end
+  end
+end

--- a/lib/agent_harness/providers/registry.rb
+++ b/lib/agent_harness/providers/registry.rb
@@ -123,6 +123,7 @@ module AgentHarness
         register_if_available(:opencode, "agent_harness/providers/opencode", :Opencode)
         register_if_available(:kilocode, "agent_harness/providers/kilocode", :Kilocode)
         register_if_available(:aider, "agent_harness/providers/aider", :Aider)
+        register_if_available(:mistral_vibe, "agent_harness/providers/mistral_vibe", :MistralVibe)
       end
 
       def register_if_available(name, require_path, class_name, aliases: [])

--- a/spec/agent_harness/providers/mistral_vibe_spec.rb
+++ b/spec/agent_harness/providers/mistral_vibe_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.describe AgentHarness::Providers::MistralVibe do
+  describe ".provider_name" do
+    it "returns :mistral_vibe" do
+      expect(described_class.provider_name).to eq(:mistral_vibe)
+    end
+  end
+
+  describe ".binary_name" do
+    it "returns mistral-vibe" do
+      expect(described_class.binary_name).to eq("mistral-vibe")
+    end
+  end
+
+  describe ".firewall_requirements" do
+    it "returns Mistral API domain" do
+      requirements = described_class.firewall_requirements
+      expect(requirements[:domains]).to eq(["api.mistral.ai"])
+      expect(requirements[:ip_ranges]).to eq([])
+    end
+  end
+
+  describe ".instruction_file_paths" do
+    it "returns empty array" do
+      expect(described_class.instruction_file_paths).to eq([])
+    end
+  end
+
+  describe ".discover_models" do
+    it "returns empty when not available" do
+      allow(described_class).to receive(:available?).and_return(false)
+      expect(described_class.discover_models).to eq([])
+    end
+  end
+
+  describe "instance" do
+    let(:mock_executor) do
+      instance_double(AgentHarness::CommandExecutor)
+    end
+
+    subject(:provider) { described_class.new(executor: mock_executor) }
+
+    describe "#name" do
+      it "returns mistral_vibe" do
+        expect(provider.name).to eq("mistral_vibe")
+      end
+    end
+
+    describe "#display_name" do
+      it "returns Mistral Vibe CLI" do
+        expect(provider.display_name).to eq("Mistral Vibe CLI")
+      end
+    end
+
+    describe "#capabilities" do
+      it "returns minimal capabilities" do
+        caps = provider.capabilities
+        expect(caps[:streaming]).to be false
+        expect(caps[:mcp]).to be false
+        expect(caps[:dangerous_mode]).to be false
+      end
+    end
+
+    describe "#send_message" do
+      it "executes mistral-vibe run with the prompt" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "response",
+            stderr: "",
+            exit_code: 0,
+            duration: 1.0
+          )
+        )
+
+        expect(mock_executor).to receive(:execute).with(
+          ["mistral-vibe", "run", "Hello"],
+          anything
+        )
+
+        provider.send_message(prompt: "Hello")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Commit succeeded. Here's what was done:

**Files created:**
- `lib/agent_harness/providers/mistral_vibe.rb` — New `MistralVibe` provider class with `mistral-vibe` binary, `api.mistral.ai` firewall domain, and standard capabilities
- `spec/agent_harness/providers/mistral_vibe_spec.rb` — Full test coverage (9 examples)

**Files modified:**
- `lib/agent_harness.rb` — Added `require_relative` for the new provider
- `lib/agent_harness/providers/registry.rb` — Registered `:mistral_vibe` in the builtin providers list

All 498 tests pass, rubocop clean, pre-commit hooks passed.

---

Closes #39