### PR TITLE
Fix #59: fix(codex): replace invalid '--sandbox none' for externally sandboxed runs

### DIFF
--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -242,6 +242,9 @@ module AgentHarness
           unless flags.is_a?(Array)
             raise ArgumentError, "Codex configuration error: default_flags must be an array of strings"
           end
+          # Strip --full-auto from defaults when externally sandboxed to avoid
+          # conflicting with --dangerously-bypass-approvals-and-sandbox.
+          flags -= dangerous_mode_flags if externally_sandboxed
           cmd += flags if flags.any?
         end
 
@@ -256,7 +259,10 @@ module AgentHarness
         runtime = options[:provider_runtime]
         if runtime
           cmd += ["--model", runtime.model] if runtime.model
-          cmd += runtime.flags unless runtime.flags.empty?
+          runtime_flags = runtime.flags
+          # Strip --full-auto from runtime flags when externally sandboxed.
+          runtime_flags -= dangerous_mode_flags if externally_sandboxed
+          cmd += runtime_flags unless runtime_flags.empty?
         end
 
         cmd << prompt

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -239,6 +239,25 @@ RSpec.describe AgentHarness::Providers::Codex do
         end
       end
 
+      context "with default_flags containing --full-auto and externally_sandboxed" do
+        let(:config_with_full_auto) do
+          AgentHarness::ProviderConfig.new(:codex).tap do |c|
+            c.default_flags = ["--full-auto", "--quiet"]
+            c.externally_sandboxed = true
+          end
+        end
+        let(:provider_with_full_auto) { described_class.new(config: config_with_full_auto, executor: mock_executor) }
+
+        it "strips --full-auto from default_flags to avoid sandbox mode conflict" do
+          expect(mock_executor).to receive(:execute).with(
+            ["codex", "exec", "--quiet", "--dangerously-bypass-approvals-and-sandbox", "Hello"],
+            anything
+          ).and_return(success_result)
+
+          provider_with_full_auto.send_message(prompt: "Hello")
+        end
+      end
+
       it "returns a Response object" do
         allow(mock_executor).to receive(:execute).and_return(
           AgentHarness::CommandExecutor::Result.new(


### PR DESCRIPTION
Updated the Codex provider to use the current CLI-compatible externally sandboxed bypass flag in [lib/agent_harness/providers/codex.rb](/workspace/lib/agent_harness/providers/codex.rb), replacing `["--sandbox", "none"]` with `["--dangerously-bypass-approvals-and-sandbox"]`. I also updated the affected command-building expectations in [spec/agent_harness/providers/codex_spec.rb](/workspace/spec/agent_harness/providers/codex_spec.rb) so externally sandboxed runs and the combined dangerous-mode case validate the new semantics.

Verification passed with `bundle exec rubocop` and `bundle exec rspec` before commit, and the commit hooks passed on `git commit`. Commit created: `1150a08` with message `fix(codex): use current sandbox bypass flag`.

---

Closes #59