### PR TITLE
Fix #72: feat(providers): add first-class smoke-test/health-check execution contracts for CLI providers

### DIFF
--- a/lib/agent_harness.rb
+++ b/lib/agent_harness.rb
@@ -117,6 +117,14 @@ module AgentHarness
       Providers::Registry.instance.installation_contracts
     end
 
+    # Get smoke-test metadata for a provider CLI when the provider exposes it.
+    #
+    # @param provider_name [Symbol, String] the provider name
+    # @return [Hash, nil] smoke-test contract
+    def provider_smoke_test_contract(provider_name)
+      smoke_test_contract(provider_name)
+    end
+
     # Get smoke-test metadata for a provider CLI.
     # @param provider_name [Symbol, String] the provider name
     # @return [Hash, nil] smoke-test contract

--- a/lib/agent_harness.rb
+++ b/lib/agent_harness.rb
@@ -168,12 +168,16 @@ module AgentHarness
     # authentication, provider health status, and config validation checks.
     #
     # @param timeout [Integer] timeout in seconds for each check (defaults to configured value)
+    # @raise [ArgumentError] if provider_runtime is supplied; runtime overrides are
+    #   only supported by `check_provider` to avoid leaking one provider's execution
+    #   context into every other health check
     # @return [Array<Hash>] health status for each provider
     def check_providers(timeout: nil, executor: nil, provider_runtime: nil)
+      raise ArgumentError, "provider_runtime is only supported for single-provider health checks" unless provider_runtime.nil?
+
       options = {}
       options[:timeout] = timeout unless timeout.nil?
       options[:executor] = executor unless executor.nil?
-      options[:provider_runtime] = provider_runtime unless provider_runtime.nil?
       ProviderHealthCheck.check_all(**options)
     end
 

--- a/lib/agent_harness.rb
+++ b/lib/agent_harness.rb
@@ -122,6 +122,8 @@ module AgentHarness
     # @return [Hash, nil] smoke-test contract
     # @raise [ConfigurationError] if the provider name is not registered
     def smoke_test_contract(provider_name)
+      # Explicitly raise if provider is not registered to match documentation
+      raise ConfigurationError, "Unknown provider: #{provider_name}" unless Providers::Registry.instance.registered?(provider_name)
       Providers::Registry.instance.smoke_test_contract(provider_name)
     end
 

--- a/lib/agent_harness.rb
+++ b/lib/agent_harness.rb
@@ -117,6 +117,20 @@ module AgentHarness
       Providers::Registry.instance.installation_contracts
     end
 
+    # Get smoke-test metadata for a provider CLI.
+    # @param provider_name [Symbol, String] the provider name
+    # @return [Hash, nil] smoke-test contract
+    # @raise [ConfigurationError] if the provider name is not registered
+    def smoke_test_contract(provider_name)
+      Providers::Registry.instance.smoke_test_contract(provider_name)
+    end
+
+    # Get all provider smoke-test contracts exposed by agent-harness.
+    # @return [Hash<Symbol, Hash>] smoke-test contracts keyed by provider
+    def smoke_test_contracts
+      Providers::Registry.instance.smoke_test_contracts
+    end
+
     # Check if authentication is valid for a provider
     # @param provider_name [Symbol] the provider name
     # @return [Boolean] true if auth is valid
@@ -155,16 +169,24 @@ module AgentHarness
     #
     # @param timeout [Integer] timeout in seconds for each check (defaults to configured value)
     # @return [Array<Hash>] health status for each provider
-    def check_providers(timeout: nil)
-      timeout ? ProviderHealthCheck.check_all(timeout: timeout) : ProviderHealthCheck.check_all
+    def check_providers(timeout: nil, executor: nil, provider_runtime: nil)
+      options = {}
+      options[:timeout] = timeout unless timeout.nil?
+      options[:executor] = executor unless executor.nil?
+      options[:provider_runtime] = provider_runtime unless provider_runtime.nil?
+      ProviderHealthCheck.check_all(**options)
     end
 
     # Check health of a single provider
     # @param provider_name [Symbol] the provider name
     # @param timeout [Integer, nil] timeout in seconds (nil lets ProviderHealthCheck apply its validated default)
     # @return [Hash] health status with :name, :status, :message, :latency_ms
-    def check_provider(provider_name, timeout: nil)
-      timeout ? ProviderHealthCheck.check(provider_name, timeout: timeout) : ProviderHealthCheck.check(provider_name)
+    def check_provider(provider_name, timeout: nil, executor: nil, provider_runtime: nil)
+      options = {}
+      options[:timeout] = timeout unless timeout.nil?
+      options[:executor] = executor unless executor.nil?
+      options[:provider_runtime] = provider_runtime unless provider_runtime.nil?
+      ProviderHealthCheck.check(provider_name, **options)
     end
   end
 end

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -333,7 +333,8 @@ module AgentHarness
       end
 
       def host_preflight_allowed?(executor:, provider_runtime: nil)
-        executor.nil?
+        effective_executor = executor || AgentHarness.configuration.command_executor
+        effective_executor.instance_of?(CommandExecutor)
       end
 
       def normalize_smoke_error_category(category, message)

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -176,55 +176,59 @@ module AgentHarness
           )
         end
 
-        # Step 2: Check CLI availability
         klass = registry.get(provider_name)
-        unless klass.available?
-          return build_result(
-            name: provider_name,
-            status: "error",
-            message: "CLI '#{klass.binary_name}' not found in PATH",
-            start_time: start_time,
-            error_category: :installation,
-            check: :availability
-          )
-        end
+        provider_instance = build_provider(provider_name, klass, executor: executor)
+        host_preflight_allowed = host_preflight_allowed?(executor: executor, provider_runtime: provider_runtime)
 
-        # Step 3: Check authentication
-        # Treat "not implemented" auth status as degraded rather than error,
-        # since most built-in providers don't implement auth_status hooks.
-        # In either case, continue to steps 4/5 so health and config issues
-        # are still surfaced for providers that lack an auth_status hook.
-        auth = Authentication.auth_status(provider_name)
         auth_degraded = false
-        unless auth[:valid]
-          unless auth_not_implemented?(auth)
+        if host_preflight_allowed
+          # Step 2: Check CLI availability
+          unless klass.available?
             return build_result(
               name: provider_name,
               status: "error",
-              message: auth[:error] || "Authentication failed",
+              message: "CLI '#{klass.binary_name}' not found in PATH",
               start_time: start_time,
-              error_category: :authentication,
-              check: :authentication
+              error_category: :installation,
+              check: :availability
             )
           end
-          auth_degraded = true
-        end
 
-        # Step 4: Check provider-level health (e.g., endpoint reachability)
-        # The Adapter default always returns {healthy: true}, so providers
-        # that haven't implemented a real health check are reported as ok
-        # with a note that the check is not implemented.
-        provider_instance = build_provider(provider_name, klass, executor: executor)
-        health = provider_instance.health_status
-        unless health[:healthy]
-          return build_result(
-            name: provider_name,
-            status: "degraded",
-            message: health[:message] || "Provider health check failed",
-            start_time: start_time,
-            error_category: :transient,
-            check: :provider_health
-          )
+          # Step 3: Check authentication
+          # Treat "not implemented" auth status as degraded rather than error,
+          # since most built-in providers don't implement auth_status hooks.
+          # In either case, continue to steps 4/5 so health and config issues
+          # are still surfaced for providers that lack an auth_status hook.
+          auth = Authentication.auth_status(provider_name)
+          unless auth[:valid]
+            unless auth_not_implemented?(auth)
+              return build_result(
+                name: provider_name,
+                status: "error",
+                message: auth[:error] || "Authentication failed",
+                start_time: start_time,
+                error_category: :authentication,
+                check: :authentication
+              )
+            end
+            auth_degraded = true
+          end
+
+          # Step 4: Check provider-level health (e.g., endpoint reachability)
+          # The Adapter default always returns {healthy: true}, so providers
+          # that haven't implemented a real health check are reported as ok
+          # with a note that the check is not implemented.
+          health = provider_instance.health_status
+          unless health[:healthy]
+            return build_result(
+              name: provider_name,
+              status: "degraded",
+              message: health[:message] || "Provider health check failed",
+              start_time: start_time,
+              error_category: :transient,
+              check: :provider_health
+            )
+          end
         end
 
         # Step 5: Validate provider config
@@ -246,13 +250,17 @@ module AgentHarness
 
         smoke_contract = provider_instance.smoke_test_contract
         unless smoke_contract || provider_overrides_method?(provider_instance, :smoke_test)
-          message = if auth_degraded
+          message = if host_preflight_allowed && auth_degraded
             "Auth status check not implemented; health and config checks passed (smoke test unavailable)"
-          elsif provider_overrides_method?(provider_instance, :health_status) ||
-              provider_overrides_method?(provider_instance, :validate_config)
+          elsif host_preflight_allowed && (provider_overrides_method?(provider_instance, :health_status) ||
+            provider_overrides_method?(provider_instance, :validate_config))
             "Health and config checks passed (smoke test unavailable)"
-          else
+          elsif host_preflight_allowed
             "Registered and authenticated; health/config checks use defaults and smoke test is unavailable"
+          elsif provider_overrides_method?(provider_instance, :validate_config)
+            "Configuration checks passed, but smoke test is unavailable for the supplied execution context"
+          else
+            "Smoke test is unavailable for the supplied execution context"
           end
 
           return build_result(
@@ -272,7 +280,7 @@ module AgentHarness
             status: smoke[:status] || "error",
             message: smoke[:message] || "Smoke test failed",
             start_time: start_time,
-            error_category: smoke[:error_category] || :unknown,
+            error_category: normalize_smoke_error_category(smoke[:error_category], smoke[:message]),
             check: :smoke_test
           )
         end
@@ -289,7 +297,11 @@ module AgentHarness
           )
         end
 
-        message = if provider_overrides_method?(provider_instance, :health_status) ||
+        message = if !host_preflight_allowed && provider_overrides_method?(provider_instance, :validate_config)
+          "Configuration and smoke test passed using the supplied execution context"
+        elsif !host_preflight_allowed
+          "Smoke test passed using the supplied execution context"
+        elsif provider_overrides_method?(provider_instance, :health_status) ||
             provider_overrides_method?(provider_instance, :validate_config)
           "All checks passed"
         else
@@ -316,6 +328,41 @@ module AgentHarness
 
         error = auth[:error].to_s
         error.include?("not implemented")
+      end
+
+      def host_preflight_allowed?(executor:, provider_runtime:)
+        executor.nil? && provider_runtime.nil?
+      end
+
+      def normalize_smoke_error_category(category, message)
+        normalized = if installation_failure_message?(message)
+          :installation
+        else
+          category || ErrorTaxonomy.classify_message(message)
+        end
+
+        case normalized&.to_sym
+        when :installation
+          :installation
+        when :auth_expired, :authentication
+          :authentication
+        when :rate_limited, :rate_limit
+          :rate_limit
+        when :quota_exceeded, :quota
+          :quota
+        when :timeout
+          :timeout
+        when :transient
+          :transient
+        when :sandbox_failure, :configuration, :permanent
+          :configuration
+        else
+          :unknown
+        end
+      end
+
+      def installation_failure_message?(message)
+        message.to_s.match?(/(not found in PATH|command not found|No such file or directory|is not installed)/i)
       end
 
       def provider_overrides_method?(provider_instance, method_name)

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -244,6 +244,27 @@ module AgentHarness
           )
         end
 
+        smoke_contract = provider_instance.smoke_test_contract
+        unless smoke_contract || provider_overrides_method?(provider_instance, :smoke_test)
+          message = if auth_degraded
+            "Auth status check not implemented; health and config checks passed (smoke test unavailable)"
+          elsif provider_overrides_method?(provider_instance, :health_status) ||
+              provider_overrides_method?(provider_instance, :validate_config)
+            "Health and config checks passed (smoke test unavailable)"
+          else
+            "Registered and authenticated; health/config checks use defaults and smoke test is unavailable"
+          end
+
+          return build_result(
+            name: provider_name,
+            status: "degraded",
+            message: message,
+            start_time: start_time,
+            error_category: :configuration,
+            check: :smoke_test
+          )
+        end
+
         smoke = provider_instance.smoke_test(timeout: timeout, provider_runtime: provider_runtime)
         unless smoke[:ok]
           return build_result(

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -299,9 +299,12 @@ module AgentHarness
           )
         end
 
-        # Let the provider contract's own timeout govern the smoke test
-        # rather than the (typically shorter) health-check timeout.
-        smoke = provider_instance.smoke_test(timeout: nil, provider_runtime: provider_runtime)
+        # When a contract exists, pass nil so the adapter falls through to
+        # contract[:timeout]. When the provider overrides #smoke_test without
+        # publishing a contract, forward the validated health-check timeout so
+        # the override can honour it instead of running without any limit.
+        smoke_timeout = smoke_contract ? nil : timeout
+        smoke = provider_instance.smoke_test(timeout: smoke_timeout, provider_runtime: provider_runtime)
         unless smoke[:ok]
           return build_result(
             name: provider_name,

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -251,7 +251,8 @@ module AgentHarness
         end
 
         smoke_contract = provider_instance.smoke_test_contract
-        unless smoke_contract || provider_overrides_method?(provider_instance, :smoke_test)
+        # Explicitly handle missing smoke-test contract when no custom smoke_test implementation
+        if smoke_contract.nil? && !provider_overrides_method?(provider_instance, :smoke_test)
           message = if host_preflight_allowed && auth_degraded
             "Auth status check not implemented; health and config checks passed (smoke test unavailable)"
           elsif host_preflight_allowed && (provider_overrides_method?(provider_instance, :health_status) ||

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -261,7 +261,7 @@ module AgentHarness
           return build_result(
             name: provider_name,
             status: "degraded",
-            message: "Auth status check not implemented; health and config checks passed",
+            message: "Auth status check not implemented; health, config, and smoke tests passed",
             start_time: start_time,
             error_category: :authentication,
             check: :authentication
@@ -272,7 +272,7 @@ module AgentHarness
             provider_overrides_method?(provider_instance, :validate_config)
           "All checks passed"
         else
-          "Registered and authenticated (health/config checks use defaults)"
+          "Registered, authenticated, and smoke test passed (health/config checks use defaults)"
         end
 
         build_result(

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -331,7 +331,10 @@ module AgentHarness
       end
 
       def host_preflight_allowed?(executor:, provider_runtime:)
-        executor.nil? && provider_runtime.nil?
+        return false unless executor.nil?
+        return true if provider_runtime.nil?
+
+        ProviderRuntime.wrap(provider_runtime).empty?
       end
 
       def normalize_smoke_error_category(category, message)

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -49,7 +49,12 @@ module AgentHarness
         start_time = monotonic_now
         timeout = validate_timeout(timeout)
 
-        Timeout.timeout(timeout) do
+        # Honor the provider smoke-test contract timeout when it exceeds
+        # the health-check timeout, so real CLI round trips are not
+        # falsely reported as timeouts.
+        outer_timeout = effective_check_timeout(name, timeout)
+
+        Timeout.timeout(outer_timeout) do
           perform_check(
             name,
             start_time,
@@ -62,7 +67,7 @@ module AgentHarness
         build_result(
           name: name,
           status: "error",
-          message: "Health check timed out after #{timeout}s",
+          message: "Health check timed out after #{outer_timeout || timeout}s",
           start_time: start_time || monotonic_now,
           error_category: :timeout,
           check: :timeout
@@ -276,7 +281,9 @@ module AgentHarness
           )
         end
 
-        smoke = provider_instance.smoke_test(timeout: timeout, provider_runtime: provider_runtime)
+        # Let the provider contract's own timeout govern the smoke test
+        # rather than the (typically shorter) health-check timeout.
+        smoke = provider_instance.smoke_test(timeout: nil, provider_runtime: provider_runtime)
         unless smoke[:ok]
           return build_result(
             name: provider_name,
@@ -342,6 +349,17 @@ module AgentHarness
           return false if runtime && (!runtime.env.empty? || !runtime.unset_env.empty? || runtime.base_url || runtime.api_provider)
         end
         effective_executor.is_a?(CommandExecutor) && !effective_executor.is_a?(DockerCommandExecutor)
+      end
+
+      def effective_check_timeout(provider_name, base_timeout)
+        registry = Providers::Registry.instance
+        return base_timeout unless registry.registered?(provider_name)
+
+        contract = registry.smoke_test_contract(provider_name)
+        contract_timeout = contract&.dig(:timeout)
+        return base_timeout unless contract_timeout.is_a?(Numeric) && contract_timeout.positive?
+
+        [base_timeout, contract_timeout].max
       end
 
       def normalize_smoke_error_category(category, message)

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -334,7 +334,7 @@ module AgentHarness
 
       def host_preflight_allowed?(executor:, provider_runtime: nil)
         effective_executor = executor || AgentHarness.configuration.command_executor
-        effective_executor.instance_of?(CommandExecutor)
+        effective_executor.is_a?(CommandExecutor) && !effective_executor.is_a?(DockerCommandExecutor)
       end
 
       def normalize_smoke_error_category(category, message)

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -26,6 +26,8 @@ module AgentHarness
       # @param timeout [Integer] timeout in seconds for each check
       # @return [Array<Hash>] health status for each provider
       def check_all(timeout: configured_timeout, executor: nil, provider_runtime: nil)
+        raise ArgumentError, "provider_runtime is only supported for single-provider health checks" unless provider_runtime.nil?
+
         provider_names = if AgentHarness.configuration.providers.empty?
           Providers::Registry.instance.all
         else
@@ -330,11 +332,8 @@ module AgentHarness
         error.include?("not implemented")
       end
 
-      def host_preflight_allowed?(executor:, provider_runtime:)
-        return false unless executor.nil?
-        return true if provider_runtime.nil?
-
-        ProviderRuntime.wrap(provider_runtime).empty?
+      def host_preflight_allowed?(executor:, provider_runtime: nil)
+        executor.nil?
       end
 
       def normalize_smoke_error_category(category, message)

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -25,14 +25,16 @@ module AgentHarness
       #
       # @param timeout [Integer] timeout in seconds for each check
       # @return [Array<Hash>] health status for each provider
-      def check_all(timeout: configured_timeout)
+      def check_all(timeout: configured_timeout, executor: nil, provider_runtime: nil)
         provider_names = if AgentHarness.configuration.providers.empty?
           Providers::Registry.instance.all
         else
           enabled_provider_names
         end
 
-        provider_names.map { |name| check(name, timeout: timeout) }
+        provider_names.map do |name|
+          check(name, timeout: timeout, executor: executor, provider_runtime: provider_runtime)
+        end
       end
 
       # Check health of a single provider
@@ -40,20 +42,28 @@ module AgentHarness
       # @param provider_name [Symbol, String] the provider name
       # @param timeout [Integer] timeout in seconds
       # @return [Hash] health status with :name, :status, :message, :latency_ms keys
-      def check(provider_name, timeout: configured_timeout)
+      def check(provider_name, timeout: configured_timeout, executor: nil, provider_runtime: nil)
         name = normalize_name(provider_name)
         start_time = monotonic_now
         timeout = validate_timeout(timeout)
 
         Timeout.timeout(timeout) do
-          perform_check(name, start_time)
+          perform_check(
+            name,
+            start_time,
+            timeout: timeout,
+            executor: executor,
+            provider_runtime: provider_runtime
+          )
         end
       rescue Timeout::Error
         build_result(
           name: name,
           status: "error",
           message: "Health check timed out after #{timeout}s",
-          start_time: start_time || monotonic_now
+          start_time: start_time || monotonic_now,
+          error_category: :timeout,
+          check: :timeout
         )
       rescue NotImplementedError => e
         # NotImplementedError inherits from ScriptError, not StandardError,
@@ -65,7 +75,9 @@ module AgentHarness
           name: name,
           status: "error",
           message: "Health check failed: #{e.class}: #{e.message}",
-          start_time: start_time || monotonic_now
+          start_time: start_time || monotonic_now,
+          error_category: :unknown,
+          check: :provider_health
         )
       rescue => e
         # Return a generic message to avoid leaking sensitive details
@@ -76,7 +88,9 @@ module AgentHarness
           name: name,
           status: "error",
           message: "Health check failed: #{e.class}",
-          start_time: start_time || monotonic_now
+          start_time: start_time || monotonic_now,
+          error_category: :unknown,
+          check: :provider_health
         )
       end
 
@@ -148,7 +162,7 @@ module AgentHarness
         :unknown
       end
 
-      def perform_check(provider_name, start_time)
+      def perform_check(provider_name, start_time, timeout:, executor:, provider_runtime:)
         # Step 1: Check provider is registered
         registry = Providers::Registry.instance
         unless registry.registered?(provider_name)
@@ -156,7 +170,9 @@ module AgentHarness
             name: provider_name,
             status: "error",
             message: "Provider not registered",
-            start_time: start_time
+            start_time: start_time,
+            error_category: :installation,
+            check: :registration
           )
         end
 
@@ -167,7 +183,9 @@ module AgentHarness
             name: provider_name,
             status: "error",
             message: "CLI '#{klass.binary_name}' not found in PATH",
-            start_time: start_time
+            start_time: start_time,
+            error_category: :installation,
+            check: :availability
           )
         end
 
@@ -184,7 +202,9 @@ module AgentHarness
               name: provider_name,
               status: "error",
               message: auth[:error] || "Authentication failed",
-              start_time: start_time
+              start_time: start_time,
+              error_category: :authentication,
+              check: :authentication
             )
           end
           auth_degraded = true
@@ -194,14 +214,16 @@ module AgentHarness
         # The Adapter default always returns {healthy: true}, so providers
         # that haven't implemented a real health check are reported as ok
         # with a note that the check is not implemented.
-        provider_instance = build_provider(provider_name, klass)
+        provider_instance = build_provider(provider_name, klass, executor: executor)
         health = provider_instance.health_status
         unless health[:healthy]
           return build_result(
             name: provider_name,
             status: "degraded",
             message: health[:message] || "Provider health check failed",
-            start_time: start_time
+            start_time: start_time,
+            error_category: :transient,
+            check: :provider_health
           )
         end
 
@@ -216,7 +238,21 @@ module AgentHarness
             name: provider_name,
             status: "degraded",
             message: "Configuration issues: #{errors_msg}",
-            start_time: start_time
+            start_time: start_time,
+            error_category: :configuration,
+            check: :configuration
+          )
+        end
+
+        smoke = provider_instance.smoke_test(timeout: timeout, provider_runtime: provider_runtime)
+        unless smoke[:ok]
+          return build_result(
+            name: provider_name,
+            status: smoke[:status] || "error",
+            message: smoke[:message] || "Smoke test failed",
+            start_time: start_time,
+            error_category: smoke[:error_category] || :unknown,
+            check: :smoke_test
           )
         end
 
@@ -226,7 +262,9 @@ module AgentHarness
             name: provider_name,
             status: "degraded",
             message: "Auth status check not implemented; health and config checks passed",
-            start_time: start_time
+            start_time: start_time,
+            error_category: :authentication,
+            check: :authentication
           )
         end
 
@@ -241,7 +279,8 @@ module AgentHarness
           name: provider_name,
           status: "ok",
           message: message,
-          start_time: start_time
+          start_time: start_time,
+          check: :smoke_test
         )
       end
 
@@ -262,21 +301,23 @@ module AgentHarness
         provider_instance.method(method_name).owner != Providers::Adapter
       end
 
-      def build_result(name:, status:, message:, start_time:)
+      def build_result(name:, status:, message:, start_time:, error_category: nil, check: nil)
         latency = ((monotonic_now - start_time) * 1000).round
         {
           name: name,
           status: status,
           message: message,
-          latency_ms: latency
+          latency_ms: latency,
+          error_category: error_category,
+          check: check
         }
       end
 
-      def build_provider(provider_name, klass)
+      def build_provider(provider_name, klass, executor:)
         config = AgentHarness.configuration.providers[provider_name]
         klass.new(
           config: config,
-          executor: AgentHarness.configuration.command_executor,
+          executor: executor || AgentHarness.configuration.command_executor,
           logger: AgentHarness.logger
         )
       end

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -189,7 +189,25 @@ module AgentHarness
 
         auth_degraded = false
         if host_preflight_allowed
-          # Step 2: Check CLI availability
+          # Step 2a: Honor the provider's `.available?` contract when running
+          # against the default host executor. Custom providers may enforce
+          # version or feature checks beyond simple PATH presence, so this
+          # catches cases where the binary exists but the provider considers
+          # itself unavailable. We skip this when a custom executor is
+          # supplied because `.available?` always queries the global
+          # executor, which may not reflect the caller's execution context.
+          if executor.nil? && !klass.available?
+            return build_result(
+              name: provider_name,
+              status: "error",
+              message: "Provider '#{klass.binary_name}' is not available (#{klass}.available? returned false)",
+              start_time: start_time,
+              error_category: :installation,
+              check: :availability
+            )
+          end
+
+          # Step 2b: Verify the binary is findable by the effective executor.
           unless provider_instance.executor.which(klass.binary_name)
             return build_result(
               name: provider_name,

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -67,18 +67,18 @@ module AgentHarness
           error_category: :timeout,
           check: :timeout
         )
-      rescue NotImplementedError => e
+      rescue NotImplementedError, ConfigurationError => e
         # NotImplementedError inherits from ScriptError, not StandardError,
         # so it must be rescued explicitly. Its messages are safe internal
-        # setup errors (e.g., missing provider methods) that help users
-        # diagnose configuration problems.
+        # setup errors (e.g., missing provider methods or malformed provider
+        # contracts) that help users diagnose configuration problems.
         AgentHarness.logger&.error("ProviderHealthCheck error for #{name}: #{e.class}")
         build_result(
           name: name,
           status: "error",
           message: "Health check failed: #{e.class}: #{e.message}",
           start_time: start_time || monotonic_now,
-          error_category: :unknown,
+          error_category: :configuration,
           check: :provider_health
         )
       rescue => e

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -335,6 +335,12 @@ module AgentHarness
 
       def host_preflight_allowed?(executor:, provider_runtime: nil)
         effective_executor = executor || AgentHarness.configuration.command_executor
+        # Skip host preflight only when provider runtime has environment/config overrides
+        # that could conflict with host-level checks (env, base_url, api_provider, unset_env)
+        if provider_runtime
+          runtime = ProviderRuntime.wrap(provider_runtime)
+          return false if runtime && (!runtime.env.empty? || !runtime.unset_env.empty? || runtime.base_url || runtime.api_provider)
+        end
         effective_executor.is_a?(CommandExecutor) && !effective_executor.is_a?(DockerCommandExecutor)
       end
 

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -185,7 +185,7 @@ module AgentHarness
         auth_degraded = false
         if host_preflight_allowed
           # Step 2: Check CLI availability
-          unless klass.available?
+          unless provider_instance.executor.which(klass.binary_name)
             return build_result(
               name: provider_name,
               status: "error",

--- a/lib/agent_harness/providers/adapter.rb
+++ b/lib/agent_harness/providers/adapter.rb
@@ -322,7 +322,11 @@ module AgentHarness
         )
 
         output = response.output.to_s.strip
-        if response.success? && (!contract.fetch(:require_output, true) || !output.empty?)
+        expected_output = contract[:expected_output]&.strip
+        success = response.success? && (!contract.fetch(:require_output, true) || !output.empty?)
+        success &&= expected_output.nil? || output == expected_output
+
+        if success
           return {
             ok: true,
             status: "ok",

--- a/lib/agent_harness/providers/adapter.rb
+++ b/lib/agent_harness/providers/adapter.rb
@@ -107,6 +107,16 @@ module AgentHarness
 
           Array(contract[:install_command_prefix]) + ["#{package_name}@#{version}"]
         end
+
+        # Canonical smoke-test contract for this provider.
+        #
+        # CLI-backed providers should expose a minimal real-execution prompt so
+        # downstream apps can reuse a stable provider-owned health check.
+        #
+        # @return [Hash, nil] smoke-test metadata or nil when not provided
+        def smoke_test_contract
+          nil
+        end
       end
 
       # Instance methods
@@ -284,6 +294,67 @@ module AgentHarness
         {healthy: true, message: "OK"}
       end
 
+      # Canonical smoke-test contract for this provider instance.
+      #
+      # @return [Hash, nil] smoke-test metadata
+      def smoke_test_contract
+        self.class.smoke_test_contract if self.class.respond_to?(:smoke_test_contract)
+      end
+
+      # Execute a minimal provider-owned smoke test via the configured executor.
+      #
+      # @param timeout [Integer, nil] timeout override in seconds
+      # @param provider_runtime [ProviderRuntime, Hash, nil] runtime overrides
+      # @return [Hash] normalized smoke-test result
+      def smoke_test(timeout: nil, provider_runtime: nil)
+        contract = smoke_test_contract
+        raise NotImplementedError, "#{self.class} does not implement #smoke_test_contract" unless contract
+
+        prompt = contract[:prompt]
+        if !prompt.is_a?(String) || prompt.strip.empty?
+          raise ConfigurationError, "#{self.class}.smoke_test_contract must define a non-empty :prompt"
+        end
+
+        response = send_message(
+          prompt: prompt,
+          timeout: timeout || contract[:timeout],
+          provider_runtime: provider_runtime
+        )
+
+        output = response.output.to_s.strip
+        if response.success? && (!contract.fetch(:require_output, true) || !output.empty?)
+          return {
+            ok: true,
+            status: "ok",
+            message: contract[:success_message] || "Smoke test passed",
+            error_category: nil,
+            output: output,
+            exit_code: response.exit_code
+          }
+        end
+
+        message = response.error.to_s.strip
+        message = output if message.empty?
+        message = "Smoke test failed with exit code #{response.exit_code}" if message.empty?
+
+        {
+          ok: false,
+          status: "error",
+          message: message,
+          error_category: classify_smoke_test_message(message),
+          output: output,
+          exit_code: response.exit_code
+        }
+      rescue TimeoutError => e
+        failure_smoke_test_result(e.message, :timeout)
+      rescue AuthenticationError => e
+        failure_smoke_test_result(e.message, :auth_expired)
+      rescue RateLimitError => e
+        failure_smoke_test_result(e.message, :rate_limited)
+      rescue ProviderError => e
+        failure_smoke_test_result(e.message, classify_smoke_test_message(e.message))
+      end
+
       # Execution semantics for this provider
       #
       # Returns a hash describing provider-specific execution behavior so
@@ -314,6 +385,23 @@ module AgentHarness
       # @return [Time, nil] when the rate limit resets, or nil if unknown
       def parse_rate_limit_reset(output)
         nil
+      end
+
+      private
+
+      def classify_smoke_test_message(message)
+        ErrorTaxonomy.classify(StandardError.new(message.to_s), error_patterns)
+      end
+
+      def failure_smoke_test_result(message, error_category)
+        {
+          ok: false,
+          status: "error",
+          message: message,
+          error_category: error_category,
+          output: nil,
+          exit_code: nil
+        }
       end
     end
   end

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -49,6 +49,10 @@ module AgentHarness
             {name: "claude-3-5-sonnet", family: "claude-3-5-sonnet", tier: "standard", provider: "aider"}
           ]
         end
+
+        def smoke_test_contract
+          Base::DEFAULT_SMOKE_TEST_CONTRACT
+        end
       end
 
       def name

--- a/lib/agent_harness/providers/anthropic.rb
+++ b/lib/agent_harness/providers/anthropic.rb
@@ -81,6 +81,10 @@ module AgentHarness
           MODEL_PATTERN.match?(family_name)
         end
 
+        def smoke_test_contract
+          Base::DEFAULT_SMOKE_TEST_CONTRACT
+        end
+
         private
 
         def parse_models_list(output)

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -26,6 +26,13 @@ module AgentHarness
     class Base
       include Adapter
 
+      DEFAULT_SMOKE_TEST_CONTRACT = {
+        prompt: "Reply with exactly OK.",
+        timeout: 30,
+        require_output: true,
+        success_message: "Smoke test passed"
+      }.freeze
+
       # Common error patterns shared across providers that use standard
       # HTTP-style error responses. Providers with unique patterns (e.g.
       # Anthropic, GitHub Copilot) override error_patterns entirely.
@@ -56,6 +63,12 @@ module AgentHarness
 
       attr_reader :config, :logger
       attr_accessor :executor
+
+      class << self
+        def smoke_test_contract
+          DEFAULT_SMOKE_TEST_CONTRACT
+        end
+      end
 
       # Initialize the provider
       #

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -28,6 +28,7 @@ module AgentHarness
 
       DEFAULT_SMOKE_TEST_CONTRACT = {
         prompt: "Reply with exactly OK.",
+        expected_output: "OK",
         timeout: 30,
         require_output: true,
         success_message: "Smoke test passed"
@@ -66,7 +67,7 @@ module AgentHarness
 
       class << self
         def smoke_test_contract
-          DEFAULT_SMOKE_TEST_CONTRACT
+          nil
         end
       end
 

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -79,6 +79,10 @@ module AgentHarness
           end
           contract.freeze
         end
+
+        def smoke_test_contract
+          Base::DEFAULT_SMOKE_TEST_CONTRACT
+        end
       end
 
       def name

--- a/lib/agent_harness/providers/cursor.rb
+++ b/lib/agent_harness/providers/cursor.rb
@@ -83,6 +83,10 @@ module AgentHarness
         def supports_model_family?(family_name)
           family_name.match?(/^(claude|gpt|cursor)-/)
         end
+
+        def smoke_test_contract
+          Base::DEFAULT_SMOKE_TEST_CONTRACT
+        end
       end
 
       def name

--- a/lib/agent_harness/providers/gemini.rb
+++ b/lib/agent_harness/providers/gemini.rb
@@ -103,6 +103,10 @@ module AgentHarness
         def supports_model_family?(family_name)
           MODEL_PATTERN.match?(family_name) || family_name.start_with?("gemini-")
         end
+
+        def smoke_test_contract
+          Base::DEFAULT_SMOKE_TEST_CONTRACT
+        end
       end
 
       def name

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -9,6 +9,20 @@ module AgentHarness
       # Model name pattern for GitHub Copilot (uses OpenAI models)
       MODEL_PATTERN = /^gpt-[\d.o-]+(?:-turbo)?(?:-mini)?$/i
 
+      # Copilot-specific smoke test contract.  The `what-the-shell` subcommand
+      # translates natural language into shell commands, so the generic
+      # "Reply with exactly OK." prompt would produce something like
+      # `echo "OK"` rather than the literal text "OK".  We use a prompt that
+      # is meaningful for the shell-translation path and only require
+      # non-empty output (no exact match).
+      SMOKE_TEST_CONTRACT = {
+        prompt: "list files in the current directory",
+        expected_output: nil,
+        timeout: 30,
+        require_output: true,
+        success_message: "Smoke test passed"
+      }.freeze
+
       class << self
         def provider_name
           :github_copilot
@@ -57,7 +71,7 @@ module AgentHarness
         end
 
         def smoke_test_contract
-          Base::DEFAULT_SMOKE_TEST_CONTRACT
+          SMOKE_TEST_CONTRACT
         end
 
         def model_family(provider_model_name)

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -57,7 +57,7 @@ module AgentHarness
         end
 
         def smoke_test_contract
-          nil
+          Base::DEFAULT_SMOKE_TEST_CONTRACT
         end
 
         def model_family(provider_model_name)

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -57,7 +57,7 @@ module AgentHarness
         end
 
         def smoke_test_contract
-          Base::DEFAULT_SMOKE_TEST_CONTRACT
+          nil
         end
 
         def model_family(provider_model_name)

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -56,6 +56,10 @@ module AgentHarness
           ]
         end
 
+        def smoke_test_contract
+          Base::DEFAULT_SMOKE_TEST_CONTRACT
+        end
+
         def model_family(provider_model_name)
           provider_model_name
         end

--- a/lib/agent_harness/providers/kilocode.rb
+++ b/lib/agent_harness/providers/kilocode.rb
@@ -60,6 +60,10 @@ module AgentHarness
           installation_contract(version: version)[:install_command]
         end
 
+        def smoke_test_contract
+          Base::DEFAULT_SMOKE_TEST_CONTRACT
+        end
+
         private
 
         def validate_install_version!(version)

--- a/lib/agent_harness/providers/mistral_vibe.rb
+++ b/lib/agent_harness/providers/mistral_vibe.rb
@@ -37,6 +37,10 @@ module AgentHarness
           return [] unless available?
           []
         end
+
+        def smoke_test_contract
+          Base::DEFAULT_SMOKE_TEST_CONTRACT
+        end
       end
 
       def name

--- a/lib/agent_harness/providers/opencode.rb
+++ b/lib/agent_harness/providers/opencode.rb
@@ -58,6 +58,10 @@ module AgentHarness
           installation_contract(version: version)[:install_command]
         end
 
+        def smoke_test_contract
+          Base::DEFAULT_SMOKE_TEST_CONTRACT
+        end
+
         private
 
         def build_installation_contract(version)

--- a/lib/agent_harness/providers/registry.rb
+++ b/lib/agent_harness/providers/registry.rb
@@ -107,6 +107,32 @@ module AgentHarness
         end
       end
 
+      # Get smoke-test metadata for a provider.
+      #
+      # @param name [Symbol, String] the provider name
+      # @return [Hash, nil] smoke-test contract
+      # @raise [ConfigurationError] if the provider name is not registered
+      def smoke_test_contract(name)
+        klass = get(name)
+        return nil unless klass.respond_to?(:smoke_test_contract)
+
+        klass.smoke_test_contract
+      end
+
+      # Get smoke-test metadata for all providers that expose it.
+      #
+      # @return [Hash<Symbol, Hash>] smoke-test contracts keyed by provider
+      def smoke_test_contracts
+        ensure_builtin_providers_registered
+
+        @providers.each_with_object({}) do |(name, klass), contracts|
+          next unless klass.respond_to?(:smoke_test_contract)
+
+          contract = klass.smoke_test_contract
+          contracts[name] = contract if contract
+        end
+      end
+
       # Reset registry (useful for testing)
       #
       # @return [void]

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -252,7 +252,9 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
 
         expect(result[:name]).to eq(:test_provider)
         expect(result[:status]).to eq("ok")
-        expect(result[:message]).to include("Registered and authenticated")
+        expect(result[:message]).to eq(
+          "Registered, authenticated, and smoke test passed (health/config checks use defaults)"
+        )
         expect(result[:check]).to eq(:smoke_test)
         expect(result[:latency_ms]).to be_a(Integer)
         expect(result[:latency_ms]).to be >= 0
@@ -337,8 +339,7 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
 
         expect(result[:name]).to eq(:test_provider)
         expect(result[:status]).to eq("degraded")
-        expect(result[:message]).to include("not implemented")
-        expect(result[:message]).to include("health and config checks passed")
+        expect(result[:message]).to eq("Auth status check not implemented; health, config, and smoke tests passed")
       end
     end
 
@@ -377,7 +378,7 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
 
         expect(result[:name]).to eq(:test_provider)
         expect(result[:status]).to eq("degraded")
-        expect(result[:message]).to include("not implemented")
+        expect(result[:message]).to eq("Auth status check not implemented; health, config, and smoke tests passed")
       end
     end
 
@@ -416,7 +417,7 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
 
         expect(result[:name]).to eq(:test_provider)
         expect(result[:status]).to eq("degraded")
-        expect(result[:message]).to include("not implemented")
+        expect(result[:message]).to eq("Auth status check not implemented; health, config, and smoke tests passed")
       end
     end
 
@@ -926,14 +927,18 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
       expect(results).to be_an(Array)
       test_result = results.find { |r| r[:name] == :test_provider }
       expect(test_result[:status]).to eq("ok")
-      expect(test_result[:message]).to include("Registered and authenticated")
+      expect(test_result[:message]).to eq(
+        "Registered, authenticated, and smoke test passed (health/config checks use defaults)"
+      )
     end
 
     it "exposes check_provider on the module" do
       result = AgentHarness.check_provider(:test_provider)
       expect(result[:name]).to eq(:test_provider)
       expect(result[:status]).to eq("ok")
-      expect(result[:message]).to include("Registered and authenticated")
+      expect(result[:message]).to eq(
+        "Registered, authenticated, and smoke test passed (health/config checks use defaults)"
+      )
     end
 
     it "exposes smoke_test_contract on the module" do

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -704,6 +704,24 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
       end
     end
 
+    context "when a ConfigurationError occurs" do
+      before do
+        allow(AgentHarness::Providers::Registry).to receive(:instance)
+          .and_raise(AgentHarness::ConfigurationError, "smoke_test_contract must define a non-empty :prompt")
+      end
+
+      it "includes the configuration failure details for easier diagnosis" do
+        result = described_class.check(:claude)
+
+        expect(result[:status]).to eq("error")
+        expect(result[:message]).to eq(
+          "Health check failed: AgentHarness::ConfigurationError: smoke_test_contract must define a non-empty :prompt"
+        )
+        expect(result[:error_category]).to eq(:configuration)
+        expect(result[:check]).to eq(:provider_health)
+      end
+    end
+
     context "when the check exceeds the timeout" do
       before do
         allow(Timeout).to receive(:timeout).and_raise(Timeout::Error)

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -52,6 +52,17 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
         expect(result[:error_category]).to eq(:installation)
         expect(result[:check]).to eq(:availability)
       end
+
+      it "still runs host preflight when provider_runtime is an empty hash" do
+        result = described_class.check(:test_provider, provider_runtime: {})
+
+        expect(result[:name]).to eq(:test_provider)
+        expect(result[:status]).to eq("error")
+        expect(result[:message]).to include("test-cli")
+        expect(result[:message]).to include("not found")
+        expect(result[:error_category]).to eq(:installation)
+        expect(result[:check]).to eq(:availability)
+      end
     end
 
     context "when authentication fails" do

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -622,6 +622,49 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
       end
     end
 
+    context "when a non-host executor is configured globally" do
+      let(:container_executor) { instance_double(AgentHarness::DockerCommandExecutor) }
+      let(:provider_class) do
+        Class.new(AgentHarness::Providers::Base) do
+          class << self
+            attr_reader :last_executor
+
+            def provider_name
+              :test_provider
+            end
+
+            def binary_name
+              "test-cli"
+            end
+
+            def available?
+              false
+            end
+          end
+
+          def smoke_test(timeout: nil, provider_runtime: nil)
+            self.class.instance_variable_set(:@last_executor, executor)
+            {ok: true, status: "ok", message: "Smoke test passed", error_category: nil}
+          end
+        end
+      end
+
+      before do
+        registry.register(:test_provider, provider_class)
+        allow(AgentHarness.configuration).to receive(:command_executor).and_return(container_executor)
+      end
+
+      it "skips host-only preflight checks and uses the configured executor for the smoke test" do
+        expect(AgentHarness::Authentication).not_to receive(:auth_status)
+
+        result = described_class.check(:test_provider)
+
+        expect(result[:status]).to eq("ok")
+        expect(result[:message]).to eq("Smoke test passed using the supplied execution context")
+        expect(provider_class.last_executor).to eq(container_executor)
+      end
+    end
+
     context "when the smoke test reports an authentication-specific adapter category" do
       let(:provider_class) do
         Class.new(AgentHarness::Providers::Base) do

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
 
   before do
     registry.reset!
+    allow_any_instance_of(AgentHarness::CommandExecutor).to receive(:which) do |_executor, binary|
+      case binary
+      when "test-cli", "provider-a"
+        "/tmp/#{binary}"
+      end
+    end
   end
 
   describe ".check" do
@@ -40,6 +46,7 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
 
       before do
         registry.register(:test_provider, provider_class)
+        allow_any_instance_of(AgentHarness::CommandExecutor).to receive(:which).with("test-cli").and_return(nil)
       end
 
       it "returns error status with CLI info" do
@@ -622,6 +629,60 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
       end
     end
 
+    context "when a local CommandExecutor subclass is provided explicitly" do
+      let(:logging_executor_class) do
+        Class.new(AgentHarness::CommandExecutor) do
+          def which(binary)
+            return "/tmp/#{binary}" if binary == "test-cli"
+
+            super
+          end
+        end
+      end
+      let(:logging_executor) { logging_executor_class.new }
+      let(:provider_class) do
+        Class.new(AgentHarness::Providers::Base) do
+          class << self
+            attr_reader :last_executor
+
+            def provider_name
+              :test_provider
+            end
+
+            def binary_name
+              "test-cli"
+            end
+
+            def available?
+              false
+            end
+          end
+
+          def smoke_test(timeout: nil, provider_runtime: nil)
+            self.class.instance_variable_set(:@last_executor, executor)
+            {ok: true, status: "ok", message: "Smoke test passed", error_category: nil}
+          end
+        end
+      end
+
+      before do
+        registry.register(:test_provider, provider_class)
+        allow(AgentHarness::Authentication).to receive(:auth_status)
+          .with(:test_provider)
+          .and_return({valid: true, expires_at: nil, error: nil})
+      end
+
+      it "runs host preflight against the supplied executor" do
+        result = described_class.check(:test_provider, executor: logging_executor)
+
+        expect(result[:status]).to eq("ok")
+        expect(result[:message]).to eq(
+          "Registered, authenticated, and smoke test passed (health/config checks use defaults)"
+        )
+        expect(provider_class.last_executor).to eq(logging_executor)
+      end
+    end
+
     context "when a non-host executor is configured globally" do
       let(:container_executor) { AgentHarness::DockerCommandExecutor.allocate }
       let(:provider_class) do
@@ -693,6 +754,7 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
       before do
         registry.register(:test_provider, provider_class)
         allow(AgentHarness.configuration).to receive(:command_executor).and_return(logging_executor)
+        allow(logging_executor).to receive(:which).with("test-cli").and_return(nil)
       end
 
       it "still runs host preflight checks" do
@@ -833,6 +895,7 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
             def available? = false
           end
         end)
+        allow_any_instance_of(AgentHarness::CommandExecutor).to receive(:which).with("test-cli").and_return(nil)
       end
 
       it "falls back to configured timeout when nil is passed" do

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -535,12 +535,12 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
           .and_return({valid: true, expires_at: nil, error: nil})
       end
 
-      it "returns the normalized smoke-test failure details" do
+      it "maps adapter taxonomy categories onto the public health-check vocabulary" do
         result = described_class.check(:test_provider, timeout: 7, provider_runtime: {model: "test-model"})
 
         expect(result[:status]).to eq("error")
         expect(result[:message]).to eq("Rate limit exceeded")
-        expect(result[:error_category]).to eq(:rate_limited)
+        expect(result[:error_category]).to eq(:rate_limit)
         expect(result[:check]).to eq(:smoke_test)
       end
     end
@@ -561,8 +561,12 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
             end
 
             def available?
-              true
+              false
             end
+          end
+
+          def health_status
+            {healthy: false, message: "Host auth check should not run here"}
           end
 
           def smoke_test(timeout: nil, provider_runtime: nil)
@@ -576,17 +580,67 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
 
       before do
         registry.register(:test_provider, provider_class)
+      end
+
+      it "skips host-only preflight checks and runs the smoke test through the supplied executor" do
+        expect(AgentHarness::Authentication).not_to receive(:auth_status)
+
+        result = described_class.check(
+          :test_provider,
+          timeout: 9,
+          executor: custom_executor,
+          provider_runtime: {model: "runtime-model"}
+        )
+
+        expect(result[:status]).to eq("ok")
+        expect(result[:message]).to eq("Smoke test passed using the supplied execution context")
+        expect(provider_class.last_executor).to eq(custom_executor)
+        expect(provider_class.last_timeout).to eq(9)
+        expect(provider_class.last_provider_runtime).to eq({model: "runtime-model"})
+      end
+    end
+
+    context "when the smoke test reports an authentication-specific adapter category" do
+      let(:provider_class) do
+        Class.new(AgentHarness::Providers::Base) do
+          class << self
+            def provider_name
+              :test_provider
+            end
+
+            def binary_name
+              "test-cli"
+            end
+
+            def available?
+              true
+            end
+          end
+
+          def smoke_test(timeout: nil, provider_runtime: nil)
+            {
+              ok: false,
+              status: "error",
+              message: "Session expired",
+              error_category: :auth_expired
+            }
+          end
+        end
+      end
+
+      before do
+        registry.register(:test_provider, provider_class)
         allow(AgentHarness::Authentication).to receive(:auth_status)
           .with(:test_provider)
           .and_return({valid: true, expires_at: nil, error: nil})
       end
 
-      it "builds the provider with the supplied executor and forwards runtime overrides" do
-        described_class.check(:test_provider, timeout: 9, executor: custom_executor, provider_runtime: {model: "runtime-model"})
+      it "normalizes the failure to :authentication" do
+        result = described_class.check(:test_provider)
 
-        expect(provider_class.last_executor).to eq(custom_executor)
-        expect(provider_class.last_timeout).to eq(9)
-        expect(provider_class.last_provider_runtime).to eq({model: "runtime-model"})
+        expect(result[:status]).to eq("error")
+        expect(result[:error_category]).to eq(:authentication)
+        expect(result[:check]).to eq(:smoke_test)
       end
     end
 

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -623,7 +623,7 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
     end
 
     context "when a non-host executor is configured globally" do
-      let(:container_executor) { instance_double(AgentHarness::DockerCommandExecutor) }
+      let(:container_executor) { AgentHarness::DockerCommandExecutor.allocate }
       let(:provider_class) do
         Class.new(AgentHarness::Providers::Base) do
           class << self
@@ -662,6 +662,49 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
         expect(result[:status]).to eq("ok")
         expect(result[:message]).to eq("Smoke test passed using the supplied execution context")
         expect(provider_class.last_executor).to eq(container_executor)
+      end
+    end
+
+    context "when a local CommandExecutor subclass is configured globally" do
+      let(:logging_executor_class) { Class.new(AgentHarness::CommandExecutor) }
+      let(:logging_executor) { logging_executor_class.new }
+      let(:provider_class) do
+        Class.new(AgentHarness::Providers::Base) do
+          class << self
+            def provider_name
+              :test_provider
+            end
+
+            def binary_name
+              "test-cli"
+            end
+
+            def available?
+              false
+            end
+          end
+
+          def smoke_test(timeout: nil, provider_runtime: nil)
+            {ok: true, status: "ok", message: "Smoke test passed", error_category: nil}
+          end
+        end
+      end
+
+      before do
+        registry.register(:test_provider, provider_class)
+        allow(AgentHarness.configuration).to receive(:command_executor).and_return(logging_executor)
+      end
+
+      it "still runs host preflight checks" do
+        expect(AgentHarness::Authentication).not_to receive(:auth_status)
+
+        result = described_class.check(:test_provider)
+
+        expect(result[:status]).to eq("error")
+        expect(result[:message]).to include("test-cli")
+        expect(result[:message]).to include("not found")
+        expect(result[:error_category]).to eq(:installation)
+        expect(result[:check]).to eq(:availability)
       end
     end
 

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -658,10 +658,10 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
         expect(result[:status]).to eq("ok")
         expect(result[:message]).to eq("Smoke test passed using the supplied execution context")
         expect(provider_class.last_executor).to eq(custom_executor)
-        # Health-check timeout is no longer forwarded; smoke_test uses
-        # its own contract timeout (or nil when the provider overrides
-        # smoke_test directly and manages its own timeout).
-        expect(provider_class.last_timeout).to be_nil
+        # When the provider overrides smoke_test without a contract,
+        # the health-check timeout is forwarded so the override can
+        # honour it instead of running without any limit.
+        expect(provider_class.last_timeout).to eq(9)
         expect(provider_class.last_provider_runtime).to eq({model: "runtime-model"})
       end
     end

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -261,6 +261,44 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
       end
     end
 
+    context "when the provider does not publish a smoke-test contract" do
+      let(:provider_class) do
+        Class.new(AgentHarness::Providers::Base) do
+          class << self
+            def provider_name
+              :test_provider
+            end
+
+            def binary_name
+              "test-cli"
+            end
+
+            def available?
+              true
+            end
+          end
+        end
+      end
+
+      before do
+        registry.register(:test_provider, provider_class)
+        allow(AgentHarness::Authentication).to receive(:auth_status)
+          .with(:test_provider)
+          .and_return({valid: true, expires_at: nil, error: nil})
+      end
+
+      it "returns degraded without attempting a smoke test" do
+        result = described_class.check(:test_provider)
+
+        expect(result[:status]).to eq("degraded")
+        expect(result[:message]).to eq(
+          "Registered and authenticated; health/config checks use defaults and smoke test is unavailable"
+        )
+        expect(result[:error_category]).to eq(:configuration)
+        expect(result[:check]).to eq(:smoke_test)
+      end
+    end
+
     context "when provider overrides health_status" do
       let(:provider_class) do
         Class.new(AgentHarness::Providers::Base) do
@@ -895,6 +933,10 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
 
           def available?
             true
+          end
+
+          def smoke_test_contract
+            AgentHarness::Providers::Base::DEFAULT_SMOKE_TEST_CONTRACT
           end
         end
 

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -1243,5 +1243,11 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
 
       expect(contract).to include(prompt: "Reply with exactly OK.")
     end
+
+    it "exposes provider_smoke_test_contract wrapper on the module" do
+      contract = AgentHarness.provider_smoke_test_contract(:test_provider)
+
+      expect(contract).to include(prompt: "Reply with exactly OK.")
+    end
   end
 end

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -49,13 +49,13 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
         allow_any_instance_of(AgentHarness::CommandExecutor).to receive(:which).with("test-cli").and_return(nil)
       end
 
-      it "returns error status with CLI info" do
+      it "returns error status when .available? returns false" do
         result = described_class.check(:test_provider)
 
         expect(result[:name]).to eq(:test_provider)
         expect(result[:status]).to eq("error")
-        expect(result[:message]).to include("test-cli")
-        expect(result[:message]).to include("not found")
+        expect(result[:message]).to include("not available")
+        expect(result[:message]).to include("available? returned false")
         expect(result[:error_category]).to eq(:installation)
         expect(result[:check]).to eq(:availability)
       end
@@ -65,8 +65,7 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
 
         expect(result[:name]).to eq(:test_provider)
         expect(result[:status]).to eq("error")
-        expect(result[:message]).to include("test-cli")
-        expect(result[:message]).to include("not found")
+        expect(result[:message]).to include("not available")
         expect(result[:error_category]).to eq(:installation)
         expect(result[:check]).to eq(:availability)
       end
@@ -76,8 +75,43 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
 
         expect(result[:name]).to eq(:test_provider)
         expect(result[:status]).to eq("error")
+        expect(result[:message]).to include("not available")
+        expect(result[:error_category]).to eq(:installation)
+        expect(result[:check]).to eq(:availability)
+      end
+    end
+
+    context "when .available? returns true but executor cannot find binary" do
+      let(:provider_class) do
+        Class.new(AgentHarness::Providers::Base) do
+          class << self
+            def provider_name
+              :test_provider
+            end
+
+            def binary_name
+              "test-cli"
+            end
+
+            def available?
+              true
+            end
+          end
+        end
+      end
+
+      before do
+        registry.register(:test_provider, provider_class)
+        allow_any_instance_of(AgentHarness::CommandExecutor).to receive(:which).with("test-cli").and_return(nil)
+      end
+
+      it "returns error status with CLI not found message" do
+        result = described_class.check(:test_provider)
+
+        expect(result[:name]).to eq(:test_provider)
+        expect(result[:status]).to eq("error")
         expect(result[:message]).to include("test-cli")
-        expect(result[:message]).to include("not found")
+        expect(result[:message]).to include("not found in PATH")
         expect(result[:error_category]).to eq(:installation)
         expect(result[:check]).to eq(:availability)
       end
@@ -824,8 +858,8 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
         result = described_class.check(:test_provider)
 
         expect(result[:status]).to eq("error")
-        expect(result[:message]).to include("test-cli")
-        expect(result[:message]).to include("not found")
+        expect(result[:message]).to include("not available")
+        expect(result[:message]).to include("available? returned false")
         expect(result[:error_category]).to eq(:installation)
         expect(result[:check]).to eq(:availability)
       end

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
         expect(result[:status]).to eq("error")
         expect(result[:message]).to include("test-cli")
         expect(result[:message]).to include("not found")
+        expect(result[:error_category]).to eq(:installation)
+        expect(result[:check]).to eq(:availability)
       end
     end
 
@@ -68,6 +70,10 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
               true
             end
           end
+
+          def smoke_test(timeout: nil, provider_runtime: nil)
+            {ok: true, status: "ok", message: "Smoke test passed", error_category: nil}
+          end
         end
       end
 
@@ -84,6 +90,8 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
         expect(result[:name]).to eq(:test_provider)
         expect(result[:status]).to eq("error")
         expect(result[:message]).to eq("Invalid API key")
+        expect(result[:error_category]).to eq(:authentication)
+        expect(result[:check]).to eq(:authentication)
       end
     end
 
@@ -123,6 +131,8 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
         expect(result[:name]).to eq(:test_provider)
         expect(result[:status]).to eq("degraded")
         expect(result[:message]).to eq("Endpoint unreachable")
+        expect(result[:error_category]).to eq(:transient)
+        expect(result[:check]).to eq(:provider_health)
       end
     end
 
@@ -162,6 +172,8 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
         expect(result[:name]).to eq(:test_provider)
         expect(result[:status]).to eq("degraded")
         expect(result[:message]).to include("Missing model name")
+        expect(result[:error_category]).to eq(:configuration)
+        expect(result[:check]).to eq(:configuration)
       end
     end
 
@@ -201,6 +213,7 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
         expect(result[:name]).to eq(:test_provider)
         expect(result[:status]).to eq("degraded")
         expect(result[:message]).to eq("Configuration issues: check provider configuration")
+        expect(result[:error_category]).to eq(:configuration)
       end
     end
 
@@ -220,6 +233,10 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
               true
             end
           end
+
+          def smoke_test(timeout: nil, provider_runtime: nil)
+            {ok: true, status: "ok", message: "Smoke test passed", error_category: nil}
+          end
         end
       end
 
@@ -236,6 +253,7 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
         expect(result[:name]).to eq(:test_provider)
         expect(result[:status]).to eq("ok")
         expect(result[:message]).to include("Registered and authenticated")
+        expect(result[:check]).to eq(:smoke_test)
         expect(result[:latency_ms]).to be_a(Integer)
         expect(result[:latency_ms]).to be >= 0
       end
@@ -260,6 +278,10 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
 
           def health_status
             {healthy: true, message: "Endpoint reachable"}
+          end
+
+          def smoke_test(timeout: nil, provider_runtime: nil)
+            {ok: true, status: "ok", message: "Smoke test passed", error_category: nil}
           end
         end
       end
@@ -295,6 +317,10 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
             def available?
               true
             end
+          end
+
+          def smoke_test(timeout: nil, provider_runtime: nil)
+            {ok: true, status: "ok", message: "Smoke test passed", error_category: nil}
           end
         end
       end
@@ -332,6 +358,10 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
               true
             end
           end
+
+          def smoke_test(timeout: nil, provider_runtime: nil)
+            {ok: true, status: "ok", message: "Smoke test passed", error_category: nil}
+          end
         end
       end
 
@@ -366,6 +396,10 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
             def available?
               true
             end
+          end
+
+          def smoke_test(timeout: nil, provider_runtime: nil)
+            {ok: true, status: "ok", message: "Smoke test passed", error_category: nil}
           end
         end
       end
@@ -425,6 +459,98 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
       end
     end
 
+    context "when the provider smoke test fails with a normalized category" do
+      let(:provider_class) do
+        Class.new(AgentHarness::Providers::Base) do
+          class << self
+            def provider_name
+              :test_provider
+            end
+
+            def binary_name
+              "test-cli"
+            end
+
+            def available?
+              true
+            end
+          end
+
+          def smoke_test(timeout: nil, provider_runtime: nil)
+            @seen_timeout = timeout
+            @seen_provider_runtime = provider_runtime
+            {
+              ok: false,
+              status: "error",
+              message: "Rate limit exceeded",
+              error_category: :rate_limited
+            }
+          end
+        end
+      end
+
+      before do
+        registry.register(:test_provider, provider_class)
+        allow(AgentHarness::Authentication).to receive(:auth_status)
+          .with(:test_provider)
+          .and_return({valid: true, expires_at: nil, error: nil})
+      end
+
+      it "returns the normalized smoke-test failure details" do
+        result = described_class.check(:test_provider, timeout: 7, provider_runtime: {model: "test-model"})
+
+        expect(result[:status]).to eq("error")
+        expect(result[:message]).to eq("Rate limit exceeded")
+        expect(result[:error_category]).to eq(:rate_limited)
+        expect(result[:check]).to eq(:smoke_test)
+      end
+    end
+
+    context "when a custom executor is provided" do
+      let(:custom_executor) { instance_double(AgentHarness::CommandExecutor) }
+      let(:provider_class) do
+        Class.new(AgentHarness::Providers::Base) do
+          class << self
+            attr_reader :last_executor, :last_provider_runtime, :last_timeout
+
+            def provider_name
+              :test_provider
+            end
+
+            def binary_name
+              "test-cli"
+            end
+
+            def available?
+              true
+            end
+          end
+
+          def smoke_test(timeout: nil, provider_runtime: nil)
+            self.class.instance_variable_set(:@last_executor, executor)
+            self.class.instance_variable_set(:@last_provider_runtime, provider_runtime)
+            self.class.instance_variable_set(:@last_timeout, timeout)
+            {ok: true, status: "ok", message: "Smoke test passed", error_category: nil}
+          end
+        end
+      end
+
+      before do
+        registry.register(:test_provider, provider_class)
+        allow(AgentHarness::Authentication).to receive(:auth_status)
+          .with(:test_provider)
+          .and_return({valid: true, expires_at: nil, error: nil})
+      end
+
+      it "builds the provider with the supplied executor and forwards runtime overrides" do
+        described_class.check(:test_provider, timeout: 9, executor: custom_executor, provider_runtime: {model: "runtime-model"})
+
+        expect(provider_class.last_executor).to eq(custom_executor)
+        expect(provider_class.last_timeout).to eq(9)
+        expect(provider_class.last_provider_runtime).to eq({model: "runtime-model"})
+      end
+    end
+
     context "when an unexpected error occurs" do
       before do
         allow(AgentHarness::Providers::Registry).to receive(:instance).and_raise(RuntimeError, "Unexpected failure")
@@ -474,6 +600,8 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
         expect(result[:status]).to eq("error")
         expect(result[:message]).to include("timed out")
         expect(result[:message]).to include("2s")
+        expect(result[:error_category]).to eq(:timeout)
+        expect(result[:check]).to eq(:timeout)
       end
     end
 
@@ -556,6 +684,10 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
           def available?
             true
           end
+        end
+
+        def smoke_test(timeout: nil, provider_runtime: nil)
+          {ok: true, status: "ok", message: "Smoke test passed", error_category: nil}
         end
       end
     end
@@ -764,6 +896,10 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
             true
           end
         end
+
+        def smoke_test(timeout: nil, provider_runtime: nil)
+          {ok: true, status: "ok", message: "Smoke test passed", error_category: nil}
+        end
       end
     end
 
@@ -798,6 +934,12 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
       expect(result[:name]).to eq(:test_provider)
       expect(result[:status]).to eq("ok")
       expect(result[:message]).to include("Registered and authenticated")
+    end
+
+    it "exposes smoke_test_contract on the module" do
+      contract = AgentHarness.smoke_test_contract(:test_provider)
+
+      expect(contract).to include(prompt: "Reply with exactly OK.")
     end
   end
 end

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -624,8 +624,69 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
         expect(result[:status]).to eq("ok")
         expect(result[:message]).to eq("Smoke test passed using the supplied execution context")
         expect(provider_class.last_executor).to eq(custom_executor)
-        expect(provider_class.last_timeout).to eq(9)
+        # Health-check timeout is no longer forwarded; smoke_test uses
+        # its own contract timeout (or nil when the provider overrides
+        # smoke_test directly and manages its own timeout).
+        expect(provider_class.last_timeout).to be_nil
         expect(provider_class.last_provider_runtime).to eq({model: "runtime-model"})
+      end
+    end
+
+    context "when provider contract timeout exceeds health-check timeout" do
+      let(:provider_class) do
+        Class.new(AgentHarness::Providers::Base) do
+          class << self
+            attr_reader :last_timeout
+
+            def provider_name
+              :test_provider
+            end
+
+            def binary_name
+              "test-cli"
+            end
+
+            def available?
+              true
+            end
+
+            def smoke_test_contract
+              {prompt: "Reply with exactly OK.", expected_output: "OK", timeout: 45, require_output: true}
+            end
+          end
+
+          def smoke_test(timeout: nil, provider_runtime: nil)
+            self.class.instance_variable_set(:@last_timeout, timeout)
+            {ok: true, status: "ok", message: "Smoke test passed", error_category: nil}
+          end
+        end
+      end
+
+      before do
+        registry.register(:test_provider, provider_class)
+        allow(AgentHarness::Authentication).to receive(:auth_status)
+          .with(:test_provider)
+          .and_return({valid: true, expires_at: nil, error: nil})
+      end
+
+      it "does not forward the health-check timeout to smoke_test" do
+        described_class.check(:test_provider, timeout: 5)
+
+        # smoke_test receives nil so it can use its own contract timeout (45s)
+        expect(provider_class.last_timeout).to be_nil
+      end
+
+      it "extends the outer timeout to honor the contract timeout" do
+        received_timeout = nil
+        allow(Timeout).to receive(:timeout).and_wrap_original do |original, timeout, &block|
+          received_timeout = timeout
+          original.call(timeout, &block)
+        end
+
+        described_class.check(:test_provider, timeout: 5)
+
+        # Outer timeout should be max(5, 45) = 45
+        expect(received_timeout).to eq(45)
       end
     end
 
@@ -880,9 +941,20 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
 
         expect(result[:status]).to eq("error")
         expect(result[:message]).to include("timed out")
-        expect(result[:message]).to include("2s")
+        # The outer timeout honors the provider contract timeout (30s)
+        # when it exceeds the caller-supplied health-check timeout (2s).
+        expect(result[:message]).to include("30s")
         expect(result[:error_category]).to eq(:timeout)
         expect(result[:check]).to eq(:timeout)
+      end
+
+      it "uses the caller timeout when the provider has no contract" do
+        result = described_class.check(:nonexistent, timeout: 2)
+
+        expect(result[:status]).to eq("error")
+        expect(result[:message]).to include("timed out")
+        expect(result[:message]).to include("2s")
+        expect(result[:error_category]).to eq(:timeout)
       end
     end
 

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -63,6 +63,17 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
         expect(result[:error_category]).to eq(:installation)
         expect(result[:check]).to eq(:availability)
       end
+
+      it "still runs host preflight when provider_runtime only contains local overrides" do
+        result = described_class.check(:test_provider, provider_runtime: {model: "runtime-only"})
+
+        expect(result[:name]).to eq(:test_provider)
+        expect(result[:status]).to eq("error")
+        expect(result[:message]).to include("test-cli")
+        expect(result[:message]).to include("not found")
+        expect(result[:error_category]).to eq(:installation)
+        expect(result[:check]).to eq(:availability)
+      end
     end
 
     context "when authentication fails" do
@@ -856,6 +867,12 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
       expect(results).to be_an(Array)
     end
 
+    it "rejects a shared provider_runtime override" do
+      expect {
+        described_class.check_all(provider_runtime: {env: {"API_KEY" => "secret"}})
+      }.to raise_error(ArgumentError, "provider_runtime is only supported for single-provider health checks")
+    end
+
     it "skips disabled providers" do
       AgentHarness.configure do |config|
         config.provider(:provider_b) { |p| p.enabled = false }
@@ -1046,6 +1063,12 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
       expect(result[:message]).to eq(
         "Registered, authenticated, and smoke test passed (health/config checks use defaults)"
       )
+    end
+
+    it "rejects provider_runtime on check_providers" do
+      expect {
+        AgentHarness.check_providers(provider_runtime: {env: {"API_KEY" => "secret"}})
+      }.to raise_error(ArgumentError, "provider_runtime is only supported for single-provider health checks")
     end
 
     it "exposes smoke_test_contract on the module" do

--- a/spec/agent_harness/providers/adapter_spec.rb
+++ b/spec/agent_harness/providers/adapter_spec.rb
@@ -383,6 +383,37 @@ RSpec.describe AgentHarness::Providers::Adapter do
         expect(result[:status]).to eq("error")
         expect(result[:error_category]).to eq(:rate_limited)
       end
+
+      it "fails when expected_output does not match" do
+        allow(adapter).to receive(:smoke_test_contract).and_return(
+          {
+            prompt: "Reply with exactly OK.",
+            timeout: 5,
+            require_output: true,
+            expected_output: "OK",
+            success_message: "Smoke test passed"
+          }
+        )
+        allow(adapter).to receive(:send_message).and_return(
+          AgentHarness::Response.new(
+            output: "Banner text",
+            exit_code: 0,
+            duration: 0.2,
+            provider: :test_adapter
+          )
+        )
+
+        result = adapter.smoke_test
+
+        expect(result).to include(
+          ok: false,
+          status: "error",
+          message: "Banner text",
+          error_category: :unknown,
+          output: "Banner text",
+          exit_code: 0
+        )
+      end
     end
 
     describe "#execution_semantics" do

--- a/spec/agent_harness/providers/adapter_spec.rb
+++ b/spec/agent_harness/providers/adapter_spec.rb
@@ -186,6 +186,12 @@ RSpec.describe AgentHarness::Providers::Adapter do
       end
     end
 
+    describe ".smoke_test_contract" do
+      it "returns nil by default" do
+        expect(adapter_class.smoke_test_contract).to be_nil
+      end
+    end
+
     describe ".install_command" do
       it "returns nil by default" do
         expect(adapter_class.install_command).to be_nil
@@ -316,6 +322,66 @@ RSpec.describe AgentHarness::Providers::Adapter do
         status = adapter.health_status
         expect(status[:healthy]).to be true
         expect(status[:message]).to eq("OK")
+      end
+    end
+
+    describe "#smoke_test" do
+      before do
+        allow(adapter).to receive(:smoke_test_contract).and_return(
+          {
+            prompt: "Reply with exactly OK.",
+            timeout: 5,
+            require_output: true,
+            success_message: "Smoke test passed"
+          }
+        )
+      end
+
+      it "uses the smoke-test contract prompt and normalizes success" do
+        expect(adapter).to receive(:send_message).with(
+          prompt: "Reply with exactly OK.",
+          timeout: 5,
+          provider_runtime: nil
+        ).and_return(
+          AgentHarness::Response.new(
+            output: "OK",
+            exit_code: 0,
+            duration: 0.2,
+            provider: :test_adapter
+          )
+        )
+
+        result = adapter.smoke_test
+
+        expect(result).to include(
+          ok: true,
+          status: "ok",
+          message: "Smoke test passed",
+          error_category: nil,
+          output: "OK",
+          exit_code: 0
+        )
+      end
+
+      it "classifies a failed smoke test using provider error patterns" do
+        allow(adapter).to receive(:error_patterns).and_return(
+          rate_limited: [/rate.?limit/i]
+        )
+        allow(adapter).to receive(:send_message).and_return(
+          AgentHarness::Response.new(
+            output: "",
+            exit_code: 1,
+            duration: 0.2,
+            provider: :test_adapter,
+            error: "Rate limit exceeded"
+          )
+        )
+
+        result = adapter.smoke_test
+
+        expect(result[:ok]).to be(false)
+        expect(result[:status]).to eq("error")
+        expect(result[:error_category]).to eq(:rate_limited)
       end
     end
 

--- a/spec/agent_harness/providers/base_spec.rb
+++ b/spec/agent_harness/providers/base_spec.rb
@@ -103,6 +103,17 @@ RSpec.describe AgentHarness::Providers::Base do
     end
   end
 
+  describe ".smoke_test_contract" do
+    it "exposes the default CLI smoke-test contract" do
+      expect(test_provider_class.smoke_test_contract).to include(
+        prompt: "Reply with exactly OK.",
+        timeout: 30,
+        require_output: true,
+        success_message: "Smoke test passed"
+      )
+    end
+  end
+
   describe "#parse_response" do
     let(:result) { instance_double("Result", stdout: "output", stderr: "", exit_code: 0) }
 

--- a/spec/agent_harness/providers/base_spec.rb
+++ b/spec/agent_harness/providers/base_spec.rb
@@ -104,13 +104,8 @@ RSpec.describe AgentHarness::Providers::Base do
   end
 
   describe ".smoke_test_contract" do
-    it "exposes the default CLI smoke-test contract" do
-      expect(test_provider_class.smoke_test_contract).to include(
-        prompt: "Reply with exactly OK.",
-        timeout: 30,
-        require_output: true,
-        success_message: "Smoke test passed"
-      )
+    it "does not expose a smoke-test contract by default" do
+      expect(test_provider_class.smoke_test_contract).to be_nil
     end
   end
 

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -28,8 +28,11 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
   end
 
   describe ".smoke_test_contract" do
-    it "uses the default smoke test contract" do
-      expect(described_class.smoke_test_contract).to eq(AgentHarness::Providers::Base::DEFAULT_SMOKE_TEST_CONTRACT)
+    it "returns a Copilot-specific contract without expected_output" do
+      contract = described_class.smoke_test_contract
+      expect(contract).to eq(AgentHarness::Providers::GithubCopilot::SMOKE_TEST_CONTRACT)
+      expect(contract[:expected_output]).to be_nil
+      expect(contract[:require_output]).to be true
     end
   end
 

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -28,13 +28,8 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
   end
 
   describe ".smoke_test_contract" do
-    it "publishes the canonical smoke-test metadata" do
-      expect(described_class.smoke_test_contract).to include(
-        prompt: "Reply with exactly OK.",
-        expected_output: "OK",
-        timeout: 30,
-        require_output: true
-      )
+    it "opts out of the generic smoke test contract" do
+      expect(described_class.smoke_test_contract).to be_nil
     end
   end
 

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
   end
 
   describe ".smoke_test_contract" do
-    it "opts out of the generic smoke test contract" do
-      expect(described_class.smoke_test_contract).to be_nil
+    it "uses the default smoke test contract" do
+      expect(described_class.smoke_test_contract).to eq(AgentHarness::Providers::Base::DEFAULT_SMOKE_TEST_CONTRACT)
     end
   end
 

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -27,6 +27,17 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
     end
   end
 
+  describe ".smoke_test_contract" do
+    it "publishes the canonical smoke-test metadata" do
+      expect(described_class.smoke_test_contract).to include(
+        prompt: "Reply with exactly OK.",
+        expected_output: "OK",
+        timeout: 30,
+        require_output: true
+      )
+    end
+  end
+
   describe ".supports_model_family?" do
     it "returns true for GPT models" do
       expect(described_class.supports_model_family?("gpt-4o")).to be true

--- a/spec/agent_harness/providers/registry_spec.rb
+++ b/spec/agent_harness/providers/registry_spec.rb
@@ -216,15 +216,8 @@ RSpec.describe AgentHarness::Providers::Registry do
       )
     end
 
-    it "returns a provider smoke-test contract for github copilot" do
-      contract = registry.smoke_test_contract(:github_copilot)
-
-      expect(contract).to include(
-        prompt: "Reply with exactly OK.",
-        expected_output: "OK",
-        timeout: 30,
-        require_output: true
-      )
+    it "returns nil for github copilot until it exposes a provider-specific smoke test" do
+      expect(registry.smoke_test_contract(:github_copilot)).to be_nil
     end
 
     it "raises ConfigurationError for an unknown provider" do
@@ -248,9 +241,9 @@ RSpec.describe AgentHarness::Providers::Registry do
     it "returns providers with smoke-test contracts" do
       contracts = registry.smoke_test_contracts
 
-      expect(contracts).to include(:codex, :github_copilot)
+      expect(contracts).to include(:codex)
+      expect(contracts).not_to include(:github_copilot)
       expect(contracts[:codex][:prompt]).to eq("Reply with exactly OK.")
-      expect(contracts[:github_copilot][:expected_output]).to eq("OK")
     end
 
     it "skips registered providers without smoke-test metadata" do

--- a/spec/agent_harness/providers/registry_spec.rb
+++ b/spec/agent_harness/providers/registry_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe AgentHarness::Providers::Registry do
     end
 
     it "returns smoke test contract for github_copilot" do
-      expect(registry.smoke_test_contract(:github_copilot)).to eq(AgentHarness::Providers::Base::DEFAULT_SMOKE_TEST_CONTRACT)
+      expect(registry.smoke_test_contract(:github_copilot)).to eq(AgentHarness::Providers::GithubCopilot::SMOKE_TEST_CONTRACT)
     end
 
     it "raises ConfigurationError for an unknown provider" do

--- a/spec/agent_harness/providers/registry_spec.rb
+++ b/spec/agent_harness/providers/registry_spec.rb
@@ -205,6 +205,53 @@ RSpec.describe AgentHarness::Providers::Registry do
     end
   end
 
+  describe "#smoke_test_contract" do
+    it "returns a provider smoke-test contract" do
+      contract = registry.smoke_test_contract(:codex)
+
+      expect(contract).to include(
+        prompt: "Reply with exactly OK.",
+        timeout: 30,
+        require_output: true
+      )
+    end
+
+    it "raises ConfigurationError for an unknown provider" do
+      expect {
+        registry.smoke_test_contract(:nonexistent_provider_xyz)
+      }.to raise_error(AgentHarness::ConfigurationError, /Unknown provider/)
+    end
+
+    it "returns nil for a registered provider without smoke-test metadata" do
+      registry.register(:test, Class.new do
+        def self.provider_name = :test
+        def self.available? = true
+        def self.binary_name = "test"
+      end)
+
+      expect(registry.smoke_test_contract(:test)).to be_nil
+    end
+  end
+
+  describe "#smoke_test_contracts" do
+    it "returns providers with smoke-test contracts" do
+      contracts = registry.smoke_test_contracts
+
+      expect(contracts).to include(:codex)
+      expect(contracts[:codex][:prompt]).to eq("Reply with exactly OK.")
+    end
+
+    it "skips registered providers without smoke-test metadata" do
+      registry.register(:test, Class.new do
+        def self.provider_name = :test
+        def self.available? = true
+        def self.binary_name = "test"
+      end)
+
+      expect(registry.smoke_test_contracts).not_to include(:test)
+    end
+  end
+
   describe "#reset!" do
     it "clears all registrations" do
       registry.send(:ensure_builtin_providers_registered)

--- a/spec/agent_harness/providers/registry_spec.rb
+++ b/spec/agent_harness/providers/registry_spec.rb
@@ -216,6 +216,17 @@ RSpec.describe AgentHarness::Providers::Registry do
       )
     end
 
+    it "returns a provider smoke-test contract for github copilot" do
+      contract = registry.smoke_test_contract(:github_copilot)
+
+      expect(contract).to include(
+        prompt: "Reply with exactly OK.",
+        expected_output: "OK",
+        timeout: 30,
+        require_output: true
+      )
+    end
+
     it "raises ConfigurationError for an unknown provider" do
       expect {
         registry.smoke_test_contract(:nonexistent_provider_xyz)
@@ -237,8 +248,9 @@ RSpec.describe AgentHarness::Providers::Registry do
     it "returns providers with smoke-test contracts" do
       contracts = registry.smoke_test_contracts
 
-      expect(contracts).to include(:codex)
+      expect(contracts).to include(:codex, :github_copilot)
       expect(contracts[:codex][:prompt]).to eq("Reply with exactly OK.")
+      expect(contracts[:github_copilot][:expected_output]).to eq("OK")
     end
 
     it "skips registered providers without smoke-test metadata" do

--- a/spec/agent_harness/providers/registry_spec.rb
+++ b/spec/agent_harness/providers/registry_spec.rb
@@ -216,8 +216,8 @@ RSpec.describe AgentHarness::Providers::Registry do
       )
     end
 
-    it "returns nil for github copilot until it exposes a provider-specific smoke test" do
-      expect(registry.smoke_test_contract(:github_copilot)).to be_nil
+    it "returns smoke test contract for github_copilot" do
+      expect(registry.smoke_test_contract(:github_copilot)).to eq(AgentHarness::Providers::Base::DEFAULT_SMOKE_TEST_CONTRACT)
     end
 
     it "raises ConfigurationError for an unknown provider" do
@@ -242,7 +242,7 @@ RSpec.describe AgentHarness::Providers::Registry do
       contracts = registry.smoke_test_contracts
 
       expect(contracts).to include(:codex)
-      expect(contracts).not_to include(:github_copilot)
+      expect(contracts).to include(:github_copilot)
       expect(contracts[:codex][:prompt]).to eq("Reply with exactly OK.")
     end
 


### PR DESCRIPTION
Implemented the provider-owned smoke-test contract and committed it as `ea2d1cd` (`feat(providers): add cli smoke test contracts`).

The main change is that CLI-backed providers now expose a first-class smoke-test contract in the adapter/base layer, and [`ProviderHealthCheck`](/workspace/lib/agent_harness/provider_health_check.rb) now executes that canonical smoke test through the selected executor instead of stopping at registration/auth/config checks. Health-check results now include normalized `error_category` and `check` metadata so downstream callers can distinguish installation, authentication, configuration, timeout, rate-limit, and related failure modes without provider-specific shell parsing. I also exposed contract lookup on the public API and registry in [`lib/agent_harness.rb`](/workspace/lib/agent_harness.rb) and [`lib/agent_harness/providers/registry.rb`](/workspace/lib/agent_harness/providers/registry.rb).

Verification passed end to end: `bundle exec rubocop`, `bundle exec rspec`, and the git commit hooks all succeeded. The worktree is clean.

---

Closes #72