### PR TITLE
Fix #68: feat(installers): make OpenCode CLI installation/version support a first-class provider contract

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     agent-harness (0.5.6)
+      logger (>= 1.6, < 2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -12,6 +13,7 @@ GEM
     json (2.18.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
+    logger (1.7.0)
     parallel (1.27.0)
     parser (3.3.10.1)
       ast (~> 2.4.1)

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ The Kilocode runtime adapter expects the `kilo` binary and executes prompts via
 `kilo run ...`, so the install contract and runtime behavior stay aligned in
 tests.
 
-Providers with fixed install metadata can also be queried through the generic
-API:
+Providers that expose installation contracts can also be queried through the
+generic API:
 
 ```ruby
 opencode_install = AgentHarness.installation_contract(:opencode)
@@ -186,6 +186,7 @@ opencode_install
 For providers with install contracts, the metadata tracks the CLI version
 supported by the current `agent-harness` release, and the runtime adapter
 tests assert that the expected binary remains aligned with that contract.
+
 ### Custom Providers
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -131,21 +131,21 @@ AgentHarness::Providers::Registry.instance.all
 downstream apps do not need to hardcode package names or version pins.
 
 ```ruby
-codex_install = AgentHarness.installation_contract(:codex)
+opencode_install = AgentHarness.installation_contract(:opencode)
 
-codex_install
+opencode_install
 # => {
 #      source: :npm,
-#      package_name: "@openai/codex",
-#      version: "0.116.0",
-#      binary_name: "codex",
-#      install_command: ["npm", "install", "-g", "--ignore-scripts", "@openai/codex@0.116.0"]
+#      package_name: "opencode-ai",
+#      version: "1.3.2",
+#      binary_name: "opencode",
+#      install_command: ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.2"]
 #    }
 ```
 
-For Codex, the install contract tracks the CLI version supported by the
-current `agent-harness` release, and the runtime adapter tests assert that
-the expected binary remains aligned with that contract.
+For providers with install contracts, the metadata tracks the CLI version
+supported by the current `agent-harness` release, and the runtime adapter
+tests assert that the expected binary remains aligned with that contract.
 
 ### Custom Providers
 

--- a/agent-harness.gemspec
+++ b/agent-harness.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "logger", ">= 1.6", "< 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "standard", "~> 1.3"

--- a/lib/agent_harness/providers/opencode.rb
+++ b/lib/agent_harness/providers/opencode.rb
@@ -78,6 +78,8 @@ module AgentHarness
         private
 
         def validate_install_version!(version)
+          raise ArgumentError, unsupported_version_message(version) unless version.is_a?(String) && !version.empty?
+
           parsed_version = Gem::Version.new(version)
           return if SUPPORTED_CLI_REQUIREMENT.satisfied_by?(parsed_version)
 

--- a/lib/agent_harness/providers/opencode.rb
+++ b/lib/agent_harness/providers/opencode.rb
@@ -9,6 +9,11 @@ module AgentHarness
       CLI_PACKAGE = "opencode-ai"
       SUPPORTED_CLI_VERSION = "1.3.2"
       SUPPORTED_CLI_REQUIREMENT = Gem::Requirement.new(">= #{SUPPORTED_CLI_VERSION}", "< 1.4.0").freeze
+      INSTALL_COMMAND_PREFIX = ["npm", "install", "-g", "--ignore-scripts"].freeze
+      SUPPORTED_CLI_VERSIONS = [SUPPORTED_CLI_VERSION].freeze
+      VERSION_REQUIREMENT_STRINGS = SUPPORTED_CLI_REQUIREMENT.requirements
+        .map { |op, ver| "#{op} #{ver}".freeze }
+        .freeze
 
       class << self
         def provider_name
@@ -46,23 +51,18 @@ module AgentHarness
           normalized_version = normalize_install_version(version)
 
           default_package = "#{CLI_PACKAGE}@#{normalized_version}".freeze
-          install_command_prefix = ["npm", "install", "-g", "--ignore-scripts"].freeze
-          install_command = (install_command_prefix + [default_package]).freeze
-          supported_versions = [SUPPORTED_CLI_VERSION].freeze
-          version_requirement = SUPPORTED_CLI_REQUIREMENT.requirements
-            .map { |op, ver| "#{op} #{ver}".freeze }
-            .freeze
+          install_command = (INSTALL_COMMAND_PREFIX + [default_package]).freeze
 
           contract = {
             source: :npm,
             package: default_package,
             package_name: CLI_PACKAGE,
             version: normalized_version,
-            version_requirement: version_requirement,
+            version_requirement: VERSION_REQUIREMENT_STRINGS,
             binary_name: binary_name,
-            install_command_prefix: install_command_prefix,
+            install_command_prefix: INSTALL_COMMAND_PREFIX,
             install_command: install_command,
-            supported_versions: supported_versions
+            supported_versions: SUPPORTED_CLI_VERSIONS
           }
 
           contract.each_value do |value|

--- a/lib/agent_harness/providers/opencode.rb
+++ b/lib/agent_harness/providers/opencode.rb
@@ -78,7 +78,7 @@ module AgentHarness
         private
 
         def validate_install_version!(version)
-          raise ArgumentError, unsupported_version_message(version) unless version.is_a?(String) && !version.empty?
+          raise ArgumentError, unsupported_version_message(version) unless version.is_a?(String) && !version.strip.empty?
 
           parsed_version = Gem::Version.new(version)
           return if SUPPORTED_CLI_REQUIREMENT.satisfied_by?(parsed_version)

--- a/lib/agent_harness/providers/opencode.rb
+++ b/lib/agent_harness/providers/opencode.rb
@@ -49,15 +49,26 @@ module AgentHarness
 
         def installation_contract(version: SUPPORTED_CLI_VERSION)
           normalized_version = normalize_install_version(version)
+          return DEFAULT_INSTALLATION_CONTRACT if normalized_version == SUPPORTED_CLI_VERSION
 
-          default_package = "#{CLI_PACKAGE}@#{normalized_version}".freeze
-          install_command = (INSTALL_COMMAND_PREFIX + [default_package]).freeze
+          build_installation_contract(normalized_version)
+        end
+
+        def install_command(version: SUPPORTED_CLI_VERSION)
+          installation_contract(version: version)[:install_command]
+        end
+
+        private
+
+        def build_installation_contract(version)
+          package = "#{CLI_PACKAGE}@#{version}".freeze
+          install_command = (INSTALL_COMMAND_PREFIX + [package]).freeze
 
           contract = {
             source: :npm,
-            package: default_package,
+            package: package,
             package_name: CLI_PACKAGE,
-            version: normalized_version,
+            version: version,
             version_requirement: VERSION_REQUIREMENT_STRINGS,
             binary_name: binary_name,
             install_command_prefix: INSTALL_COMMAND_PREFIX,
@@ -70,12 +81,6 @@ module AgentHarness
           end
           contract.freeze
         end
-
-        def install_command(version: SUPPORTED_CLI_VERSION)
-          installation_contract(version: version)[:install_command]
-        end
-
-        private
 
         def normalize_install_version(version)
           raise ArgumentError, unsupported_version_message(version) unless version.is_a?(String) && !version.strip.empty?
@@ -94,6 +99,8 @@ module AgentHarness
             "supported versions must satisfy #{SUPPORTED_CLI_REQUIREMENT}"
         end
       end
+
+      DEFAULT_INSTALLATION_CONTRACT = build_installation_contract(SUPPORTED_CLI_VERSION)
 
       def name
         "opencode"

--- a/lib/agent_harness/providers/opencode.rb
+++ b/lib/agent_harness/providers/opencode.rb
@@ -43,9 +43,9 @@ module AgentHarness
         end
 
         def installation_contract(version: SUPPORTED_CLI_VERSION)
-          validate_install_version!(version)
+          normalized_version = normalize_install_version(version)
 
-          default_package = "#{CLI_PACKAGE}@#{version}".freeze
+          default_package = "#{CLI_PACKAGE}@#{normalized_version}".freeze
           install_command_prefix = ["npm", "install", "-g", "--ignore-scripts"].freeze
           install_command = (install_command_prefix + [default_package]).freeze
           supported_versions = [SUPPORTED_CLI_VERSION].freeze
@@ -57,7 +57,7 @@ module AgentHarness
             source: :npm,
             package: default_package,
             package_name: CLI_PACKAGE,
-            version: version,
+            version: normalized_version,
             version_requirement: version_requirement,
             binary_name: binary_name,
             install_command_prefix: install_command_prefix,
@@ -77,11 +77,12 @@ module AgentHarness
 
         private
 
-        def validate_install_version!(version)
+        def normalize_install_version(version)
           raise ArgumentError, unsupported_version_message(version) unless version.is_a?(String) && !version.strip.empty?
 
-          parsed_version = Gem::Version.new(version)
-          return if SUPPORTED_CLI_REQUIREMENT.satisfied_by?(parsed_version)
+          normalized_version = version.strip
+          parsed_version = Gem::Version.new(normalized_version)
+          return normalized_version if SUPPORTED_CLI_REQUIREMENT.satisfied_by?(parsed_version)
 
           raise ArgumentError, unsupported_version_message(version)
         rescue ArgumentError
@@ -142,7 +143,7 @@ module AgentHarness
       protected
 
       def build_command(prompt, options)
-        cmd = [self.class.binary_name, "run"]
+        cmd = [self.class.installation_contract[:binary_name], "run"]
 
         runtime = options[:provider_runtime]
         if runtime

--- a/lib/agent_harness/providers/opencode.rb
+++ b/lib/agent_harness/providers/opencode.rb
@@ -6,6 +6,7 @@ module AgentHarness
     #
     # Provides integration with the OpenCode CLI tool.
     class Opencode < Base
+      CLI_PACKAGE = "opencode-ai"
       SUPPORTED_CLI_VERSION = "1.3.2"
       SUPPORTED_CLI_REQUIREMENT = Gem::Requirement.new(">= #{SUPPORTED_CLI_VERSION}", "< 1.4.0").freeze
 
@@ -44,7 +45,7 @@ module AgentHarness
         def installation_contract(version: SUPPORTED_CLI_VERSION)
           validate_install_version!(version)
 
-          default_package = "opencode-ai@#{version}".freeze
+          default_package = "#{CLI_PACKAGE}@#{version}".freeze
           install_command_prefix = ["npm", "install", "-g", "--ignore-scripts"].freeze
           install_command = (install_command_prefix + [default_package]).freeze
           supported_versions = [SUPPORTED_CLI_VERSION].freeze
@@ -55,7 +56,7 @@ module AgentHarness
           contract = {
             source: :npm,
             package: default_package,
-            package_name: "opencode-ai",
+            package_name: CLI_PACKAGE,
             version: version,
             version_requirement: version_requirement,
             binary_name: binary_name,
@@ -77,10 +78,16 @@ module AgentHarness
         private
 
         def validate_install_version!(version)
-          return if SUPPORTED_CLI_REQUIREMENT.satisfied_by?(Gem::Version.new(version))
+          parsed_version = Gem::Version.new(version)
+          return if SUPPORTED_CLI_REQUIREMENT.satisfied_by?(parsed_version)
 
-          raise ArgumentError,
-            "Unsupported OpenCode CLI version #{version.inspect}; " \
+          raise ArgumentError, unsupported_version_message(version)
+        rescue ArgumentError
+          raise ArgumentError, unsupported_version_message(version)
+        end
+
+        def unsupported_version_message(version)
+          "Unsupported OpenCode CLI version #{version.inspect}; " \
             "supported versions must satisfy #{SUPPORTED_CLI_REQUIREMENT}"
         end
       end

--- a/lib/agent_harness/providers/opencode.rb
+++ b/lib/agent_harness/providers/opencode.rb
@@ -6,6 +6,9 @@ module AgentHarness
     #
     # Provides integration with the OpenCode CLI tool.
     class Opencode < Base
+      SUPPORTED_CLI_VERSION = "1.3.2"
+      SUPPORTED_CLI_REQUIREMENT = Gem::Requirement.new(">= #{SUPPORTED_CLI_VERSION}", "< 1.4.0").freeze
+
       class << self
         def provider_name
           :opencode
@@ -36,6 +39,33 @@ module AgentHarness
         def discover_models
           return [] unless available?
           []
+        end
+
+        def installation_contract
+          default_package = "opencode-ai@#{SUPPORTED_CLI_VERSION}".freeze
+          install_command_prefix = ["npm", "install", "-g", "--ignore-scripts"].freeze
+          install_command = (install_command_prefix + [default_package]).freeze
+          supported_versions = [SUPPORTED_CLI_VERSION].freeze
+          version_requirement = SUPPORTED_CLI_REQUIREMENT.requirements
+            .map { |op, ver| "#{op} #{ver}".freeze }
+            .freeze
+
+          contract = {
+            source: :npm,
+            package: default_package,
+            package_name: "opencode-ai",
+            version: SUPPORTED_CLI_VERSION,
+            version_requirement: version_requirement,
+            binary_name: binary_name,
+            install_command_prefix: install_command_prefix,
+            install_command: install_command,
+            supported_versions: supported_versions
+          }
+
+          contract.each_value do |value|
+            value.freeze if value.is_a?(String)
+          end
+          contract.freeze
         end
       end
 

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -50,6 +50,13 @@ RSpec.describe AgentHarness::Providers::Opencode do
       expect(described_class.installation_contract).to equal(described_class.installation_contract)
     end
 
+    it "reuses the default frozen install contract for explicit default versions" do
+      default_contract = described_class.installation_contract
+
+      expect(described_class.installation_contract(version: "1.3.2")).to equal(default_contract)
+      expect(described_class.installation_contract(version: " 1.3.2 ")).to equal(default_contract)
+    end
+
     it "normalizes surrounding whitespace in supported explicit versions" do
       contract = described_class.installation_contract(version: " 1.3.9 ")
 

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -13,6 +13,54 @@ RSpec.describe AgentHarness::Providers::Opencode do
     end
   end
 
+  describe ".installation_contract" do
+    it "exposes OpenCode CLI install metadata" do
+      contract = described_class.installation_contract
+
+      expect(contract).to include(
+        source: :npm,
+        package_name: "opencode-ai",
+        version: "1.3.2",
+        binary_name: "opencode"
+      )
+      expect(contract[:package]).to eq("opencode-ai@1.3.2")
+      expect(contract[:supported_versions]).to eq(["1.3.2"])
+      expect(contract[:version_requirement]).to eq([">= 1.3.2", "< 1.4.0"])
+      expect(contract[:install_command]).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.2"]
+      )
+    end
+
+    it "keeps the runtime binary aligned with the install contract" do
+      contract = described_class.installation_contract
+
+      expect(contract[:binary_name]).to eq(described_class.binary_name)
+    end
+
+    it "deep-freezes nested contract values" do
+      contract = described_class.installation_contract
+
+      expect { contract[:install_command_prefix] << "opencode-ai" }.to raise_error(FrozenError)
+      expect { contract[:install_command] << "opencode-ai" }.to raise_error(FrozenError)
+      expect { contract[:supported_versions] << "1.3.1" }.to raise_error(FrozenError)
+      expect { contract[:version_requirement] << ">= 1.3.1" }.to raise_error(FrozenError)
+    end
+  end
+
+  describe ".install_command" do
+    it "builds the default install command from the contract" do
+      expect(described_class.install_command).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.2"]
+      )
+    end
+
+    it "supports explicit version overrides" do
+      expect(described_class.install_command(version: "1.3.1")).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.1"]
+      )
+    end
+  end
+
   describe ".firewall_requirements" do
     it "returns required domains" do
       requirements = described_class.firewall_requirements
@@ -88,6 +136,26 @@ RSpec.describe AgentHarness::Providers::Opencode do
 
         expect(mock_executor).to receive(:execute).with(
           ["opencode", "run", "Hello"],
+          anything
+        )
+
+        provider.send_message(prompt: "Hello")
+      end
+
+      it "uses the install contract binary in the runtime command" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "response",
+            stderr: "",
+            exit_code: 0,
+            duration: 1.0
+          )
+        )
+
+        binary = described_class.installation_contract[:binary_name]
+
+        expect(mock_executor).to receive(:execute).with(
+          [binary, "run", "Hello"],
           anything
         )
 

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -249,7 +249,9 @@ RSpec.describe AgentHarness::Providers::Opencode do
           )
         )
 
-        binary = described_class.installation_contract[:binary_name]
+        binary = "opencode-custom"
+        contract = described_class.installation_contract.merge(binary_name: binary).freeze
+        allow(described_class).to receive(:installation_contract).and_return(contract)
 
         expect(mock_executor).to receive(:execute).with(
           [binary, "run", "Hello"],

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -46,6 +46,16 @@ RSpec.describe AgentHarness::Providers::Opencode do
       )
     end
 
+    it "normalizes surrounding whitespace in supported explicit versions" do
+      contract = described_class.installation_contract(version: " 1.3.9 ")
+
+      expect(contract[:version]).to eq("1.3.9")
+      expect(contract[:package]).to eq("opencode-ai@1.3.9")
+      expect(contract[:install_command]).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
+      )
+    end
+
     it "rejects versions outside the advertised requirement" do
       expect {
         described_class.installation_contract(version: "1.4.0")
@@ -101,6 +111,12 @@ RSpec.describe AgentHarness::Providers::Opencode do
 
     it "supports explicit version overrides" do
       expect(described_class.install_command(version: "1.3.9")).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
+      )
+    end
+
+    it "normalizes surrounding whitespace in explicit version overrides" do
+      expect(described_class.install_command(version: " 1.3.9 ")).to eq(
         ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
       )
     end

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe AgentHarness::Providers::Opencode do
       }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version/)
     end
 
+    it "rejects malformed versions with the provider-specific error" do
+      expect {
+        described_class.installation_contract(version: "not-a-version")
+      }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version "not-a-version"/)
+    end
+
     it "deep-freezes nested contract values" do
       contract = described_class.installation_contract
 
@@ -79,6 +85,12 @@ RSpec.describe AgentHarness::Providers::Opencode do
       expect {
         described_class.install_command(version: "1.3.1")
       }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version/)
+    end
+
+    it "rejects malformed version overrides with the provider-specific error" do
+      expect {
+        described_class.install_command(version: "not-a-version")
+      }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version "not-a-version"/)
     end
   end
 

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -131,6 +131,13 @@ RSpec.describe AgentHarness::Providers::Opencode do
       )
     end
 
+    it "reuses the default frozen install command for explicit default versions" do
+      default_install_command = described_class.install_command
+
+      expect(described_class.install_command(version: "1.3.2")).to equal(default_install_command)
+      expect(described_class.install_command(version: " 1.3.2 ")).to equal(default_install_command)
+    end
+
     it "normalizes surrounding whitespace in explicit version overrides" do
       expect(described_class.install_command(version: " 1.3.9 ")).to eq(
         ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe AgentHarness::Providers::Opencode do
       }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version ""/)
     end
 
+    it "rejects whitespace-only versions with the provider-specific error" do
+      expect {
+        described_class.installation_contract(version: "   ")
+      }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version "   "/)
+    end
+
     it "rejects non-string versions with the provider-specific error" do
       expect {
         described_class.installation_contract(version: 1.3)
@@ -115,6 +121,12 @@ RSpec.describe AgentHarness::Providers::Opencode do
       expect {
         described_class.install_command(version: nil)
       }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version nil/)
+    end
+
+    it "rejects whitespace-only version overrides with the provider-specific error" do
+      expect {
+        described_class.install_command(version: "   ")
+      }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version "   "/)
     end
   end
 

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -58,6 +58,24 @@ RSpec.describe AgentHarness::Providers::Opencode do
       }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version "not-a-version"/)
     end
 
+    it "rejects nil versions with the provider-specific error" do
+      expect {
+        described_class.installation_contract(version: nil)
+      }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version nil/)
+    end
+
+    it "rejects blank versions with the provider-specific error" do
+      expect {
+        described_class.installation_contract(version: "")
+      }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version ""/)
+    end
+
+    it "rejects non-string versions with the provider-specific error" do
+      expect {
+        described_class.installation_contract(version: 1.3)
+      }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version 1\.3/)
+    end
+
     it "deep-freezes nested contract values" do
       contract = described_class.installation_contract
 
@@ -91,6 +109,12 @@ RSpec.describe AgentHarness::Providers::Opencode do
       expect {
         described_class.install_command(version: "not-a-version")
       }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version "not-a-version"/)
+    end
+
+    it "rejects nil version overrides with the provider-specific error" do
+      expect {
+        described_class.install_command(version: nil)
+      }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version nil/)
     end
   end
 

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe AgentHarness::Providers::Opencode do
       )
     end
 
+    it "reuses the default frozen install contract" do
+      expect(described_class.installation_contract).to equal(described_class.installation_contract)
+    end
+
     it "normalizes surrounding whitespace in supported explicit versions" do
       contract = described_class.installation_contract(version: " 1.3.9 ")
 

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -95,6 +95,11 @@ RSpec.describe AgentHarness::Providers::Opencode do
     it "deep-freezes nested contract values" do
       contract = described_class.installation_contract
 
+      expect(contract).to be_frozen
+      expect(contract[:package]).to be_frozen
+      expect(contract[:package_name]).to be_frozen
+      expect(contract[:version]).to be_frozen
+      expect(contract[:binary_name]).to be_frozen
       expect { contract[:install_command_prefix] << "opencode-ai" }.to raise_error(FrozenError)
       expect { contract[:install_command] << "opencode-ai" }.to raise_error(FrozenError)
       expect { contract[:supported_versions] << "1.3.1" }.to raise_error(FrozenError)

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -123,10 +123,22 @@ RSpec.describe AgentHarness::Providers::Opencode do
       }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version nil/)
     end
 
+    it "rejects blank version overrides with the provider-specific error" do
+      expect {
+        described_class.install_command(version: "")
+      }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version ""/)
+    end
+
     it "rejects whitespace-only version overrides with the provider-specific error" do
       expect {
         described_class.install_command(version: "   ")
       }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version "   "/)
+    end
+
+    it "rejects non-string version overrides with the provider-specific error" do
+      expect {
+        described_class.install_command(version: 1.3)
+      }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version 1\.3/)
     end
   end
 

--- a/spec/agent_harness/providers/registry_spec.rb
+++ b/spec/agent_harness/providers/registry_spec.rb
@@ -108,6 +108,19 @@ RSpec.describe AgentHarness::Providers::Registry do
       )
     end
 
+    it "forwards target selection options to providers with generic contracts" do
+      contract = registry.installation_contract(:opencode, version: "1.3.9")
+
+      expect(contract).to include(
+        package_name: "opencode-ai",
+        version: "1.3.9",
+        binary_name: "opencode"
+      )
+      expect(contract[:install_command]).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
+      )
+    end
+
     it "returns nil for registered providers without installation contract support" do
       provider_without_install_contract = Class.new do
         def self.provider_name

--- a/spec/agent_harness/providers/registry_spec.rb
+++ b/spec/agent_harness/providers/registry_spec.rb
@@ -110,9 +110,12 @@ RSpec.describe AgentHarness::Providers::Registry do
     it "returns providers with installation contracts" do
       contracts = registry.installation_contracts
 
-      expect(contracts).to include(:codex)
+      expect(contracts).to include(:codex, :opencode)
       expect(contracts[:codex][:install_command]).to eq(
         ["npm", "install", "-g", "--ignore-scripts", "@openai/codex@0.116.0"]
+      )
+      expect(contracts[:opencode][:install_command]).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.2"]
       )
     end
 

--- a/spec/agent_harness/providers/registry_spec.rb
+++ b/spec/agent_harness/providers/registry_spec.rb
@@ -121,6 +121,19 @@ RSpec.describe AgentHarness::Providers::Registry do
       )
     end
 
+    it "preserves provider normalization for generic-contract version lookups" do
+      contract = registry.installation_contract(:opencode, version: " 1.3.9 ")
+
+      expect(contract).to include(
+        package_name: "opencode-ai",
+        version: "1.3.9",
+        binary_name: "opencode"
+      )
+      expect(contract[:install_command]).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
+      )
+    end
+
     it "returns nil for registered providers without installation contract support" do
       provider_without_install_contract = Class.new do
         def self.provider_name

--- a/spec/agent_harness_spec.rb
+++ b/spec/agent_harness_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe AgentHarness do
     it "returns all registered provider installation contracts" do
       contracts = AgentHarness.installation_contracts
 
-      expect(contracts).to include(:codex)
+      expect(contracts).to include(:codex, :opencode)
     end
   end
 

--- a/spec/agent_harness_spec.rb
+++ b/spec/agent_harness_spec.rb
@@ -160,6 +160,19 @@ RSpec.describe AgentHarness do
 
       expect(AgentHarness.installation_contract(:kilocode, version: "7.1.3")).to eq(contract)
     end
+
+    it "returns versioned install metadata for providers with generic contracts" do
+      contract = AgentHarness.installation_contract(:opencode, version: "1.3.9")
+
+      expect(contract).to include(
+        package_name: "opencode-ai",
+        version: "1.3.9",
+        binary_name: "opencode"
+      )
+      expect(contract[:install_command]).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
+      )
+    end
   end
 
   describe ".installation_contracts" do

--- a/spec/agent_harness_spec.rb
+++ b/spec/agent_harness_spec.rb
@@ -173,6 +173,19 @@ RSpec.describe AgentHarness do
         ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
       )
     end
+
+    it "preserves provider normalization for generic-contract version lookups" do
+      contract = AgentHarness.installation_contract(:opencode, version: " 1.3.9 ")
+
+      expect(contract).to include(
+        package_name: "opencode-ai",
+        version: "1.3.9",
+        binary_name: "opencode"
+      )
+      expect(contract[:install_command]).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
+      )
+    end
   end
 
   describe ".installation_contracts" do


### PR DESCRIPTION
Added a first-class OpenCode install contract in [lib/agent_harness/providers/opencode.rb](/workspace/lib/agent_harness/providers/opencode.rb), matching the existing provider contract surface with package source, package name, default install command, binary name, supported version `1.3.2`, and version requirement `>= 1.3.2`, `< 1.4.0`. The provider spec now validates contract shape, immutability, `install_command` overrides, and that the runtime command continues to use the contract’s binary in [spec/agent_harness/providers/opencode_spec.rb](/workspace/spec/agent_harness/providers/opencode_spec.rb). I also extended the public/registry coverage in [spec/agent_harness/providers/registry_spec.rb](/workspace/spec/agent_harness/providers/registry_spec.rb) and [spec/agent_harness_spec.rb](/workspace/spec/agent_harness_spec.rb), and updated the install-contract docs in [README.md](/workspace/README.md).

Verification passed with `bundle exec rubocop` and `bundle exec rspec`. The changes are committed as `9c90013` with message `feat(installers): add opencode install contract`.

---

Closes #68