### PR TITLE
Fix #54: Add per-request provider runtime overrides for CLI-backed providers

### DIFF
--- a/lib/agent_harness.rb
+++ b/lib/agent_harness.rb
@@ -138,6 +138,7 @@ end
 # Core components
 require_relative "agent_harness/errors"
 require_relative "agent_harness/mcp_server"
+require_relative "agent_harness/provider_runtime"
 require_relative "agent_harness/configuration"
 require_relative "agent_harness/command_executor"
 require_relative "agent_harness/docker_command_executor"

--- a/lib/agent_harness/provider_runtime.rb
+++ b/lib/agent_harness/provider_runtime.rb
@@ -51,7 +51,11 @@ module AgentHarness
       end
       @env = normalized_env.freeze
 
-      normalized_flags = Array(flags).dup
+      normalized_flags = flags || []
+      unless normalized_flags.is_a?(Array)
+        raise ArgumentError, "flags must be an Array (got #{normalized_flags.class})"
+      end
+      normalized_flags = normalized_flags.dup
       normalized_flags.each_with_index do |flag, index|
         unless flag.is_a?(String)
           raise ArgumentError,

--- a/lib/agent_harness/provider_runtime.rb
+++ b/lib/agent_harness/provider_runtime.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module AgentHarness
+  # Normalized runtime configuration for per-request provider overrides.
+  #
+  # ProviderRuntime lets callers pass a single, provider-agnostic payload
+  # into +send_message+ that each provider materializes into CLI args, env
+  # vars, or config files as needed.
+  #
+  # @example Routing OpenCode through OpenRouter with a specific model
+  #   runtime = AgentHarness::ProviderRuntime.new(
+  #     model: "anthropic/claude-opus-4.1",
+  #     base_url: "https://openrouter.ai/api/v1",
+  #     api_provider: "openrouter",
+  #     env: { "OPENROUTER_API_KEY" => "sk-..." }
+  #   )
+  #   provider.send_message(prompt: "Hello", provider_runtime: runtime)
+  #
+  # @example Passing a Hash (auto-coerced by Base#send_message)
+  #   provider.send_message(
+  #     prompt: "Hello",
+  #     provider_runtime: {
+  #       model: "openai/gpt-5.3-codex",
+  #       base_url: "https://openrouter.ai/api/v1"
+  #     }
+  #   )
+  class ProviderRuntime
+    attr_reader :model, :base_url, :api_provider, :env, :flags, :metadata
+
+    # @param model [String, nil] model identifier override
+    # @param base_url [String, nil] upstream API base URL override
+    # @param api_provider [String, nil] API-compatible backend name
+    # @param env [Hash<String,String>] extra environment variables for the subprocess
+    # @param flags [Array<String>] extra CLI flags to append
+    # @param metadata [Hash] arbitrary provider-specific data
+    def initialize(model: nil, base_url: nil, api_provider: nil, env: {}, flags: [], metadata: {})
+      @model = model
+      @base_url = base_url
+      @api_provider = api_provider
+      @env = env.transform_keys(&:to_s).freeze
+      @flags = Array(flags).freeze
+      @metadata = metadata.freeze
+
+      freeze
+    end
+
+    # Build a ProviderRuntime from a Hash.
+    #
+    # @param hash [Hash] runtime attributes
+    # @return [ProviderRuntime]
+    def self.from_hash(hash)
+      new(
+        model: hash[:model] || hash["model"],
+        base_url: hash[:base_url] || hash["base_url"],
+        api_provider: hash[:api_provider] || hash["api_provider"],
+        env: hash[:env] || hash["env"] || {},
+        flags: hash[:flags] || hash["flags"] || [],
+        metadata: hash[:metadata] || hash["metadata"] || {}
+      )
+    end
+
+    # Coerce a value into a ProviderRuntime.
+    #
+    # @param value [ProviderRuntime, Hash, nil] input
+    # @return [ProviderRuntime, nil]
+    def self.wrap(value)
+      case value
+      when ProviderRuntime then value
+      when Hash then from_hash(value)
+      when nil then nil
+      else
+        raise ArgumentError, "Cannot coerce #{value.class} into ProviderRuntime"
+      end
+    end
+
+    # Whether any meaningful overrides are present.
+    #
+    # @return [Boolean]
+    def empty?
+      model.nil? && base_url.nil? && api_provider.nil? &&
+        env.empty? && flags.empty? && metadata.empty?
+    end
+  end
+end

--- a/lib/agent_harness/provider_runtime.rb
+++ b/lib/agent_harness/provider_runtime.rb
@@ -37,7 +37,14 @@ module AgentHarness
       @model = model
       @base_url = base_url
       @api_provider = api_provider
-      @env = env.transform_keys(&:to_s).freeze
+      normalized_env = env.each_with_object({}) do |(key, value), acc|
+        string_key = key.to_s
+        unless value.is_a?(String)
+          raise ArgumentError, "env value for #{string_key.inspect} must be a String (got #{value.class})"
+        end
+        acc[string_key] = value
+      end
+      @env = normalized_env.freeze
       @flags = Array(flags).freeze
       @metadata = metadata.freeze
 

--- a/lib/agent_harness/provider_runtime.rb
+++ b/lib/agent_harness/provider_runtime.rb
@@ -38,7 +38,11 @@ module AgentHarness
       @base_url = base_url
       @api_provider = api_provider
 
-      normalized_env = (env || {}).each_with_object({}) do |(key, value), acc|
+      env_hash = env || {}
+      unless env_hash.is_a?(Hash)
+        raise ArgumentError, "env must be a Hash (got #{env_hash.class})"
+      end
+      normalized_env = env_hash.each_with_object({}) do |(key, value), acc|
         string_key = key.to_s
         unless value.is_a?(String)
           raise ArgumentError, "env value for #{string_key.inspect} must be a String (got #{value.class})"
@@ -47,7 +51,7 @@ module AgentHarness
       end
       @env = normalized_env.freeze
 
-      normalized_flags = Array(flags)
+      normalized_flags = Array(flags).dup
       normalized_flags.each_with_index do |flag, index|
         unless flag.is_a?(String)
           raise ArgumentError,
@@ -56,7 +60,11 @@ module AgentHarness
       end
       @flags = normalized_flags.freeze
 
-      @metadata = (metadata || {}).freeze
+      metadata_hash = metadata || {}
+      unless metadata_hash.is_a?(Hash)
+        raise ArgumentError, "metadata must be a Hash (got #{metadata_hash.class})"
+      end
+      @metadata = metadata_hash.dup.freeze
 
       freeze
     end
@@ -66,6 +74,8 @@ module AgentHarness
     # @param hash [Hash] runtime attributes
     # @return [ProviderRuntime]
     def self.from_hash(hash)
+      raise ArgumentError, "expected a Hash, got #{hash.class}" unless hash.is_a?(Hash)
+
       new(
         model: hash[:model] || hash["model"],
         base_url: hash[:base_url] || hash["base_url"],

--- a/lib/agent_harness/provider_runtime.rb
+++ b/lib/agent_harness/provider_runtime.rb
@@ -37,7 +37,8 @@ module AgentHarness
       @model = model
       @base_url = base_url
       @api_provider = api_provider
-      normalized_env = env.each_with_object({}) do |(key, value), acc|
+
+      normalized_env = (env || {}).each_with_object({}) do |(key, value), acc|
         string_key = key.to_s
         unless value.is_a?(String)
           raise ArgumentError, "env value for #{string_key.inspect} must be a String (got #{value.class})"
@@ -45,8 +46,17 @@ module AgentHarness
         acc[string_key] = value
       end
       @env = normalized_env.freeze
-      @flags = Array(flags).freeze
-      @metadata = metadata.freeze
+
+      normalized_flags = Array(flags)
+      normalized_flags.each_with_index do |flag, index|
+        unless flag.is_a?(String)
+          raise ArgumentError,
+            "flags must be an Array of Strings; invalid element at index #{index}: #{flag.inspect} (#{flag.class})"
+        end
+      end
+      @flags = normalized_flags.freeze
+
+      @metadata = (metadata || {}).freeze
 
       freeze
     end

--- a/lib/agent_harness/providers/adapter.rb
+++ b/lib/agent_harness/providers/adapter.rb
@@ -75,6 +75,9 @@ module AgentHarness
       # @option options [Integer] :timeout timeout in seconds
       # @option options [String] :session session identifier
       # @option options [Boolean] :dangerous_mode skip permission checks
+      # @option options [ProviderRuntime, Hash, nil] :provider_runtime per-request
+      #   runtime overrides (model, base_url, api_provider, env, flags, metadata).
+      #   A plain Hash is automatically coerced into a ProviderRuntime.
       # @return [Response] response object with output and metadata
       def send_message(prompt:, **options)
         raise NotImplementedError, "#{self.class} must implement #send_message"

--- a/lib/agent_harness/providers/adapter.rb
+++ b/lib/agent_harness/providers/adapter.rb
@@ -77,7 +77,9 @@ module AgentHarness
       # @option options [Boolean] :dangerous_mode skip permission checks
       # @option options [ProviderRuntime, Hash, nil] :provider_runtime per-request
       #   runtime overrides (model, base_url, api_provider, env, flags, metadata).
-      #   A plain Hash is automatically coerced into a ProviderRuntime.
+      #   For providers that delegate to Providers::Base#send_message, a plain Hash
+      #   is automatically coerced into a ProviderRuntime. Providers that override
+      #   #send_message directly are responsible for handling this option.
       # @return [Response] response object with output and metadata
       def send_message(prompt:, **options)
         raise NotImplementedError, "#{self.class} must implement #send_message"

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -115,7 +115,7 @@ module AgentHarness
         # Parse response — use runtime model for the response when provided
         response = parse_response(result, duration: duration)
         runtime = options[:provider_runtime]
-        if runtime&.model && response.model.nil?
+        if runtime&.model
           response = Response.new(
             output: response.output,
             exit_code: response.exit_code,

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -112,9 +112,13 @@ module AgentHarness
         result = execute_with_timeout(command, timeout: timeout, env: build_env(options))
         duration = Time.now - start_time
 
-        # Parse response — use runtime model for the response when provided
+        # Parse response
         response = parse_response(result, duration: duration)
         runtime = options[:provider_runtime]
+        # Runtime model is a per-request override and always takes precedence
+        # over both the config-level model and whatever parse_response returned.
+        # This is intentional: callers use runtime overrides to route a single
+        # provider instance through different backends on each request.
         if runtime&.model
           response = Response.new(
             output: response.output,

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -284,7 +284,7 @@ module AgentHarness
 
         AgentHarness.token_tracker.record(
           provider: self.class.provider_name,
-          model: @config.model,
+          model: response.model || @config.model,
           input_tokens: response.tokens[:input] || 0,
           output_tokens: response.tokens[:output] || 0,
           total_tokens: response.tokens[:total]

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -87,9 +87,15 @@ module AgentHarness
       #
       # @param prompt [String] the prompt to send
       # @param options [Hash] additional options
+      # @option options [ProviderRuntime, Hash, nil] :provider_runtime per-request
+      #   runtime overrides (model, base_url, api_provider, env, flags, metadata).
+      #   A plain Hash is automatically coerced into a ProviderRuntime.
       # @return [Response] the response
       def send_message(prompt:, **options)
         log_debug("send_message_start", prompt_length: prompt.length, options: options.keys)
+
+        # Coerce provider_runtime from Hash if needed
+        options = normalize_provider_runtime(options)
 
         # Normalize and validate MCP servers
         options = normalize_mcp_servers(options)
@@ -106,8 +112,21 @@ module AgentHarness
         result = execute_with_timeout(command, timeout: timeout, env: build_env(options))
         duration = Time.now - start_time
 
-        # Parse response
+        # Parse response — use runtime model for the response when provided
         response = parse_response(result, duration: duration)
+        runtime = options[:provider_runtime]
+        if runtime&.model && response.model.nil?
+          response = Response.new(
+            output: response.output,
+            exit_code: response.exit_code,
+            duration: response.duration,
+            provider: response.provider,
+            model: runtime.model,
+            tokens: response.tokens,
+            metadata: response.metadata,
+            error: response.error
+          )
+        end
 
         # Track tokens
         track_tokens(response) if response.tokens
@@ -158,10 +177,16 @@ module AgentHarness
 
       # Build environment variables - override in subclasses
       #
+      # Provider subclasses should call +super+ and merge their own env vars
+      # so that ProviderRuntime env overrides are always included.
+      #
       # @param options [Hash] options
       # @return [Hash] environment variables
       def build_env(options)
-        {}
+        runtime = options[:provider_runtime]
+        return {} unless runtime
+
+        runtime.env.dup
       end
 
       # Parse CLI output into Response - override in subclasses
@@ -210,6 +235,13 @@ module AgentHarness
       end
 
       private
+
+      def normalize_provider_runtime(options)
+        raw = options[:provider_runtime]
+        return options if raw.nil? || raw.is_a?(ProviderRuntime)
+
+        options.merge(provider_runtime: ProviderRuntime.wrap(raw))
+      end
 
       def normalize_mcp_servers(options)
         servers = options[:mcp_servers]

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -219,9 +219,24 @@ module AgentHarness
           cmd += session_flags(options[:session])
         end
 
+        runtime = options[:provider_runtime]
+        if runtime
+          cmd += ["--model", runtime.model] if runtime.model
+          cmd += runtime.flags unless runtime.flags.empty?
+        end
+
         cmd << prompt
 
         cmd
+      end
+
+      def build_env(options)
+        env = super
+        runtime = options[:provider_runtime]
+        return env unless runtime
+
+        env["OPENAI_BASE_URL"] = runtime.base_url if runtime.base_url
+        env
       end
 
       def default_timeout

--- a/lib/agent_harness/providers/cursor.rb
+++ b/lib/agent_harness/providers/cursor.rb
@@ -192,8 +192,11 @@ module AgentHarness
         result = @executor.execute(command, timeout: timeout, stdin_data: prompt, env: env)
         duration = Time.now - start_time
 
-        # Parse response — use runtime model for the response when provided
+        # Parse response
         response = parse_response(result, duration: duration)
+        # Runtime model is a per-request override and always takes precedence
+        # over both the config-level model and whatever parse_response returned.
+        # See Base#send_message for rationale.
         if runtime&.model
           response = Response.new(
             output: response.output,

--- a/lib/agent_harness/providers/cursor.rb
+++ b/lib/agent_harness/providers/cursor.rb
@@ -227,10 +227,7 @@ module AgentHarness
       end
 
       def build_env(options)
-        runtime = options[:provider_runtime]
-        return {} unless runtime
-
-        runtime.env.dup
+        super
       end
 
       def default_timeout

--- a/lib/agent_harness/providers/cursor.rb
+++ b/lib/agent_harness/providers/cursor.rb
@@ -171,23 +171,41 @@ module AgentHarness
       def send_message(prompt:, **options)
         log_debug("send_message_start", prompt_length: prompt.length, options: options.keys)
 
+        # Coerce provider_runtime from Hash if needed (same as Base#send_message)
+        options = normalize_provider_runtime(options)
+        runtime = options[:provider_runtime]
+
         # Normalize and validate MCP servers (same as Base#send_message)
         options = normalize_mcp_servers(options)
         validate_mcp_servers!(options[:mcp_servers]) if options[:mcp_servers]&.any?
 
         # Build command (without prompt in args - we send via stdin)
         command = [self.class.binary_name, "-p"]
+        command.concat(runtime.flags) if runtime&.flags&.any?
 
         # Calculate timeout
         timeout = options[:timeout] || @config.timeout || default_timeout
 
         # Execute command with prompt on stdin
+        env = build_env(options)
         start_time = Time.now
-        result = @executor.execute(command, timeout: timeout, stdin_data: prompt)
+        result = @executor.execute(command, timeout: timeout, stdin_data: prompt, env: env)
         duration = Time.now - start_time
 
-        # Parse response
+        # Parse response — use runtime model for the response when provided
         response = parse_response(result, duration: duration)
+        if runtime&.model && response.model.nil?
+          response = Response.new(
+            output: response.output,
+            exit_code: response.exit_code,
+            duration: response.duration,
+            provider: response.provider,
+            model: runtime.model,
+            tokens: response.tokens,
+            metadata: response.metadata,
+            error: response.error
+          )
+        end
 
         # Track tokens
         track_tokens(response) if response.tokens
@@ -209,7 +227,10 @@ module AgentHarness
       end
 
       def build_env(options)
-        {}
+        runtime = options[:provider_runtime]
+        return {} unless runtime
+
+        runtime.env.dup
       end
 
       def default_timeout

--- a/lib/agent_harness/providers/cursor.rb
+++ b/lib/agent_harness/providers/cursor.rb
@@ -194,7 +194,7 @@ module AgentHarness
 
         # Parse response — use runtime model for the response when provided
         response = parse_response(result, duration: duration)
-        if runtime&.model && response.model.nil?
+        if runtime&.model
           response = Response.new(
             output: response.output,
             exit_code: response.exit_code,

--- a/lib/agent_harness/providers/opencode.rb
+++ b/lib/agent_harness/providers/opencode.rb
@@ -88,8 +88,23 @@ module AgentHarness
 
       def build_command(prompt, options)
         cmd = [self.class.binary_name, "run"]
+
+        runtime = options[:provider_runtime]
+        if runtime
+          cmd += runtime.flags unless runtime.flags.empty?
+        end
+
         cmd << prompt
         cmd
+      end
+
+      def build_env(options)
+        env = super
+        runtime = options[:provider_runtime]
+        return env unless runtime
+
+        env["OPENAI_BASE_URL"] = runtime.base_url if runtime.base_url
+        env
       end
 
       def default_timeout

--- a/spec/agent_harness/provider_runtime_spec.rb
+++ b/spec/agent_harness/provider_runtime_spec.rb
@@ -81,6 +81,28 @@ RSpec.describe AgentHarness::ProviderRuntime do
       expect(runtime.flags).to be_frozen
       expect(runtime.metadata).to be_frozen
     end
+
+    it "does not freeze the caller's flags array" do
+      caller_flags = ["--verbose"]
+      described_class.new(flags: caller_flags)
+      expect(caller_flags).not_to be_frozen
+    end
+
+    it "does not freeze the caller's metadata hash" do
+      caller_metadata = {tier: "premium"}
+      described_class.new(metadata: caller_metadata)
+      expect(caller_metadata).not_to be_frozen
+    end
+
+    it "raises ArgumentError when env is not a Hash" do
+      expect { described_class.new(env: "bad") }
+        .to raise_error(ArgumentError, /env must be a Hash/)
+    end
+
+    it "raises ArgumentError when metadata is not a Hash" do
+      expect { described_class.new(metadata: "bad") }
+        .to raise_error(ArgumentError, /metadata must be a Hash/)
+    end
   end
 
   describe ".from_hash" do
@@ -111,6 +133,11 @@ RSpec.describe AgentHarness::ProviderRuntime do
       expect(runtime.model).to be_nil
       expect(runtime.env).to eq({})
       expect(runtime.flags).to eq([])
+    end
+
+    it "raises ArgumentError when given a non-Hash" do
+      expect { described_class.from_hash("bad") }
+        .to raise_error(ArgumentError, /expected a Hash/)
     end
   end
 

--- a/spec/agent_harness/provider_runtime_spec.rb
+++ b/spec/agent_harness/provider_runtime_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+RSpec.describe AgentHarness::ProviderRuntime do
+  describe "#initialize" do
+    it "accepts all keyword arguments" do
+      runtime = described_class.new(
+        model: "gpt-5",
+        base_url: "https://example.com",
+        api_provider: "openrouter",
+        env: {"API_KEY" => "sk-123"},
+        flags: ["--verbose"],
+        metadata: {tier: "premium"}
+      )
+
+      expect(runtime.model).to eq("gpt-5")
+      expect(runtime.base_url).to eq("https://example.com")
+      expect(runtime.api_provider).to eq("openrouter")
+      expect(runtime.env).to eq("API_KEY" => "sk-123")
+      expect(runtime.flags).to eq(["--verbose"])
+      expect(runtime.metadata).to eq(tier: "premium")
+    end
+
+    it "defaults optional fields" do
+      runtime = described_class.new
+      expect(runtime.model).to be_nil
+      expect(runtime.base_url).to be_nil
+      expect(runtime.api_provider).to be_nil
+      expect(runtime.env).to eq({})
+      expect(runtime.flags).to eq([])
+      expect(runtime.metadata).to eq({})
+    end
+
+    it "converts symbol env keys to strings" do
+      runtime = described_class.new(env: {MY_VAR: "val"})
+      expect(runtime.env).to eq("MY_VAR" => "val")
+    end
+
+    it "freezes the instance" do
+      runtime = described_class.new(model: "gpt-5")
+      expect(runtime).to be_frozen
+    end
+
+    it "freezes env, flags, and metadata" do
+      runtime = described_class.new(
+        env: {"K" => "V"},
+        flags: ["--foo"],
+        metadata: {a: 1}
+      )
+
+      expect(runtime.env).to be_frozen
+      expect(runtime.flags).to be_frozen
+      expect(runtime.metadata).to be_frozen
+    end
+  end
+
+  describe ".from_hash" do
+    it "builds from symbol-keyed hash" do
+      runtime = described_class.from_hash(
+        model: "claude-opus",
+        base_url: "https://api.example.com",
+        api_provider: "openrouter"
+      )
+
+      expect(runtime.model).to eq("claude-opus")
+      expect(runtime.base_url).to eq("https://api.example.com")
+      expect(runtime.api_provider).to eq("openrouter")
+    end
+
+    it "builds from string-keyed hash" do
+      runtime = described_class.from_hash(
+        "model" => "gpt-5",
+        "base_url" => "https://api.example.com"
+      )
+
+      expect(runtime.model).to eq("gpt-5")
+      expect(runtime.base_url).to eq("https://api.example.com")
+    end
+
+    it "defaults missing keys" do
+      runtime = described_class.from_hash({})
+      expect(runtime.model).to be_nil
+      expect(runtime.env).to eq({})
+      expect(runtime.flags).to eq([])
+    end
+  end
+
+  describe ".wrap" do
+    it "returns nil for nil" do
+      expect(described_class.wrap(nil)).to be_nil
+    end
+
+    it "returns the same instance for a ProviderRuntime" do
+      runtime = described_class.new(model: "gpt-5")
+      expect(described_class.wrap(runtime)).to be(runtime)
+    end
+
+    it "coerces a Hash into a ProviderRuntime" do
+      result = described_class.wrap(model: "gpt-5", base_url: "https://example.com")
+      expect(result).to be_a(described_class)
+      expect(result.model).to eq("gpt-5")
+      expect(result.base_url).to eq("https://example.com")
+    end
+
+    it "raises ArgumentError for unsupported types" do
+      expect { described_class.wrap("bad") }.to raise_error(ArgumentError, /Cannot coerce/)
+    end
+  end
+
+  describe "#empty?" do
+    it "returns true when no overrides are set" do
+      expect(described_class.new).to be_empty
+    end
+
+    it "returns false when model is set" do
+      expect(described_class.new(model: "gpt-5")).not_to be_empty
+    end
+
+    it "returns false when base_url is set" do
+      expect(described_class.new(base_url: "https://example.com")).not_to be_empty
+    end
+
+    it "returns false when api_provider is set" do
+      expect(described_class.new(api_provider: "openrouter")).not_to be_empty
+    end
+
+    it "returns false when env is set" do
+      expect(described_class.new(env: {"K" => "V"})).not_to be_empty
+    end
+
+    it "returns false when flags are set" do
+      expect(described_class.new(flags: ["--foo"])).not_to be_empty
+    end
+
+    it "returns false when metadata is set" do
+      expect(described_class.new(metadata: {a: 1})).not_to be_empty
+    end
+  end
+end

--- a/spec/agent_harness/provider_runtime_spec.rb
+++ b/spec/agent_harness/provider_runtime_spec.rb
@@ -45,6 +45,26 @@ RSpec.describe AgentHarness::ProviderRuntime do
         .to raise_error(ArgumentError, /env value for "DEBUG" must be a String/)
     end
 
+    it "coerces nil env to empty hash" do
+      runtime = described_class.new(env: nil)
+      expect(runtime.env).to eq({})
+    end
+
+    it "coerces nil metadata to empty hash" do
+      runtime = described_class.new(metadata: nil)
+      expect(runtime.metadata).to eq({})
+    end
+
+    it "raises ArgumentError for non-String flags" do
+      expect { described_class.new(flags: ["--verbose", 42]) }
+        .to raise_error(ArgumentError, /flags must be an Array of Strings.*index 1.*42/)
+    end
+
+    it "raises ArgumentError when flags contain a Hash" do
+      expect { described_class.new(flags: [{key: "val"}]) }
+        .to raise_error(ArgumentError, /flags must be an Array of Strings/)
+    end
+
     it "freezes the instance" do
       runtime = described_class.new(model: "gpt-5")
       expect(runtime).to be_frozen

--- a/spec/agent_harness/provider_runtime_spec.rb
+++ b/spec/agent_harness/provider_runtime_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe AgentHarness::ProviderRuntime do
       expect(runtime.metadata).to eq({})
     end
 
+    it "raises ArgumentError when flags is not an Array" do
+      expect { described_class.new(flags: "--verbose") }
+        .to raise_error(ArgumentError, /flags must be an Array \(got String\)/)
+    end
+
+    it "coerces nil flags to empty array" do
+      runtime = described_class.new(flags: nil)
+      expect(runtime.flags).to eq([])
+    end
+
     it "raises ArgumentError for non-String flags" do
       expect { described_class.new(flags: ["--verbose", 42]) }
         .to raise_error(ArgumentError, /flags must be an Array of Strings.*index 1.*42/)

--- a/spec/agent_harness/provider_runtime_spec.rb
+++ b/spec/agent_harness/provider_runtime_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe AgentHarness::ProviderRuntime do
     end
 
     it "coerces a Hash into a ProviderRuntime" do
-      result = described_class.wrap(model: "gpt-5", base_url: "https://example.com")
+      result = described_class.wrap({model: "gpt-5", base_url: "https://example.com"})
       expect(result).to be_a(described_class)
       expect(result.model).to eq("gpt-5")
       expect(result.base_url).to eq("https://example.com")

--- a/spec/agent_harness/provider_runtime_spec.rb
+++ b/spec/agent_harness/provider_runtime_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe AgentHarness::ProviderRuntime do
       expect(runtime.env).to eq("MY_VAR" => "val")
     end
 
+    it "raises ArgumentError for non-String env values" do
+      expect { described_class.new(env: {"PORT" => 3000}) }
+        .to raise_error(ArgumentError, /env value for "PORT" must be a String \(got Integer\)/)
+    end
+
+    it "raises ArgumentError for boolean env values" do
+      expect { described_class.new(env: {"DEBUG" => true}) }
+        .to raise_error(ArgumentError, /env value for "DEBUG" must be a String/)
+    end
+
     it "freezes the instance" do
       runtime = described_class.new(model: "gpt-5")
       expect(runtime).to be_frozen

--- a/spec/agent_harness/providers/provider_runtime_integration_spec.rb
+++ b/spec/agent_harness/providers/provider_runtime_integration_spec.rb
@@ -192,6 +192,78 @@ RSpec.describe "ProviderRuntime integration" do
     end
   end
 
+  describe AgentHarness::Providers::Cursor do
+    let(:provider) { described_class.new(executor: mock_executor) }
+
+    it "passes runtime env vars to the executor" do
+      runtime = AgentHarness::ProviderRuntime.new(
+        env: {"CUSTOM_KEY" => "custom_value"}
+      )
+
+      expect(mock_executor).to receive(:execute).with(
+        anything,
+        hash_including(env: hash_including("CUSTOM_KEY" => "custom_value"))
+      ).and_return(success_result)
+
+      provider.send_message(prompt: "Hello", provider_runtime: runtime)
+    end
+
+    it "works without a provider_runtime" do
+      expect(mock_executor).to receive(:execute).with(
+        anything,
+        hash_including(env: {})
+      ).and_return(success_result)
+
+      provider.send_message(prompt: "Hello")
+    end
+
+    it "coerces a plain Hash into a ProviderRuntime" do
+      expect(mock_executor).to receive(:execute).with(
+        anything,
+        hash_including(env: hash_including("MY_VAR" => "value"))
+      ).and_return(success_result)
+
+      provider.send_message(
+        prompt: "Hello",
+        provider_runtime: {env: {"MY_VAR" => "value"}}
+      )
+    end
+
+    it "appends runtime flags to the command" do
+      runtime = AgentHarness::ProviderRuntime.new(flags: ["--verbose"])
+
+      expect(mock_executor).to receive(:execute).with(
+        ["cursor-agent", "-p", "--verbose"],
+        anything
+      ).and_return(success_result)
+
+      provider.send_message(prompt: "Hello", provider_runtime: runtime)
+    end
+
+    it "sets model on response from runtime when response model is nil" do
+      runtime = AgentHarness::ProviderRuntime.new(model: "gpt-5-turbo")
+
+      allow(mock_executor).to receive(:execute).and_return(success_result)
+
+      response = provider.send_message(prompt: "Hello", provider_runtime: runtime)
+      expect(response.model).to eq("gpt-5-turbo")
+    end
+
+    it "still sends prompt via stdin" do
+      runtime = AgentHarness::ProviderRuntime.new(
+        env: {"CUSTOM_KEY" => "value"},
+        flags: ["--debug"]
+      )
+
+      expect(mock_executor).to receive(:execute).with(
+        ["cursor-agent", "-p", "--debug"],
+        hash_including(stdin_data: "Hello", env: hash_including("CUSTOM_KEY" => "value"))
+      ).and_return(success_result)
+
+      provider.send_message(prompt: "Hello", provider_runtime: runtime)
+    end
+  end
+
   describe AgentHarness::Providers::Codex do
     let(:provider) { described_class.new(executor: mock_executor) }
 

--- a/spec/agent_harness/providers/provider_runtime_integration_spec.rb
+++ b/spec/agent_harness/providers/provider_runtime_integration_spec.rb
@@ -100,6 +100,33 @@ RSpec.describe "ProviderRuntime integration" do
       expect(response.model).to eq("gpt-5-turbo")
     end
 
+    it "records runtime model in token tracking when config model is nil" do
+      runtime = AgentHarness::ProviderRuntime.new(model: "gpt-5-turbo")
+
+      # Build a response with tokens so track_tokens is invoked
+      token_response = AgentHarness::Response.new(
+        output: "ok",
+        exit_code: 0,
+        duration: 1.0,
+        provider: :test_runtime,
+        model: nil,
+        tokens: {input: 10, output: 20, total: 30}
+      )
+
+      allow(mock_executor).to receive(:execute).and_return(success_result)
+      allow(provider).to receive(:parse_response).and_return(token_response)
+
+      tracker = instance_double(AgentHarness::TokenTracker)
+      allow(AgentHarness).to receive(:token_tracker).and_return(tracker)
+      allow(tracker).to receive(:record)
+
+      provider.send_message(prompt: "Hello", provider_runtime: runtime)
+
+      expect(tracker).to have_received(:record).with(
+        hash_including(model: "gpt-5-turbo")
+      )
+    end
+
     it "keeps config model when runtime model is nil" do
       config = AgentHarness::ProviderConfig.new(:test_runtime)
       config.model = "config-model"

--- a/spec/agent_harness/providers/provider_runtime_integration_spec.rb
+++ b/spec/agent_harness/providers/provider_runtime_integration_spec.rb
@@ -137,6 +137,19 @@ RSpec.describe "ProviderRuntime integration" do
       response = provider_with_model.send_message(prompt: "Hello", provider_runtime: {})
       expect(response.model).to eq("config-model")
     end
+
+    it "prefers runtime model over config model when both are set" do
+      config = AgentHarness::ProviderConfig.new(:test_runtime)
+      config.model = "config-model"
+      provider_with_model = test_provider_class.new(config: config, executor: mock_executor)
+
+      runtime = AgentHarness::ProviderRuntime.new(model: "runtime-model")
+
+      allow(mock_executor).to receive(:execute).and_return(success_result)
+
+      response = provider_with_model.send_message(prompt: "Hello", provider_runtime: runtime)
+      expect(response.model).to eq("runtime-model")
+    end
   end
 
   describe AgentHarness::Providers::Opencode do

--- a/spec/agent_harness/providers/provider_runtime_integration_spec.rb
+++ b/spec/agent_harness/providers/provider_runtime_integration_spec.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+RSpec.describe "ProviderRuntime integration" do
+  let(:mock_executor) do
+    instance_double(AgentHarness::CommandExecutor).tap do |executor|
+      allow(executor).to receive(:execute).and_return(
+        AgentHarness::CommandExecutor::Result.new(
+          stdout: "response output",
+          stderr: "",
+          exit_code: 0,
+          duration: 1.0
+        )
+      )
+    end
+  end
+
+  let(:success_result) do
+    AgentHarness::CommandExecutor::Result.new(
+      stdout: "ok",
+      stderr: "",
+      exit_code: 0,
+      duration: 1.0
+    )
+  end
+
+  shared_examples "runtime env passthrough" do
+    it "passes runtime env vars to the executor" do
+      runtime = AgentHarness::ProviderRuntime.new(
+        env: {"CUSTOM_KEY" => "custom_value"}
+      )
+
+      expect(mock_executor).to receive(:execute).with(
+        anything,
+        hash_including(env: hash_including("CUSTOM_KEY" => "custom_value"))
+      ).and_return(success_result)
+
+      provider.send_message(prompt: "Hello", provider_runtime: runtime)
+    end
+
+    it "works without a provider_runtime" do
+      expect(mock_executor).to receive(:execute).with(
+        anything,
+        hash_including(env: {})
+      ).and_return(success_result)
+
+      provider.send_message(prompt: "Hello")
+    end
+  end
+
+  shared_examples "runtime hash coercion" do
+    it "coerces a plain Hash into a ProviderRuntime" do
+      expect(mock_executor).to receive(:execute).with(
+        anything,
+        hash_including(env: hash_including("MY_VAR" => "value"))
+      ).and_return(success_result)
+
+      provider.send_message(
+        prompt: "Hello",
+        provider_runtime: {env: {"MY_VAR" => "value"}}
+      )
+    end
+  end
+
+  describe AgentHarness::Providers::Base do
+    let(:test_provider_class) do
+      Class.new(described_class) do
+        class << self
+          def provider_name
+            :test_runtime
+          end
+
+          def binary_name
+            "test-cli"
+          end
+
+          def available?
+            true
+          end
+        end
+
+        protected
+
+        def build_command(prompt, options)
+          [self.class.binary_name, prompt]
+        end
+      end
+    end
+
+    let(:provider) { test_provider_class.new(executor: mock_executor) }
+
+    include_examples "runtime env passthrough"
+    include_examples "runtime hash coercion"
+
+    it "sets model on response from runtime when config model is nil" do
+      runtime = AgentHarness::ProviderRuntime.new(model: "gpt-5-turbo")
+
+      allow(mock_executor).to receive(:execute).and_return(success_result)
+
+      response = provider.send_message(prompt: "Hello", provider_runtime: runtime)
+      expect(response.model).to eq("gpt-5-turbo")
+    end
+
+    it "keeps config model when runtime model is nil" do
+      config = AgentHarness::ProviderConfig.new(:test_runtime)
+      config.model = "config-model"
+      provider_with_model = test_provider_class.new(config: config, executor: mock_executor)
+
+      allow(mock_executor).to receive(:execute).and_return(success_result)
+
+      response = provider_with_model.send_message(prompt: "Hello", provider_runtime: {})
+      expect(response.model).to eq("config-model")
+    end
+  end
+
+  describe AgentHarness::Providers::Opencode do
+    let(:provider) { described_class.new(executor: mock_executor) }
+
+    include_examples "runtime env passthrough"
+    include_examples "runtime hash coercion"
+
+    it "sets OPENAI_BASE_URL from runtime base_url" do
+      runtime = AgentHarness::ProviderRuntime.new(
+        base_url: "https://openrouter.ai/api/v1"
+      )
+
+      expect(mock_executor).to receive(:execute).with(
+        anything,
+        hash_including(env: hash_including("OPENAI_BASE_URL" => "https://openrouter.ai/api/v1"))
+      ).and_return(success_result)
+
+      provider.send_message(prompt: "Hello", provider_runtime: runtime)
+    end
+
+    it "appends runtime flags to the command" do
+      runtime = AgentHarness::ProviderRuntime.new(
+        flags: ["--verbose"]
+      )
+
+      expect(mock_executor).to receive(:execute).with(
+        ["opencode", "run", "--verbose", "Hello"],
+        anything
+      ).and_return(success_result)
+
+      provider.send_message(prompt: "Hello", provider_runtime: runtime)
+    end
+
+    it "builds full OpenRouter routing command" do
+      runtime = AgentHarness::ProviderRuntime.new(
+        model: "anthropic/claude-opus-4.1",
+        base_url: "https://openrouter.ai/api/v1",
+        api_provider: "openrouter",
+        env: {"OPENROUTER_API_KEY" => "sk-or-123"}
+      )
+
+      expect(mock_executor).to receive(:execute).with(
+        ["opencode", "run", "Write tests"],
+        hash_including(env: hash_including(
+          "OPENAI_BASE_URL" => "https://openrouter.ai/api/v1",
+          "OPENROUTER_API_KEY" => "sk-or-123"
+        ))
+      ).and_return(success_result)
+
+      response = provider.send_message(prompt: "Write tests", provider_runtime: runtime)
+      expect(response.model).to eq("anthropic/claude-opus-4.1")
+    end
+  end
+
+  describe AgentHarness::Providers::Codex do
+    let(:provider) { described_class.new(executor: mock_executor) }
+
+    include_examples "runtime env passthrough"
+    include_examples "runtime hash coercion"
+
+    it "sets OPENAI_BASE_URL from runtime base_url" do
+      runtime = AgentHarness::ProviderRuntime.new(
+        base_url: "https://openrouter.ai/api/v1"
+      )
+
+      expect(mock_executor).to receive(:execute).with(
+        anything,
+        hash_including(env: hash_including("OPENAI_BASE_URL" => "https://openrouter.ai/api/v1"))
+      ).and_return(success_result)
+
+      provider.send_message(prompt: "Hello", provider_runtime: runtime)
+    end
+
+    it "adds --model flag from runtime model" do
+      runtime = AgentHarness::ProviderRuntime.new(model: "o3-pro")
+
+      expect(mock_executor).to receive(:execute).with(
+        array_including("--model", "o3-pro"),
+        anything
+      ).and_return(success_result)
+
+      provider.send_message(prompt: "Hello", provider_runtime: runtime)
+    end
+
+    it "appends runtime flags to the command" do
+      runtime = AgentHarness::ProviderRuntime.new(flags: ["--quiet"])
+
+      expect(mock_executor).to receive(:execute).with(
+        array_including("--quiet"),
+        anything
+      ).and_return(success_result)
+
+      provider.send_message(prompt: "Hello", provider_runtime: runtime)
+    end
+
+    it "combines runtime with existing options" do
+      runtime = AgentHarness::ProviderRuntime.new(
+        model: "o3-pro",
+        env: {"CUSTOM_VAR" => "value"}
+      )
+
+      expect(mock_executor).to receive(:execute).with(
+        array_including("codex", "exec", "--model", "o3-pro"),
+        hash_including(env: hash_including("CUSTOM_VAR" => "value"))
+      ).and_return(success_result)
+
+      provider.send_message(
+        prompt: "Hello",
+        session: "sess-123",
+        provider_runtime: runtime
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Enable per-request provider runtime overrides so applications like Paid can route the same CLI provider through multiple backends (e.g., OpenCode → OpenRouter → different models) using a single normalized config payload, instead of embedding provider-specific shell wrappers and temp config generation in app code.

## Changes

**New abstraction: `ProviderRuntime` value object** (`lib/agent_harness/provider_runtime.rb`)
- Frozen, provider-agnostic data object carrying runtime overrides: `model`, `base_url`, `api_provider`, `env`, `flags`, and `metadata`
- Supports construction from Hash via `.from_hash` and auto-coercion via `.wrap`

**Provider base class** (`lib/agent_harness/providers/base.rb`)
- `send_message` accepts a `provider_runtime:` keyword, coercing Hash inputs to `ProviderRuntime`
- Runtime `env` merges into the subprocess environment through `build_env`
- Falls back to runtime `model` on the Response when no config-level model is set

**OpenCode provider** (`lib/agent_harness/providers/opencode.rb`)
- Maps `runtime.base_url` → `OPENAI_BASE_URL` env var for OpenRouter/custom endpoint routing
- Appends `runtime.flags` to the subprocess command

**Codex provider** (`lib/agent_harness/providers/codex.rb`)
- Maps `runtime.model` → `--model` CLI flag
- Maps `runtime.base_url` → `OPENAI_BASE_URL` env var
- Appends `runtime.flags` to the subprocess command

**Tests**
- 37 new specs covering `ProviderRuntime` construction/coercion and runtime materialization for Base, OpenCode, and Codex providers

## Design Decisions

- **Common shape, provider-specific materialization**: `ProviderRuntime` defines a normalized contract but each provider adapter decides how to materialize fields into env vars, CLI flags, or config files. This avoids leaking provider details into calling code while remaining flexible.
- **Value object, not configuration**: `ProviderRuntime` is frozen and per-request, keeping it separate from the persistent provider config. This lets callers vary routing on every invocation without mutating shared state.
- **`env` and `flags` as escape hatches**: Structured fields (`model`, `base_url`, `api_provider`) cover common cases; `env`, `flags`, and `metadata` provide extension points for provider-specific needs without expanding the core interface.
- **Coercion via `.wrap`**: Accepting raw Hashes at the `send_message` boundary reduces ceremony for callers while still normalizing internally.

---

Closes #54