### PR TITLE
Fix #100: feat(aider): extract token usage via --llm-history-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@
 mkmf.log
 /.gems/
 /badges/
-.aider*

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 mkmf.log
 /.gems/
 /badges/
+.aider*

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -324,12 +324,9 @@ module AgentHarness
         # Prefer the request-local history file when it includes a token report,
         # but fall back to captured command output because the usage summary is
         # printed there during normal runs.
-        parse_token_usage_text(read_llm_history(llm_history_path), source: :history) ||
+        parse_token_usage_text(safe_read_llm_history(llm_history_path), source: :history) ||
           parse_token_usage_text(result.stdout, source: :output) ||
           parse_token_usage_text(result.stderr, source: :output)
-      rescue => e
-        log_debug("llm_history_parse_error", error: e.message)
-        nil
       end
 
       def read_llm_history(path)
@@ -340,6 +337,13 @@ module AgentHarness
         return nil if content.strip.empty?
 
         content
+      end
+
+      def safe_read_llm_history(path)
+        read_llm_history(path)
+      rescue => e
+        log_debug("llm_history_parse_error", error: e.message)
+        nil
       end
 
       def parse_token_usage_text(content, source: :output)

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -301,7 +301,7 @@ module AgentHarness
       TOKEN_COUNT_PATTERN = /\d[\d,]*(?:\.\d+)?[kmb]?/i
 
       TOKEN_USAGE_PATTERN =
-        /Tokens:\s*(?<input>#{TOKEN_COUNT_PATTERN})\s+sent(?:,\s*#{TOKEN_COUNT_PATTERN}\s+cache\s+\w+)*,\s*(?<output>#{TOKEN_COUNT_PATTERN})\s+received\.?/i
+        /^\s*Tokens:\s*(?<input>#{TOKEN_COUNT_PATTERN})\s+sent(?:,\s*#{TOKEN_COUNT_PATTERN}\s+cache\s+\w+)*,\s*(?<output>#{TOKEN_COUNT_PATTERN})\s+received\.?\s*$/i
 
       def generate_llm_history_path
         File.join(Dir.tmpdir, "aider_llm_history_#{Process.pid}_#{SecureRandom.hex(8)}")

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -308,7 +308,7 @@ module AgentHarness
       FOOTER_COST_PATTERN = /^\s*Cost:\s+.+\s*$/i
       OUTPUT_STATUS_PATTERN =
         /^\s*(?:Applied edit to|Commit\b|You can use \/undo\b|Added .+ to the chat\.|Removed .+ from the chat\.|Use \/help\b|Create new file\?|Allow edits to\b|Edit the files\?|Run shell command\?).*$/i
-      OUTPUT_PATH_PATTERN = %r{^\s*[\w./-]+\s*$}
+      OUTPUT_PATH_PATTERN = %r{^\s*[\w.-]*[/.][\w./-]*\s*$}
 
       def generate_llm_history_path
         File.join(Dir.tmpdir, "aider_llm_history_#{Process.pid}_#{SecureRandom.hex(8)}")

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -310,7 +310,9 @@ module AgentHarness
       RUN_SHELL_COMMAND_PATTERN = /^\s*Run shell command\?.*$/i
       OUTPUT_STATUS_PATTERN =
         /^\s*(?:Applied edit to|Commit\b|Committing\b|You can use \/undo\b|Added .+ to the chat\.|Removed .+ from the chat\.|Use \/help\b|Create new file\?|Allow edits to\b|Edit the files\?|Run shell command\?).*$/i
-      OUTPUT_PATH_PATTERN = %r{^\s*[\w.-]*[/.][\w./-]*\s*$}
+      OUTPUT_PATH_PATTERN = /\A(?:\.\.?\/|\/|~\/)[\w.\-\/]+\z/
+      OUTPUT_DOTFILE_PATTERN = /\A\.[\w.-]+\z/
+      OUTPUT_FILENAME_PATTERN = /\A[\w.-]+\.[A-Za-z][\w.-]*\z/
       COMMON_SHELL_COMMAND_PATTERN =
         /\A(?:git|bundle|ruby|python\d*(?:\.\d+)?|uv|npm|yarn|pnpm|node|bash|sh|zsh|make|rake|rspec|rails|bin\/[\w.-]+|sed|rg|grep|find|ls|cat|cp|mv|rm|mkdir|touch|chmod|chown|docker|kubectl)\z/
       EXECUTOR_LLM_HISTORY_TIMEOUT = 10
@@ -428,9 +430,16 @@ module AgentHarness
             TOKEN_USAGE_PATTERN.match?(line) ||
             FOOTER_COST_PATTERN.match?(line) ||
             OUTPUT_STATUS_PATTERN.match?(line) ||
-            OUTPUT_PATH_PATTERN.match?(line) ||
+            output_path_footer_line?(stripped) ||
             output_command_footer_line?(line, line_index, shell_prompt_index)
         end
+      end
+
+      def output_path_footer_line?(line)
+        OUTPUT_PATH_PATTERN.match?(line) ||
+          OUTPUT_DOTFILE_PATTERN.match?(line) ||
+          OUTPUT_FILENAME_PATTERN.match?(line) ||
+          (line.include?("/") && line.match?(/\A[\w.\-\/]+\z/))
       end
 
       def output_command_footer_line?(line, line_index, shell_prompt_index)

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -302,6 +302,7 @@ module AgentHarness
 
       TOKEN_USAGE_PATTERN =
         /^\s*Tokens:\s*(?<input>#{TOKEN_COUNT_PATTERN})\s+sent(?:,\s*#{TOKEN_COUNT_PATTERN}\s+cache\s+\w+)*,\s*(?<output>#{TOKEN_COUNT_PATTERN})\s+received\.?(?:\s+Cost:\s+.+)?\s*$/i
+      FOOTER_COST_PATTERN = /^\s*Cost:\s+.+\s*$/i
 
       def generate_llm_history_path
         File.join(Dir.tmpdir, "aider_llm_history_#{Process.pid}_#{SecureRandom.hex(8)}")
@@ -376,7 +377,7 @@ module AgentHarness
       def footer_suffix?(lines, index)
         lines[(index + 1)..].to_a.all? do |line|
           stripped = line.strip
-          stripped.empty? || TOKEN_USAGE_PATTERN.match?(line)
+          stripped.empty? || TOKEN_USAGE_PATTERN.match?(line) || FOOTER_COST_PATTERN.match?(line)
         end
       end
 

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -359,11 +359,22 @@ module AgentHarness
       end
 
       def history_token_usage_footer_line?(lines, index)
+        footer_prefix?(lines, index) && footer_suffix?(lines, index)
+      end
+
+      def footer_prefix?(lines, index)
         previous_index = index - 1
         return true if previous_index.negative?
 
         previous_line = lines[previous_index]
         previous_line.strip.empty? || TOKEN_USAGE_PATTERN.match?(previous_line)
+      end
+
+      def footer_suffix?(lines, index)
+        lines[(index + 1)..].to_a.all? do |line|
+          stripped = line.strip
+          stripped.empty? || TOKEN_USAGE_PATTERN.match?(line)
+        end
       end
 
       def parse_token_count(value)

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -441,13 +441,17 @@ module AgentHarness
         tokens = stripped.sub(/\A[$>#]\s*/, "").split(/\s+/)
         return false if tokens.empty?
         return false unless tokens.first.match?(/\A[\w.\/~:-]+\z/)
-        return true if tokens.length == 1
+        return command_token?(tokens.first) if tokens.length == 1
 
         tokens[1..].all? do |token|
           token.match?(%r{\A(?:&&|\|\|?|[<>]|>>|&>|2>|[~-]|["'$`(])}) ||
             token.match?(%r{[/.=:]}) ||
             (tokens.length == 2 && token.match?(/\A[\w-]+\z/))
         end
+      end
+
+      def command_token?(token)
+        token.match?(/\A[a-z0-9_][\w.\/~:-]*\z/) && token.match?(/[a-z]/)
       end
 
       def parse_token_count(value)

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -306,6 +306,9 @@ module AgentHarness
       TOKEN_USAGE_PATTERN =
         /^\s*Tokens:\s*(?<input>#{TOKEN_COUNT_PATTERN})\s+sent(?:,\s*#{TOKEN_COUNT_PATTERN}\s+cache\s+\w+)*,\s*(?<output>#{TOKEN_COUNT_PATTERN})\s+received\.?(?:\s+Cost:\s+.+)?\s*$/i
       FOOTER_COST_PATTERN = /^\s*Cost:\s+.+\s*$/i
+      OUTPUT_STATUS_PATTERN =
+        /^\s*(?:Applied edit to|Commit\b|You can use \/undo\b|Added .+ to the chat\.|Removed .+ from the chat\.|Use \/help\b|Create new file\?|Allow edits to\b|Edit the files\?|Run shell command\?).*$/i
+      OUTPUT_PATH_PATTERN = %r{^\s*[\w./-]+\s*$}
 
       def generate_llm_history_path
         File.join(Dir.tmpdir, "aider_llm_history_#{Process.pid}_#{SecureRandom.hex(8)}")
@@ -382,7 +385,7 @@ module AgentHarness
       end
 
       def output_token_usage_footer_line?(lines, index)
-        footer_prefix?(lines, index) && footer_suffix?(lines, index)
+        footer_prefix?(lines, index) && output_footer_suffix?(lines, index)
       end
 
       def footer_prefix?(lines, index)
@@ -400,6 +403,17 @@ module AgentHarness
         lines[(index + 1)..].to_a.all? do |line|
           stripped = line.strip
           stripped.empty? || TOKEN_USAGE_PATTERN.match?(line) || FOOTER_COST_PATTERN.match?(line)
+        end
+      end
+
+      def output_footer_suffix?(lines, index)
+        lines[(index + 1)..].to_a.all? do |line|
+          stripped = line.strip
+          stripped.empty? ||
+            TOKEN_USAGE_PATTERN.match?(line) ||
+            FOOTER_COST_PATTERN.match?(line) ||
+            OUTPUT_STATUS_PATTERN.match?(line) ||
+            OUTPUT_PATH_PATTERN.match?(line)
         end
       end
 

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -267,7 +267,10 @@ module AgentHarness
           cmd += session_flags(options[:session])
         end
 
-        cmd += runtime.flags if runtime&.flags&.any?
+        if runtime&.flags&.any?
+          validate_runtime_flags!(runtime.flags)
+          cmd += runtime.flags
+        end
 
         cmd += ["--message", prompt]
 
@@ -420,6 +423,31 @@ module AgentHarness
       rescue => e
         log_debug("llm_history_cleanup_error", error: e.message)
         nil
+      end
+
+      def validate_runtime_flags!(flags)
+        invalid_flags = reserved_runtime_flags(flags)
+        return if invalid_flags.empty?
+
+        raise ArgumentError,
+          "Aider provider_runtime.flags cannot override provider-managed flags: " \
+          "#{invalid_flags.join(", ")}"
+      end
+
+      def reserved_runtime_flags(flags)
+        flags.each_with_index.filter_map do |flag, index|
+          next unless reserved_runtime_flag?(flag)
+
+          if flag == "--llm-history-file" && flags[index + 1]
+            "#{flag} #{flags[index + 1]}"
+          else
+            flag
+          end
+        end.uniq
+      end
+
+      def reserved_runtime_flag?(flag)
+        flag == "--llm-history-file" || flag.start_with?("--llm-history-file=")
       end
     end
   end

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "securerandom"
+require "shellwords"
 require "tmpdir"
 
 module AgentHarness
@@ -310,8 +311,11 @@ module AgentHarness
       OUTPUT_STATUS_PATTERN =
         /^\s*(?:Applied edit to|Commit\b|You can use \/undo\b|Added .+ to the chat\.|Removed .+ from the chat\.|Use \/help\b|Create new file\?|Allow edits to\b|Edit the files\?|Run shell command\?).*$/i
       OUTPUT_PATH_PATTERN = %r{^\s*[\w.-]*[/.][\w./-]*\s*$}
+      EXECUTOR_LLM_HISTORY_TIMEOUT = 10
 
       def generate_llm_history_path
+        return "/tmp/aider_llm_history_#{Process.pid}_#{SecureRandom.hex(8)}" if sandboxed_environment?
+
         File.join(Dir.tmpdir, "aider_llm_history_#{Process.pid}_#{SecureRandom.hex(8)}")
       end
 
@@ -329,6 +333,7 @@ module AgentHarness
       end
 
       def read_llm_history(path)
+        return read_executor_llm_history(path) if sandboxed_environment?
         return nil unless path && File.exist?(path) && !File.zero?(path)
 
         content = File.read(path)
@@ -457,6 +462,8 @@ module AgentHarness
       def cleanup_llm_history_file!(path)
         return unless path
 
+        return cleanup_executor_llm_history_file!(path) if sandboxed_environment?
+
         File.delete(path) if File.exist?(path)
       rescue => e
         log_debug("llm_history_cleanup_error", error: e.message)
@@ -486,6 +493,31 @@ module AgentHarness
 
       def reserved_runtime_flag?(flag)
         flag == "--llm-history-file" || flag.start_with?("--llm-history-file=")
+      end
+
+      def read_executor_llm_history(path)
+        return nil unless path
+
+        result = @executor.execute(
+          ["sh", "-lc", "if [ -s #{Shellwords.escape(path)} ]; then cat #{Shellwords.escape(path)}; fi"],
+          timeout: EXECUTOR_LLM_HISTORY_TIMEOUT
+        )
+        return nil unless result.success?
+
+        content = result.stdout
+        return nil if content.to_s.strip.empty?
+
+        content
+      end
+
+      def cleanup_executor_llm_history_file!(path)
+        @executor.execute(
+          ["sh", "-lc", "rm -f -- #{Shellwords.escape(path)}"],
+          timeout: EXECUTOR_LLM_HISTORY_TIMEOUT
+        )
+      rescue => e
+        log_debug("llm_history_cleanup_error", error: e.message)
+        nil
       end
     end
   end

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "securerandom"
+require "tmpdir"
 
 module AgentHarness
   module Providers
@@ -296,7 +297,7 @@ module AgentHarness
       TOKEN_COUNT_PATTERN = /\d[\d,]*(?:\.\d+)?[kmb]?/i
 
       TOKEN_USAGE_PATTERN =
-        /Tokens:\s*(?<input>#{TOKEN_COUNT_PATTERN})\s+sent(?:,\s*#{TOKEN_COUNT_PATTERN}\s+cache\s+\w+)*,\s*(?<output>#{TOKEN_COUNT_PATTERN})\s+received\./i
+        /Tokens:\s*(?<input>#{TOKEN_COUNT_PATTERN})\s+sent(?:,\s*#{TOKEN_COUNT_PATTERN}\s+cache\s+\w+)*,\s*(?<output>#{TOKEN_COUNT_PATTERN})\s+received\.?/i
 
       def generate_llm_history_path
         File.join(Dir.tmpdir, "aider_llm_history_#{Process.pid}_#{SecureRandom.hex(8)}")

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -335,7 +335,7 @@ module AgentHarness
         match = if source == :history
           extract_history_token_usage_match(content)
         else
-          content.to_enum(:scan, TOKEN_USAGE_PATTERN).map { Regexp.last_match }.last
+          extract_output_token_usage_match(content)
         end
         return nil unless match
 
@@ -359,7 +359,25 @@ module AgentHarness
         nil
       end
 
+      def extract_output_token_usage_match(content)
+        lines = content.lines
+
+        lines.each_index.reverse_each do |index|
+          match = TOKEN_USAGE_PATTERN.match(lines[index])
+          next unless match
+          next unless output_token_usage_footer_line?(lines, index)
+
+          return match
+        end
+
+        nil
+      end
+
       def history_token_usage_footer_line?(lines, index)
+        footer_prefix?(lines, index) && footer_suffix?(lines, index)
+      end
+
+      def output_token_usage_footer_line?(lines, index)
         footer_prefix?(lines, index) && footer_suffix?(lines, index)
       end
 

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
 require "securerandom"
 
 module AgentHarness
@@ -196,11 +195,54 @@ module AgentHarness
       end
 
       def send_message(prompt:, **options)
-        @llm_history_path = generate_llm_history_path
-        super
+        log_debug("send_message_start", prompt_length: prompt.length, options: options.keys)
+
+        options = normalize_provider_runtime(options)
+        runtime = options[:provider_runtime]
+
+        options = normalize_mcp_servers(options)
+        validate_mcp_servers!(options[:mcp_servers]) if options[:mcp_servers]&.any?
+
+        llm_history_path = generate_llm_history_path
+        command = build_command(prompt, options.merge(llm_history_path: llm_history_path))
+        preparation = build_execution_preparation(options)
+        timeout = options[:timeout] || @config.timeout || default_timeout
+
+        start_time = Time.now
+        result = execute_with_timeout(
+          command,
+          timeout: timeout,
+          env: build_env(options),
+          preparation: preparation,
+          **command_execution_options(options)
+        )
+        duration = Time.now - start_time
+
+        response = parse_response(result, duration: duration, llm_history_path: llm_history_path)
+        if runtime&.model
+          response = Response.new(
+            output: response.output,
+            exit_code: response.exit_code,
+            duration: response.duration,
+            provider: response.provider,
+            model: runtime.model,
+            tokens: response.tokens,
+            metadata: response.metadata,
+            error: response.error
+          )
+        end
+
+        track_tokens(response) if response.tokens
+
+        log_debug("send_message_complete", duration: duration, tokens: response.tokens)
+
+        response
+      rescue McpConfigurationError, McpUnsupportedError, McpTransportUnsupportedError
+        raise
+      rescue => e
+        handle_error(e, prompt: prompt, options: options)
       ensure
-        cleanup_llm_history_file!
-        @llm_history_path = nil
+        cleanup_llm_history_file!(llm_history_path)
       end
 
       protected
@@ -210,8 +252,8 @@ module AgentHarness
 
         cmd << "--yes"
 
-        if @llm_history_path
-          cmd += ["--llm-history-file", @llm_history_path]
+        if options[:llm_history_path]
+          cmd += ["--llm-history-file", options[:llm_history_path]]
         end
 
         if @config.model && !@config.model.empty?
@@ -227,9 +269,9 @@ module AgentHarness
         cmd
       end
 
-      def parse_response(result, duration:)
-        response = super
-        tokens = parse_llm_history_tokens(@llm_history_path)
+      def parse_response(result, duration:, llm_history_path: nil)
+        response = super(result, duration: duration)
+        tokens = parse_token_usage(result, llm_history_path: llm_history_path)
 
         return response unless tokens
 
@@ -251,72 +293,50 @@ module AgentHarness
 
       private
 
+      TOKEN_USAGE_PATTERN =
+        /Tokens:\s*(?<input>[\d,]+)\s+sent(?:,\s*[\d,]+\s+cache\s+\w+)*,\s*(?<output>[\d,]+)\s+received\./i
+
       def generate_llm_history_path
         File.join(Dir.tmpdir, "aider_llm_history_#{Process.pid}_#{SecureRandom.hex(8)}")
       end
 
-      def parse_llm_history_tokens(path)
-        return nil unless path && File.exist?(path) && !File.zero?(path)
-
-        content = File.read(path)
-        return nil if content.strip.empty?
-
-        total_input = 0
-        total_output = 0
-        found_usage = false
-
-        content.each_line do |line|
-          line = line.strip
-          next if line.empty?
-
-          entry = begin
-            JSON.parse(line)
-          rescue JSON::ParserError
-            next
-          end
-
-          usage = extract_usage_from_entry(entry)
-          next unless usage
-
-          found_usage = true
-          total_input += usage[:input]
-          total_output += usage[:output]
-        end
-
-        return nil unless found_usage
-
-        {input: total_input, output: total_output, total: total_input + total_output}
+      def parse_token_usage(result, llm_history_path:)
+        # Aider 0.86.x writes --llm-history-file as conversation text, not JSONL.
+        # Prefer the request-local history file when it includes a token report,
+        # but fall back to captured command output because the usage summary is
+        # printed there during normal runs.
+        parse_token_usage_text(read_llm_history(llm_history_path)) ||
+          parse_token_usage_text([result.stdout, result.stderr].compact.join("\n"))
       rescue => e
         log_debug("llm_history_parse_error", error: e.message)
         nil
       end
 
-      def extract_usage_from_entry(entry)
-        usage = entry["usage"]
-        tokens = extract_token_counts(usage) if usage.is_a?(Hash)
-        return tokens if tokens
+      def read_llm_history(path)
+        return nil unless path && File.exist?(path) && !File.zero?(path)
 
-        response = entry["response"]
-        if response.is_a?(Hash)
-          usage = response["usage"]
-          return extract_token_counts(usage) if usage.is_a?(Hash)
-        end
+        content = File.read(path)
+        return nil if content.strip.empty?
 
-        nil
+        content
       end
 
-      def extract_token_counts(usage)
-        input = usage["prompt_tokens"] || usage["input_tokens"]
-        output = usage["completion_tokens"] || usage["output_tokens"]
-        return nil unless input || output
+      def parse_token_usage_text(content)
+        return nil if content.nil? || content.strip.empty?
 
-        {input: input.to_i, output: output.to_i}
+        match = content.to_enum(:scan, TOKEN_USAGE_PATTERN).map { Regexp.last_match }.last
+        return nil unless match
+
+        input = match[:input].delete(",").to_i
+        output = match[:output].delete(",").to_i
+
+        {input: input, output: output, total: input + output}
       end
 
-      def cleanup_llm_history_file!
-        return unless @llm_history_path
+      def cleanup_llm_history_file!(path)
+        return unless path
 
-        File.delete(@llm_history_path) if File.exist?(@llm_history_path)
+        File.delete(path) if File.exist?(path)
       rescue => e
         log_debug("llm_history_cleanup_error", error: e.message)
         nil

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -314,7 +314,8 @@ module AgentHarness
         # but fall back to captured command output because the usage summary is
         # printed there during normal runs.
         parse_token_usage_text(read_llm_history(llm_history_path), source: :history) ||
-          parse_token_usage_text([result.stdout, result.stderr].compact.join("\n"), source: :output)
+          parse_token_usage_text(result.stdout, source: :output) ||
+          parse_token_usage_text(result.stderr, source: :output)
       rescue => e
         log_debug("llm_history_parse_error", error: e.message)
         nil

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -301,7 +301,7 @@ module AgentHarness
       TOKEN_COUNT_PATTERN = /\d[\d,]*(?:\.\d+)?[kmb]?/i
 
       TOKEN_USAGE_PATTERN =
-        /^\s*Tokens:\s*(?<input>#{TOKEN_COUNT_PATTERN})\s+sent(?:,\s*#{TOKEN_COUNT_PATTERN}\s+cache\s+\w+)*,\s*(?<output>#{TOKEN_COUNT_PATTERN})\s+received\.?\s*$/i
+        /^\s*Tokens:\s*(?<input>#{TOKEN_COUNT_PATTERN})\s+sent(?:,\s*#{TOKEN_COUNT_PATTERN}\s+cache\s+\w+)*,\s*(?<output>#{TOKEN_COUNT_PATTERN})\s+received\.?(?:\s+Cost:\s+.+)?\s*$/i
 
       def generate_llm_history_path
         File.join(Dir.tmpdir, "aider_llm_history_#{Process.pid}_#{SecureRandom.hex(8)}")

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "json"
+require "securerandom"
+
 module AgentHarness
   module Providers
     # Aider AI coding assistant provider
@@ -192,13 +195,24 @@ module AgentHarness
         ["--restore-chat-history", session_id]
       end
 
+      def send_message(prompt:, **options)
+        @llm_history_path = generate_llm_history_path
+        super
+      ensure
+        cleanup_llm_history_file!
+        @llm_history_path = nil
+      end
+
       protected
 
       def build_command(prompt, options)
         cmd = [self.class.binary_name]
 
-        # Run in non-interactive mode
         cmd << "--yes"
+
+        if @llm_history_path
+          cmd += ["--llm-history-file", @llm_history_path]
+        end
 
         if @config.model && !@config.model.empty?
           cmd += ["--model", @config.model]
@@ -213,8 +227,99 @@ module AgentHarness
         cmd
       end
 
+      def parse_response(result, duration:)
+        response = super
+        tokens = parse_llm_history_tokens(@llm_history_path)
+
+        return response unless tokens
+
+        Response.new(
+          output: response.output,
+          exit_code: response.exit_code,
+          duration: response.duration,
+          provider: response.provider,
+          model: response.model,
+          tokens: tokens,
+          metadata: response.metadata,
+          error: response.error
+        )
+      end
+
       def default_timeout
-        600 # Aider can take longer
+        600
+      end
+
+      private
+
+      def generate_llm_history_path
+        File.join(Dir.tmpdir, "aider_llm_history_#{Process.pid}_#{SecureRandom.hex(8)}")
+      end
+
+      def parse_llm_history_tokens(path)
+        return nil unless path && File.exist?(path) && !File.zero?(path)
+
+        content = File.read(path)
+        return nil if content.strip.empty?
+
+        total_input = 0
+        total_output = 0
+        found_usage = false
+
+        content.each_line do |line|
+          line = line.strip
+          next if line.empty?
+
+          entry = begin
+            JSON.parse(line)
+          rescue JSON::ParserError
+            next
+          end
+
+          usage = extract_usage_from_entry(entry)
+          next unless usage
+
+          found_usage = true
+          total_input += usage[:input]
+          total_output += usage[:output]
+        end
+
+        return nil unless found_usage
+
+        {input: total_input, output: total_output, total: total_input + total_output}
+      rescue => e
+        log_debug("llm_history_parse_error", error: e.message)
+        nil
+      end
+
+      def extract_usage_from_entry(entry)
+        usage = entry["usage"]
+        tokens = extract_token_counts(usage) if usage.is_a?(Hash)
+        return tokens if tokens
+
+        response = entry["response"]
+        if response.is_a?(Hash)
+          usage = response["usage"]
+          return extract_token_counts(usage) if usage.is_a?(Hash)
+        end
+
+        nil
+      end
+
+      def extract_token_counts(usage)
+        input = usage["prompt_tokens"] || usage["input_tokens"]
+        output = usage["completion_tokens"] || usage["output_tokens"]
+        return nil unless input || output
+
+        {input: input.to_i, output: output.to_i}
+      end
+
+      def cleanup_llm_history_file!
+        return unless @llm_history_path
+
+        File.delete(@llm_history_path) if File.exist?(@llm_history_path)
+      rescue => e
+        log_debug("llm_history_cleanup_error", error: e.message)
+        nil
       end
     end
   end

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -311,6 +311,8 @@ module AgentHarness
       OUTPUT_STATUS_PATTERN =
         /^\s*(?:Applied edit to|Commit\b|You can use \/undo\b|Added .+ to the chat\.|Removed .+ from the chat\.|Use \/help\b|Create new file\?|Allow edits to\b|Edit the files\?|Run shell command\?).*$/i
       OUTPUT_PATH_PATTERN = %r{^\s*[\w.-]*[/.][\w./-]*\s*$}
+      COMMON_SHELL_COMMAND_PATTERN =
+        /\A(?:git|bundle|ruby|python\d*(?:\.\d+)?|uv|npm|yarn|pnpm|node|bash|sh|zsh|make|rake|rspec|rails|bin\/[\w.-]+|sed|rg|grep|find|ls|cat|cp|mv|rm|mkdir|touch|chmod|chown|docker|kubectl)\z/
       EXECUTOR_LLM_HISTORY_TIMEOUT = 10
 
       def generate_llm_history_path
@@ -440,18 +442,25 @@ module AgentHarness
 
         tokens = stripped.sub(/\A[$>#]\s*/, "").split(/\s+/)
         return false if tokens.empty?
-        return false unless tokens.first.match?(/\A[\w.\/~:-]+\z/)
-        return command_token?(tokens.first) if tokens.length == 1
+        command = tokens.first
+        return false unless command.match?(/\A[\w.\/~:-]+\z/)
+        return command_token?(command) if tokens.length == 1
+        return false unless command_line_token?(command)
 
-        tokens[1..].all? do |token|
-          token.match?(%r{\A(?:&&|\|\|?|[<>]|>>|&>|2>|[~-]|["'$`(])}) ||
-            token.match?(%r{[/.=:]}) ||
-            (tokens.length == 2 && token.match?(/\A[\w-]+\z/))
-        end
+        tokens[1..].all? { |token| command_argument_token?(token) }
       end
 
       def command_token?(token)
         token.match?(/\A[a-z0-9_][\w.\/~:-]*\z/) && token.match?(/[a-z]/)
+      end
+
+      def command_line_token?(token)
+        command_token?(token) && COMMON_SHELL_COMMAND_PATTERN.match?(token)
+      end
+
+      def command_argument_token?(token)
+        token.match?(%r{\A(?:&&|\|\|?|[<>]|>>|&>|2>|[~-]|["'$`(])}) ||
+          token.match?(%r{\A[-\w@%+=:,./~^]+\z})
       end
 
       def parse_token_count(value)

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -309,7 +309,7 @@ module AgentHarness
       FOOTER_COST_PATTERN = /^\s*Cost:\s+.+\s*$/i
       RUN_SHELL_COMMAND_PATTERN = /^\s*Run shell command\?.*$/i
       OUTPUT_STATUS_PATTERN =
-        /^\s*(?:Applied edit to|Commit\b|You can use \/undo\b|Added .+ to the chat\.|Removed .+ from the chat\.|Use \/help\b|Create new file\?|Allow edits to\b|Edit the files\?|Run shell command\?).*$/i
+        /^\s*(?:Applied edit to|Commit\b|Committing\b|You can use \/undo\b|Added .+ to the chat\.|Removed .+ from the chat\.|Use \/help\b|Create new file\?|Allow edits to\b|Edit the files\?|Run shell command\?).*$/i
       OUTPUT_PATH_PATTERN = %r{^\s*[\w.-]*[/.][\w./-]*\s*$}
       COMMON_SHELL_COMMAND_PATTERN =
         /\A(?:git|bundle|ruby|python\d*(?:\.\d+)?|uv|npm|yarn|pnpm|node|bash|sh|zsh|make|rake|rspec|rails|bin\/[\w.-]+|sed|rg|grep|find|ls|cat|cp|mv|rm|mkdir|touch|chmod|chown|docker|kubectl)\z/

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -250,6 +250,7 @@ module AgentHarness
 
       def build_command(prompt, options)
         cmd = [self.class.binary_name]
+        runtime = options[:provider_runtime]
 
         cmd << "--yes"
 
@@ -257,13 +258,16 @@ module AgentHarness
           cmd += ["--llm-history-file", options[:llm_history_path]]
         end
 
-        if @config.model && !@config.model.empty?
-          cmd += ["--model", @config.model]
+        model = runtime&.model || @config.model
+        if model && !model.empty?
+          cmd += ["--model", model]
         end
 
         if options[:session]
           cmd += session_flags(options[:session])
         end
+
+        cmd += runtime.flags if runtime&.flags&.any?
 
         cmd += ["--message", prompt]
 

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -453,7 +453,7 @@ module AgentHarness
         return false if tokens.empty?
         command = tokens.first
         return false unless command_invocation_token?(command)
-        return true if tokens.length == 1
+        return single_token_command_footer?(command) if tokens.length == 1
         return false unless command_line_token?(command, tokens[1..])
 
         tokens[1..].all? { |token| command_argument_token?(token) }
@@ -482,6 +482,10 @@ module AgentHarness
           (COMMON_SHELL_COMMAND_PATTERN.match?(token) ||
             executable_path_token?(token) ||
             command_footer_shell_like_arguments?(arguments))
+      end
+
+      def single_token_command_footer?(token)
+        COMMON_SHELL_COMMAND_PATTERN.match?(token) || executable_path_token?(token)
       end
 
       def command_footer_shell_like_arguments?(arguments)

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -306,6 +306,7 @@ module AgentHarness
       TOKEN_USAGE_PATTERN =
         /^\s*Tokens:\s*(?<input>#{TOKEN_COUNT_PATTERN})\s+sent(?:,\s*#{TOKEN_COUNT_PATTERN}\s+cache\s+\w+)*,\s*(?<output>#{TOKEN_COUNT_PATTERN})\s+received\.?(?:\s+Cost:\s+.+)?\s*$/i
       FOOTER_COST_PATTERN = /^\s*Cost:\s+.+\s*$/i
+      RUN_SHELL_COMMAND_PATTERN = /^\s*Run shell command\?.*$/i
       OUTPUT_STATUS_PATTERN =
         /^\s*(?:Applied edit to|Commit\b|You can use \/undo\b|Added .+ to the chat\.|Removed .+ from the chat\.|Use \/help\b|Create new file\?|Allow edits to\b|Edit the files\?|Run shell command\?).*$/i
       OUTPUT_PATH_PATTERN = %r{^\s*[\w.-]*[/.][\w./-]*\s*$}
@@ -407,13 +408,36 @@ module AgentHarness
       end
 
       def output_footer_suffix?(lines, index)
-        lines[(index + 1)..].to_a.all? do |line|
+        suffix_lines = lines[(index + 1)..].to_a
+        shell_prompt_index = suffix_lines.index { |line| RUN_SHELL_COMMAND_PATTERN.match?(line) }
+
+        suffix_lines.each_with_index.all? do |line, line_index|
           stripped = line.strip
           stripped.empty? ||
             TOKEN_USAGE_PATTERN.match?(line) ||
             FOOTER_COST_PATTERN.match?(line) ||
             OUTPUT_STATUS_PATTERN.match?(line) ||
-            OUTPUT_PATH_PATTERN.match?(line)
+            OUTPUT_PATH_PATTERN.match?(line) ||
+            output_command_footer_line?(line, line_index, shell_prompt_index)
+        end
+      end
+
+      def output_command_footer_line?(line, line_index, shell_prompt_index)
+        return false unless shell_prompt_index && line_index < shell_prompt_index
+
+        stripped = line.strip
+        return false if stripped.end_with?(".", "?", "!")
+        return false if stripped.empty?
+
+        tokens = stripped.sub(/\A[$>#]\s*/, "").split(/\s+/)
+        return false if tokens.empty?
+        return false unless tokens.first.match?(/\A[\w.\/~:-]+\z/)
+        return true if tokens.length == 1
+
+        tokens[1..].all? do |token|
+          token.match?(%r{\A(?:&&|\|\|?|[<>]|>>|&>|2>|[~-]|["'$`(])}) ||
+            token.match?(%r{[/.=:]}) ||
+            (tokens.length == 2 && token.match?(/\A[\w-]+\z/))
         end
       end
 

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -314,7 +314,7 @@ module AgentHarness
       OUTPUT_DOTFILE_PATTERN = /\A\.[\w.-]+\z/
       OUTPUT_FILENAME_PATTERN = /\A[\w.-]+\.[A-Za-z][\w.-]*\z/
       COMMON_SHELL_COMMAND_PATTERN =
-        /\A(?:git|bundle|ruby|python\d*(?:\.\d+)?|uv|npm|yarn|pnpm|node|bash|sh|zsh|make|rake|rspec|rails|bin\/[\w.-]+|sed|rg|grep|find|ls|cat|cp|mv|rm|mkdir|touch|chmod|chown|docker|kubectl)\z/
+        /\A(?:git|bundle|ruby|python\d*(?:\.\d+)?|uv|npm|yarn|pnpm|node|bash|sh|zsh|make|rake|rspec|rails|go|pytest|bin\/[\w.-]+|sed|rg|grep|find|ls|cat|cp|mv|rm|mkdir|touch|chmod|chown|docker|kubectl)\z/
       EXECUTOR_LLM_HISTORY_TIMEOUT = 10
 
       def generate_llm_history_path
@@ -449,27 +449,51 @@ module AgentHarness
         return false if stripped.end_with?(".", "?", "!")
         return false if stripped.empty?
 
-        tokens = stripped.sub(/\A[$>#]\s*/, "").split(/\s+/)
+        tokens = shell_command_footer_tokens(stripped)
         return false if tokens.empty?
         command = tokens.first
-        return false unless command.match?(/\A[\w.\/~:-]+\z/)
-        return command_token?(command) if tokens.length == 1
-        return false unless command_line_token?(command)
+        return false unless command_invocation_token?(command)
+        return true if tokens.length == 1
+        return false unless command_line_token?(command, tokens[1..])
 
         tokens[1..].all? { |token| command_argument_token?(token) }
+      end
+
+      def shell_command_footer_tokens(line)
+        Shellwords.shellsplit(line.sub(/\A[$>#]\s*/, ""))
+      rescue ArgumentError
+        []
       end
 
       def command_token?(token)
         token.match?(/\A[a-z0-9_][\w.\/~:-]*\z/) && token.match?(/[a-z]/)
       end
 
-      def command_line_token?(token)
-        command_token?(token) && COMMON_SHELL_COMMAND_PATTERN.match?(token)
+      def command_invocation_token?(token)
+        command_token?(token) || executable_path_token?(token)
+      end
+
+      def executable_path_token?(token)
+        token.match?(%r{\A(?:\.\.?/|/|~/)[\w.+%:@=-][\w./+%:@~=-]*\z})
+      end
+
+      def command_line_token?(token, arguments)
+        command_invocation_token?(token) &&
+          (COMMON_SHELL_COMMAND_PATTERN.match?(token) ||
+            executable_path_token?(token) ||
+            command_footer_shell_like_arguments?(arguments))
+      end
+
+      def command_footer_shell_like_arguments?(arguments)
+        arguments.any? do |argument|
+          argument.match?(%r{\A(?:&&|\|\|?|\||[<>]|>>|&>|2>)\z}) ||
+            argument.start_with?("-", "./", "../", "/", "~/") ||
+            argument.include?("/")
+        end
       end
 
       def command_argument_token?(token)
-        token.match?(%r{\A(?:&&|\|\|?|[<>]|>>|&>|2>|[~-]|["'$`(])}) ||
-          token.match?(%r{\A[-\w@%+=:,./~^]+\z})
+        !token.empty? && !token.match?(/[[:cntrl:]]/)
       end
 
       def parse_token_count(value)

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -293,8 +293,10 @@ module AgentHarness
 
       private
 
+      TOKEN_COUNT_PATTERN = /\d[\d,]*(?:\.\d+)?[kmb]?/i
+
       TOKEN_USAGE_PATTERN =
-        /Tokens:\s*(?<input>[\d,]+)\s+sent(?:,\s*[\d,]+\s+cache\s+\w+)*,\s*(?<output>[\d,]+)\s+received\./i
+        /Tokens:\s*(?<input>#{TOKEN_COUNT_PATTERN})\s+sent(?:,\s*#{TOKEN_COUNT_PATTERN}\s+cache\s+\w+)*,\s*(?<output>#{TOKEN_COUNT_PATTERN})\s+received\./i
 
       def generate_llm_history_path
         File.join(Dir.tmpdir, "aider_llm_history_#{Process.pid}_#{SecureRandom.hex(8)}")
@@ -327,10 +329,23 @@ module AgentHarness
         match = content.to_enum(:scan, TOKEN_USAGE_PATTERN).map { Regexp.last_match }.last
         return nil unless match
 
-        input = match[:input].delete(",").to_i
-        output = match[:output].delete(",").to_i
+        input = parse_token_count(match[:input])
+        output = parse_token_count(match[:output])
 
         {input: input, output: output, total: input + output}
+      end
+
+      def parse_token_count(value)
+        normalized = value.delete(",").downcase
+        multiplier = case normalized[-1]
+        when "k" then 1_000
+        when "m" then 1_000_000
+        when "b" then 1_000_000_000
+        else 1
+        end
+        normalized = normalized[0...-1] if multiplier > 1
+
+        (normalized.to_f * multiplier).round
       end
 
       def cleanup_llm_history_file!(path)

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -312,8 +312,8 @@ module AgentHarness
         # Prefer the request-local history file when it includes a token report,
         # but fall back to captured command output because the usage summary is
         # printed there during normal runs.
-        parse_token_usage_text(read_llm_history(llm_history_path)) ||
-          parse_token_usage_text([result.stdout, result.stderr].compact.join("\n"))
+        parse_token_usage_text(read_llm_history(llm_history_path), source: :history) ||
+          parse_token_usage_text([result.stdout, result.stderr].compact.join("\n"), source: :output)
       rescue => e
         log_debug("llm_history_parse_error", error: e.message)
         nil
@@ -328,16 +328,42 @@ module AgentHarness
         content
       end
 
-      def parse_token_usage_text(content)
+      def parse_token_usage_text(content, source: :output)
         return nil if content.nil? || content.strip.empty?
 
-        match = content.to_enum(:scan, TOKEN_USAGE_PATTERN).map { Regexp.last_match }.last
+        match = if source == :history
+          extract_history_token_usage_match(content)
+        else
+          content.to_enum(:scan, TOKEN_USAGE_PATTERN).map { Regexp.last_match }.last
+        end
         return nil unless match
 
         input = parse_token_count(match[:input])
         output = parse_token_count(match[:output])
 
         {input: input, output: output, total: input + output}
+      end
+
+      def extract_history_token_usage_match(content)
+        lines = content.lines
+
+        lines.each_index.reverse_each do |index|
+          match = TOKEN_USAGE_PATTERN.match(lines[index])
+          next unless match
+          next unless history_token_usage_footer_line?(lines, index)
+
+          return match
+        end
+
+        nil
+      end
+
+      def history_token_usage_footer_line?(lines, index)
+        previous_index = index - 1
+        return true if previous_index.negative?
+
+        previous_line = lines[previous_index]
+        previous_line.strip.empty? || TOKEN_USAGE_PATTERN.match?(previous_line)
       end
 
       def parse_token_count(value)

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -363,11 +363,14 @@ module AgentHarness
       end
 
       def footer_prefix?(lines, index)
-        previous_index = index - 1
-        return true if previous_index.negative?
+        block_start = index
+        while block_start.positive? && TOKEN_USAGE_PATTERN.match?(lines[block_start - 1])
+          block_start -= 1
+        end
 
-        previous_line = lines[previous_index]
-        previous_line.strip.empty? || TOKEN_USAGE_PATTERN.match?(previous_line)
+        return false if block_start.zero?
+
+        lines[block_start - 1].strip.empty?
       end
 
       def footer_suffix?(lines, index)

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -376,6 +376,21 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(response.tokens).to eq({input: 2900, output: 31, total: 2931})
       end
 
+      it "parses token counts when aider includes trailing cost text" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, "")
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "response text\nTokens: 1,500 sent, 250 received. Cost: $0.0012 message, $0.0045 session.\n",
+            stderr: "",
+            exit_code: 0
+          )
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to eq({input: 1500, output: 250, total: 1750})
+      end
+
       it "uses the last token report when multiple usage lines are present" do
         allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
           history_path = cmd[cmd.index("--llm-history-file") + 1]
@@ -536,6 +551,15 @@ RSpec.describe AgentHarness::Providers::Aider do
 
       it "parses token counters without a trailing period" do
         tokens = provider.send(:parse_token_usage_text, "Tokens: 42 sent, 8 received")
+
+        expect(tokens).to eq({input: 42, output: 8, total: 50})
+      end
+
+      it "parses token counters with trailing cost text" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          "Tokens: 42 sent, 8 received. Cost: $0.0012 message, $0.0045 session."
+        )
 
         expect(tokens).to eq({input: 42, output: 8, total: 50})
       end

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -539,6 +539,15 @@ RSpec.describe AgentHarness::Providers::Aider do
 
         expect(tokens).to eq({input: 42, output: 8, total: 50})
       end
+
+      it "ignores token-like text embedded in conversation content" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          "ASSISTANT Please print the exact text Tokens: 42 sent, 8 received. in your reply."
+        )
+
+        expect(tokens).to be_nil
+      end
     end
   end
 end

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -776,6 +776,22 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(tokens).to eq({input: 42, output: 8, total: 50})
       end
 
+      it "parses output footer token counters when aider prints a shell command before the prompt" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT
+            response text
+
+            Tokens: 42 sent, 8 received.
+
+            touch a.txt
+            Run shell command?
+          TEXT
+        )
+
+        expect(tokens).to eq({input: 42, output: 8, total: 50})
+      end
+
       it "still ignores output token counters followed by arbitrary prose" do
         tokens = provider.send(
           :parse_token_usage_text,
@@ -784,6 +800,21 @@ RSpec.describe AgentHarness::Providers::Aider do
 
             Tokens: 42 sent, 8 received.
             Here is more assistant prose after the token line.
+          TEXT
+        )
+
+        expect(tokens).to be_nil
+      end
+
+      it "ignores output token counters followed by prose before a shell prompt" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT
+            response text
+
+            Tokens: 42 sent, 8 received.
+            Here is a sentence.
+            Run shell command?
           TEXT
         )
 

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe AgentHarness::Providers::Aider do
             USER hello
           TEXT
           AgentHarness::CommandExecutor::Result.new(
-            stdout: "response text\nTokens: 1,500 sent, 250 received.\n",
+            stdout: "response text\n\nTokens: 1,500 sent, 250 received.\n",
             stderr: "",
             exit_code: 0
           )
@@ -367,7 +367,7 @@ RSpec.describe AgentHarness::Providers::Aider do
           history_path = cmd[cmd.index("--llm-history-file") + 1]
           File.write(history_path, "")
           AgentHarness::CommandExecutor::Result.new(
-            stdout: "response text\nTokens: 2.9k sent, 7.6k cache write, 31 received.\n",
+            stdout: "response text\n\nTokens: 2.9k sent, 7.6k cache write, 31 received.\n",
             stderr: "",
             exit_code: 0
           )
@@ -382,7 +382,7 @@ RSpec.describe AgentHarness::Providers::Aider do
           history_path = cmd[cmd.index("--llm-history-file") + 1]
           File.write(history_path, "")
           AgentHarness::CommandExecutor::Result.new(
-            stdout: "response text\nTokens: 1,500 sent, 250 received. Cost: $0.0012 message, $0.0045 session.\n",
+            stdout: "response text\n\nTokens: 1,500 sent, 250 received. Cost: $0.0012 message, $0.0045 session.\n",
             stderr: "",
             exit_code: 0
           )
@@ -509,13 +509,28 @@ RSpec.describe AgentHarness::Providers::Aider do
           File.write(history_path, "")
           AgentHarness::CommandExecutor::Result.new(
             stdout: "response text",
-            stderr: "Tokens: 12 sent, 34 received.",
+            stderr: "response text\n\nTokens: 12 sent, 34 received.",
             exit_code: 0
           )
         end
 
         response = provider.send_message(prompt: "hello")
         expect(response.tokens).to eq({input: 12, output: 34, total: 46})
+      end
+
+      it "ignores standalone output token lines without a footer separator" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, "")
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "Please print this exactly:\nTokens: 42 sent, 8 received.\n",
+            stderr: "",
+            exit_code: 0
+          )
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to be_nil
       end
 
       it "keeps llm history paths request-local across concurrent calls" do
@@ -604,7 +619,7 @@ RSpec.describe AgentHarness::Providers::Aider do
 
     describe "#parse_token_usage_text" do
       it "parses abbreviated token counters" do
-        tokens = provider.send(:parse_token_usage_text, "Tokens: 1.2k sent, 31 received.")
+        tokens = provider.send(:parse_token_usage_text, "response text\n\nTokens: 1.2k sent, 31 received.")
 
         expect(tokens).to eq({input: 1200, output: 31, total: 1231})
       end
@@ -612,14 +627,14 @@ RSpec.describe AgentHarness::Providers::Aider do
       it "parses abbreviated token counters with cache usage" do
         tokens = provider.send(
           :parse_token_usage_text,
-          "Tokens: 2.9k sent, 7.6k cache write, 3.2k cache read, 31 received."
+          "response text\n\nTokens: 2.9k sent, 7.6k cache write, 3.2k cache read, 31 received."
         )
 
         expect(tokens).to eq({input: 2900, output: 31, total: 2931})
       end
 
       it "parses token counters without a trailing period" do
-        tokens = provider.send(:parse_token_usage_text, "Tokens: 42 sent, 8 received")
+        tokens = provider.send(:parse_token_usage_text, "response text\n\nTokens: 42 sent, 8 received")
 
         expect(tokens).to eq({input: 42, output: 8, total: 50})
       end
@@ -627,7 +642,7 @@ RSpec.describe AgentHarness::Providers::Aider do
       it "parses token counters with trailing cost text" do
         tokens = provider.send(
           :parse_token_usage_text,
-          "Tokens: 42 sent, 8 received. Cost: $0.0012 message, $0.0045 session."
+          "response text\n\nTokens: 42 sent, 8 received. Cost: $0.0012 message, $0.0045 session."
         )
 
         expect(tokens).to eq({input: 42, output: 8, total: 50})
@@ -653,6 +668,31 @@ RSpec.describe AgentHarness::Providers::Aider do
         )
 
         expect(tokens).to be_nil
+      end
+
+      it "ignores standalone output token lines unless they are in a footer block" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT
+            ASSISTANT Please print this exactly:
+            Tokens: 42 sent, 8 received.
+          TEXT
+        )
+
+        expect(tokens).to be_nil
+      end
+
+      it "parses output footer token counters after a blank-line separator" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT
+            response text
+
+            Tokens: 42 sent, 8 received.
+          TEXT
+        )
+
+        expect(tokens).to eq({input: 42, output: 8, total: 50})
       end
 
       it "parses history footer token counters after a blank-line separator" do

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "tmpdir"
+
 RSpec.describe AgentHarness::Providers::Aider do
   describe ".provider_name" do
     it "returns :aider" do
@@ -512,6 +514,12 @@ RSpec.describe AgentHarness::Providers::Aider do
         )
 
         expect(tokens).to eq({input: 2900, output: 31, total: 2931})
+      end
+
+      it "parses token counters without a trailing period" do
+        tokens = provider.send(:parse_token_usage_text, "Tokens: 42 sent, 8 received")
+
+        expect(tokens).to eq({input: 42, output: 8, total: 50})
       end
     end
   end

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -957,6 +957,20 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(tokens).to be_nil
       end
 
+      it "ignores output token counters followed by status-like lines ending in a period" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT
+            response text
+
+            Tokens: 42 sent, 8 received.
+            Done.
+          TEXT
+        )
+
+        expect(tokens).to be_nil
+      end
+
       it "parses history footer token counters after a blank-line separator" do
         tokens = provider.send(
           :parse_token_usage_text,

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -790,6 +790,20 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(tokens).to be_nil
       end
 
+      it "ignores output token counters followed by a one-word status line" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT
+            response text
+
+            Tokens: 42 sent, 8 received.
+            OK
+          TEXT
+        )
+
+        expect(tokens).to be_nil
+      end
+
       it "parses history footer token counters after a blank-line separator" do
         tokens = provider.send(
           :parse_token_usage_text,

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -272,6 +272,22 @@ RSpec.describe AgentHarness::Providers::Aider do
 
         expect(command).to include("--map-tokens", "0")
       end
+
+      it "rejects runtime flags that override the provider-managed history path" do
+        runtime = AgentHarness::ProviderRuntime.new(flags: ["--llm-history-file", "/tmp/override.log"])
+
+        expect {
+          provider.send(:build_command, "hello", provider_runtime: runtime, llm_history_path: "/tmp/request.log")
+        }.to raise_error(ArgumentError, /provider-managed flags: --llm-history-file \/tmp\/override\.log/)
+      end
+
+      it "rejects runtime flags that use inline history-file assignment" do
+        runtime = AgentHarness::ProviderRuntime.new(flags: ["--llm-history-file=/tmp/override.log"])
+
+        expect {
+          provider.send(:build_command, "hello", provider_runtime: runtime, llm_history_path: "/tmp/request.log")
+        }.to raise_error(ArgumentError, /provider-managed flags: --llm-history-file=\/tmp\/override\.log/)
+      end
     end
 
     describe "#send_message" do
@@ -596,6 +612,16 @@ RSpec.describe AgentHarness::Providers::Aider do
           {input: 20, output: 2, total: 22}
         )
         expect(returned_paths).to all(satisfy { |path| !File.exist?(path) })
+      end
+
+      it "fails before execution when runtime flags try to override llm history output" do
+        runtime = AgentHarness::ProviderRuntime.new(flags: ["--llm-history-file", "/tmp/override.log"])
+
+        expect(mock_executor).not_to receive(:execute)
+
+        expect {
+          provider.send_message(prompt: "hello", provider_runtime: runtime)
+        }.to raise_error(AgentHarness::ProviderError, /provider-managed flags: --llm-history-file \/tmp\/override\.log/)
       end
     end
 

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -882,6 +882,54 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(tokens).to eq({input: 42, output: 8, total: 50})
       end
 
+      it "parses output footer token counters for quoted shell commands" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT
+            response text
+
+            Tokens: 42 sent, 8 received.
+
+            git commit -m "fix bug"
+            Run shell command?
+          TEXT
+        )
+
+        expect(tokens).to eq({input: 42, output: 8, total: 50})
+      end
+
+      it "parses output footer token counters for non-whitelisted shell commands with shell-like arguments" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT
+            response text
+
+            Tokens: 42 sent, 8 received.
+
+            pytest -q
+            Run shell command?
+          TEXT
+        )
+
+        expect(tokens).to eq({input: 42, output: 8, total: 50})
+      end
+
+      it "parses output footer token counters for script-path shell commands" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT
+            response text
+
+            Tokens: 42 sent, 8 received.
+
+            ./scripts/test.sh --help
+            Run shell command?
+          TEXT
+        )
+
+        expect(tokens).to eq({input: 42, output: 8, total: 50})
+      end
+
       it "parses output footer token counters when aider prints a committing status line" do
         tokens = provider.send(
           :parse_token_usage_text,

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -450,6 +450,22 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(response.tokens).to be_nil
       end
 
+      it "ignores history token lines that are followed by more transcript content" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, <<~TEXT)
+            ASSISTANT world
+
+            Tokens: 42 sent, 8 received.
+            ASSISTANT This is transcript content, not the footer.
+          TEXT
+          result
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to be_nil
+      end
+
       it "returns nil tokens when history file does not exist" do
         response = provider.send_message(prompt: "hello")
         expect(response.tokens).to be_nil
@@ -615,6 +631,21 @@ RSpec.describe AgentHarness::Providers::Aider do
         )
 
         expect(tokens).to eq({input: 42, output: 8, total: 50})
+      end
+
+      it "ignores history token counters when later transcript lines follow" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT,
+            ASSISTANT world
+
+            Tokens: 42 sent, 8 received.
+            ASSISTANT This is transcript content, not the footer.
+          TEXT
+          source: :history
+        )
+
+        expect(tokens).to be_nil
       end
     end
   end

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -518,6 +518,21 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(response.tokens).to eq({input: 12, output: 34, total: 46})
       end
 
+      it "parses stdout token usage even when stderr contains diagnostics" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, "")
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "response text\n\nTokens: 12 sent, 34 received.\n",
+            stderr: "warning: model metadata unavailable\n",
+            exit_code: 0
+          )
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to eq({input: 12, output: 34, total: 46})
+      end
+
       it "ignores standalone output token lines without a footer separator" do
         allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
           history_path = cmd[cmd.index("--llm-history-file") + 1]

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -333,6 +333,7 @@ RSpec.describe AgentHarness::Providers::Aider do
             USER hello
             LLM RESPONSE 2026-04-12T00:00:01
             ASSISTANT world
+
             Tokens: 10 sent, 20 received.
           TEXT
           result
@@ -433,6 +434,22 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(response.tokens).to be_nil
       end
 
+      it "ignores usage-shaped transcript lines in history content" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, <<~TEXT)
+            TO LLM 2026-04-12T00:00:00
+            -------
+            USER Please repeat this exactly:
+            Tokens: 42 sent, 8 received.
+          TEXT
+          result
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to be_nil
+      end
+
       it "returns nil tokens when history file does not exist" do
         response = provider.send_message(prompt: "hello")
         expect(response.tokens).to be_nil
@@ -512,7 +529,7 @@ RSpec.describe AgentHarness::Providers::Aider do
       it "augments the base response with tokens from the history file" do
         Dir.mktmpdir do |dir|
           path = File.join(dir, "history.log")
-          File.write(path, "Tokens: 100 sent, 50 received.")
+          File.write(path, "ASSISTANT world\n\nTokens: 100 sent, 50 received.")
 
           response = provider.send(:parse_response, result, duration: 1.0, llm_history_path: path)
           expect(response.output).to eq("response text")
@@ -571,6 +588,33 @@ RSpec.describe AgentHarness::Providers::Aider do
         )
 
         expect(tokens).to be_nil
+      end
+
+      it "ignores standalone transcript lines unless they are in a footer block" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT,
+            USER Please repeat this exactly:
+            Tokens: 42 sent, 8 received.
+          TEXT
+          source: :history
+        )
+
+        expect(tokens).to be_nil
+      end
+
+      it "parses history footer token counters after a blank-line separator" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT,
+            ASSISTANT world
+
+            Tokens: 42 sent, 8 received. Cost: $0.0012 message, $0.0045 session.
+          TEXT
+          source: :history
+        )
+
+        expect(tokens).to eq({input: 42, output: 8, total: 50})
       end
     end
   end

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -341,6 +341,21 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(response.tokens).to eq({input: 1500, output: 250, total: 1750})
       end
 
+      it "parses abbreviated token counts with cache segments from command output" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, "")
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "response text\nTokens: 2.9k sent, 7.6k cache write, 31 received.\n",
+            stderr: "",
+            exit_code: 0
+          )
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to eq({input: 2900, output: 31, total: 2931})
+      end
+
       it "uses the last token report when multiple usage lines are present" do
         allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
           history_path = cmd[cmd.index("--llm-history-file") + 1]
@@ -480,6 +495,23 @@ RSpec.describe AgentHarness::Providers::Aider do
           expect(response.output).to eq("response text")
           expect(response.tokens).to be_nil
         end
+      end
+    end
+
+    describe "#parse_token_usage_text" do
+      it "parses abbreviated token counters" do
+        tokens = provider.send(:parse_token_usage_text, "Tokens: 1.2k sent, 31 received.")
+
+        expect(tokens).to eq({input: 1200, output: 31, total: 1231})
+      end
+
+      it "parses abbreviated token counters with cache usage" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          "Tokens: 2.9k sent, 7.6k cache write, 3.2k cache read, 31 received."
+        )
+
+        expect(tokens).to eq({input: 2900, output: 31, total: 2931})
       end
     end
   end

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -254,6 +254,24 @@ RSpec.describe AgentHarness::Providers::Aider do
 
         expect(command).not_to include("--llm-history-file")
       end
+
+      it "prefers the runtime model over the configured model" do
+        provider.configure(model: "configured-model")
+        runtime = AgentHarness::ProviderRuntime.new(model: "runtime-model")
+
+        command = provider.send(:build_command, "hello", provider_runtime: runtime)
+
+        expect(command).to include("--model", "runtime-model")
+        expect(command).not_to include("configured-model")
+      end
+
+      it "appends runtime flags after provider flags" do
+        runtime = AgentHarness::ProviderRuntime.new(flags: ["--map-tokens", "0"])
+
+        command = provider.send(:build_command, "hello", provider_runtime: runtime)
+
+        expect(command).to include("--map-tokens", "0")
+      end
     end
 
     describe "#send_message" do

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -866,6 +866,22 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(tokens).to eq({input: 42, output: 8, total: 50})
       end
 
+      it "parses output footer token counters for multi-argument shell commands" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT
+            response text
+
+            Tokens: 42 sent, 8 received.
+
+            bundle exec rspec
+            Run shell command?
+          TEXT
+        )
+
+        expect(tokens).to eq({input: 42, output: 8, total: 50})
+      end
+
       it "ignores capitalized status lines before a shell prompt" do
         tokens = provider.send(
           :parse_token_usage_text,

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -866,6 +866,22 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(tokens).to eq({input: 42, output: 8, total: 50})
       end
 
+      it "ignores capitalized status lines before a shell prompt" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT
+            response text
+
+            Tokens: 42 sent, 8 received.
+
+            Done
+            Run shell command?
+          TEXT
+        )
+
+        expect(tokens).to be_nil
+      end
+
       it "still ignores output token counters followed by arbitrary prose" do
         tokens = provider.send(
           :parse_token_usage_text,

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -242,16 +242,12 @@ RSpec.describe AgentHarness::Providers::Aider do
       end
 
       it "includes --llm-history-file when llm_history_path is set" do
-        provider.instance_variable_set(:@llm_history_path, "/tmp/test_history.jsonl")
-        command = provider.send(:build_command, "hello", {})
+        command = provider.send(:build_command, "hello", llm_history_path: "/tmp/test_history.log")
 
-        expect(command).to include("--llm-history-file", "/tmp/test_history.jsonl")
-      ensure
-        provider.instance_variable_set(:@llm_history_path, nil)
+        expect(command).to include("--llm-history-file", "/tmp/test_history.log")
       end
 
       it "does not include --llm-history-file when llm_history_path is nil" do
-        provider.instance_variable_set(:@llm_history_path, nil)
         command = provider.send(:build_command, "hello", {})
 
         expect(command).not_to include("--llm-history-file")
@@ -308,13 +304,17 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(File.exist?(history_path)).to be false
       end
 
-      it "extracts OpenAI-format tokens from the history file" do
+      it "extracts tokens from plain-text usage reports in the history file" do
         allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
           history_path = cmd[cmd.index("--llm-history-file") + 1]
-          File.write(history_path, <<~JSONL)
-            {"role":"user","content":"hello"}
-            {"role":"assistant","content":"world","usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}
-          JSONL
+          File.write(history_path, <<~TEXT)
+            TO LLM 2026-04-12T00:00:00
+            -------
+            USER hello
+            LLM RESPONSE 2026-04-12T00:00:01
+            ASSISTANT world
+            Tokens: 10 sent, 20 received.
+          TEXT
           result
         end
 
@@ -322,32 +322,37 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(response.tokens).to eq({input: 10, output: 20, total: 30})
       end
 
-      it "extracts Anthropic-format tokens from the history file" do
+      it "parses comma-delimited token counts from command output when history lacks usage" do
         allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
           history_path = cmd[cmd.index("--llm-history-file") + 1]
-          File.write(history_path, <<~JSONL)
-            {"role":"user","content":"hello"}
-            {"role":"assistant","content":"world","usage":{"input_tokens":15,"output_tokens":25}}
-          JSONL
-          result
+          File.write(history_path, <<~TEXT)
+            TO LLM 2026-04-12T00:00:00
+            -------
+            USER hello
+          TEXT
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "response text\nTokens: 1,500 sent, 250 received.\n",
+            stderr: "",
+            exit_code: 0
+          )
         end
 
         response = provider.send_message(prompt: "hello")
-        expect(response.tokens).to eq({input: 15, output: 25, total: 40})
+        expect(response.tokens).to eq({input: 1500, output: 250, total: 1750})
       end
 
-      it "aggregates tokens across multiple responses" do
+      it "uses the last token report when multiple usage lines are present" do
         allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
           history_path = cmd[cmd.index("--llm-history-file") + 1]
-          File.write(history_path, <<~JSONL)
-            {"role":"assistant","usage":{"prompt_tokens":10,"completion_tokens":5}}
-            {"role":"assistant","usage":{"prompt_tokens":20,"completion_tokens":10}}
-          JSONL
+          File.write(history_path, <<~TEXT)
+            Tokens: 10 sent, 5 received.
+            Tokens: 20 sent, 10 received.
+          TEXT
           result
         end
 
         response = provider.send_message(prompt: "hello")
-        expect(response.tokens).to eq({input: 30, output: 15, total: 45})
+        expect(response.tokens).to eq({input: 20, output: 10, total: 30})
       end
 
       it "returns nil tokens when history file is empty" do
@@ -364,10 +369,13 @@ RSpec.describe AgentHarness::Providers::Aider do
       it "returns nil tokens when history file has no usage data" do
         allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
           history_path = cmd[cmd.index("--llm-history-file") + 1]
-          File.write(history_path, <<~JSONL)
-            {"role":"user","content":"hello"}
-            {"role":"assistant","content":"world"}
-          JSONL
+          File.write(history_path, <<~TEXT)
+            TO LLM 2026-04-12T00:00:00
+            -------
+            USER hello
+            LLM RESPONSE 2026-04-12T00:00:01
+            ASSISTANT world
+          TEXT
           result
         end
 
@@ -380,32 +388,65 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(response.tokens).to be_nil
       end
 
-      it "handles malformed JSON lines gracefully" do
+      it "parses token usage from stderr when stdout has none" do
         allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
           history_path = cmd[cmd.index("--llm-history-file") + 1]
-          File.write(history_path, <<~JSONL)
-            not-json
-            {"role":"assistant","usage":{"prompt_tokens":10,"completion_tokens":20}}
-            {broken
-          JSONL
-          result
+          File.write(history_path, "")
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "response text",
+            stderr: "Tokens: 12 sent, 34 received.",
+            exit_code: 0
+          )
         end
 
         response = provider.send_message(prompt: "hello")
-        expect(response.tokens).to eq({input: 10, output: 20, total: 30})
+        expect(response.tokens).to eq({input: 12, output: 34, total: 46})
       end
 
-      it "extracts usage from nested response objects" do
+      it "keeps llm history paths request-local across concurrent calls" do
+        paths = Queue.new
+        mutex = Mutex.new
+        ready = ConditionVariable.new
+        started = 0
+
         allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
           history_path = cmd[cmd.index("--llm-history-file") + 1]
-          File.write(history_path, <<~JSONL)
-            {"response":{"usage":{"input_tokens":5,"output_tokens":8}}}
-          JSONL
-          result
+          call_number = nil
+
+          mutex.synchronize do
+            started += 1
+            call_number = started
+            ready.wait(mutex) while started < 2
+            ready.broadcast
+          end
+
+          File.write(history_path, "Tokens: #{call_number}0 sent, #{call_number} received.\n")
+          paths << history_path
+          sleep(0.05) if call_number == 2
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "response #{call_number}",
+            stderr: "",
+            exit_code: 0
+          )
         end
 
-        response = provider.send_message(prompt: "hello")
-        expect(response.tokens).to eq({input: 5, output: 8, total: 13})
+        responses = Queue.new
+        threads = 2.times.map do
+          Thread.new do
+            responses << provider.send_message(prompt: "hello")
+          end
+        end
+        threads.each(&:join)
+
+        returned_paths = 2.times.map { paths.pop }
+        returned_tokens = 2.times.map { responses.pop.tokens }
+
+        expect(returned_paths.uniq.size).to eq(2)
+        expect(returned_tokens).to contain_exactly(
+          {input: 10, output: 1, total: 11},
+          {input: 20, output: 2, total: 22}
+        )
+        expect(returned_paths).to all(satisfy { |path| !File.exist?(path) })
       end
     end
 
@@ -420,31 +461,25 @@ RSpec.describe AgentHarness::Providers::Aider do
 
       it "augments the base response with tokens from the history file" do
         Dir.mktmpdir do |dir|
-          path = File.join(dir, "history.jsonl")
-          File.write(path, '{"usage":{"prompt_tokens":100,"completion_tokens":50}}')
-          provider.instance_variable_set(:@llm_history_path, path)
+          path = File.join(dir, "history.log")
+          File.write(path, "Tokens: 100 sent, 50 received.")
 
-          response = provider.send(:parse_response, result, duration: 1.0)
+          response = provider.send(:parse_response, result, duration: 1.0, llm_history_path: path)
           expect(response.output).to eq("response text")
           expect(response.exit_code).to eq(0)
           expect(response.tokens).to eq({input: 100, output: 50, total: 150})
         end
-      ensure
-        provider.instance_variable_set(:@llm_history_path, nil)
       end
 
       it "returns the base response unchanged when no tokens are found" do
         Dir.mktmpdir do |dir|
-          path = File.join(dir, "history.jsonl")
-          File.write(path, '{"role":"user","content":"hello"}')
-          provider.instance_variable_set(:@llm_history_path, path)
+          path = File.join(dir, "history.log")
+          File.write(path, "TO LLM 2026-04-12T00:00:00\nUSER hello")
 
-          response = provider.send(:parse_response, result, duration: 1.0)
+          response = provider.send(:parse_response, result, duration: 1.0, llm_history_path: path)
           expect(response.output).to eq("response text")
           expect(response.tokens).to be_nil
         end
-      ensure
-        provider.instance_variable_set(:@llm_history_path, nil)
       end
     end
   end

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -408,6 +408,22 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(response.tokens).to eq({input: 20, output: 10, total: 30})
       end
 
+      it "parses history footer token counts when cost appears on a following line" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, <<~TEXT)
+            ASSISTANT world
+
+            Tokens: 10 sent, 20 received.
+            Cost: $0.0012 message, $0.0045 session.
+          TEXT
+          result
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to eq({input: 10, output: 20, total: 30})
+      end
+
       it "returns nil tokens when history file is empty" do
         allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
           history_path = cmd[cmd.index("--llm-history-file") + 1]
@@ -646,6 +662,21 @@ RSpec.describe AgentHarness::Providers::Aider do
             ASSISTANT world
 
             Tokens: 42 sent, 8 received. Cost: $0.0012 message, $0.0045 session.
+          TEXT
+          source: :history
+        )
+
+        expect(tokens).to eq({input: 42, output: 8, total: 50})
+      end
+
+      it "parses history footer token counters when cost is on the next line" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT,
+            ASSISTANT world
+
+            Tokens: 42 sent, 8 received.
+            Cost: $0.0012 message, $0.0045 session.
           TEXT
           source: :history
         )

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -962,6 +962,22 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(tokens).to be_nil
       end
 
+      it "ignores lowercase prose-like lines before a shell prompt" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT
+            response text
+
+            Tokens: 42 sent, 8 received.
+
+            thanks
+            Run shell command?
+          TEXT
+        )
+
+        expect(tokens).to be_nil
+      end
+
       it "still ignores output token counters followed by arbitrary prose" do
         tokens = provider.send(
           :parse_token_usage_text,

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -396,6 +396,8 @@ RSpec.describe AgentHarness::Providers::Aider do
         allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
           history_path = cmd[cmd.index("--llm-history-file") + 1]
           File.write(history_path, <<~TEXT)
+            ASSISTANT world
+
             Tokens: 10 sent, 5 received.
             Tokens: 20 sent, 10 received.
           TEXT
@@ -442,6 +444,20 @@ RSpec.describe AgentHarness::Providers::Aider do
             -------
             USER Please repeat this exactly:
             Tokens: 42 sent, 8 received.
+          TEXT
+          result
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to be_nil
+      end
+
+      it "ignores token-only history files that are missing a footer separator" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, <<~TEXT)
+            Tokens: 42 sent, 8 received.
+            Tokens: 50 sent, 10 received.
           TEXT
           result
         end
@@ -503,7 +519,11 @@ RSpec.describe AgentHarness::Providers::Aider do
             ready.broadcast
           end
 
-          File.write(history_path, "Tokens: #{call_number}0 sent, #{call_number} received.\n")
+          File.write(history_path, <<~TEXT)
+            ASSISTANT response #{call_number}
+
+            Tokens: #{call_number}0 sent, #{call_number} received.
+          TEXT
           paths << history_path
           sleep(0.05) if call_number == 2
           AgentHarness::CommandExecutor::Result.new(
@@ -631,6 +651,19 @@ RSpec.describe AgentHarness::Providers::Aider do
         )
 
         expect(tokens).to eq({input: 42, output: 8, total: 50})
+      end
+
+      it "ignores token-only history content without a blank-line footer separator" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT,
+            Tokens: 42 sent, 8 received.
+            Tokens: 50 sent, 10 received.
+          TEXT
+          source: :history
+        )
+
+        expect(tokens).to be_nil
       end
 
       it "ignores history token counters when later transcript lines follow" do

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -549,6 +549,22 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(response.tokens).to eq({input: 12, output: 34, total: 46})
       end
 
+      it "falls back to command output when reading llm history raises" do
+        allow(provider).to receive(:read_llm_history).and_raise(Timeout::Error, "history read timed out")
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, "ASSISTANT world\n")
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "response text\n\nTokens: 12 sent, 34 received.\n",
+            stderr: "",
+            exit_code: 0
+          )
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to eq({input: 12, output: 34, total: 46})
+      end
+
       it "parses stdout token usage when aider prints edit status after the token footer" do
         allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
           history_path = cmd[cmd.index("--llm-history-file") + 1]

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -882,6 +882,22 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(tokens).to eq({input: 42, output: 8, total: 50})
       end
 
+      it "parses output footer token counters when aider prints a committing status line" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT
+            response text
+
+            Tokens: 42 sent, 8 received.
+
+            Committing lib/example.rb before applying edits.
+            Applied edit to lib/example.rb
+          TEXT
+        )
+
+        expect(tokens).to eq({input: 42, output: 8, total: 50})
+      end
+
       it "ignores capitalized status lines before a shell prompt" do
         tokens = provider.send(
           :parse_token_usage_text,

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -646,6 +646,64 @@ RSpec.describe AgentHarness::Providers::Aider do
           provider.send_message(prompt: "hello", provider_runtime: runtime)
         }.to raise_error(AgentHarness::ProviderError, /provider-managed flags: --llm-history-file \/tmp\/override\.log/)
       end
+
+      context "with DockerCommandExecutor" do
+        let(:docker_executor) { instance_double(AgentHarness::DockerCommandExecutor) }
+        let(:provider) { described_class.new(executor: docker_executor) }
+
+        before do
+          allow(docker_executor).to receive(:is_a?).with(AgentHarness::DockerCommandExecutor).and_return(true)
+        end
+
+        it "reads and cleans up the history file inside the container" do
+          history_path = nil
+          calls = []
+          allow(docker_executor).to receive(:execute) do |cmd, **kwargs|
+            calls << [cmd, kwargs]
+
+            if cmd.first == "aider"
+              history_path = cmd[cmd.index("--llm-history-file") + 1]
+              result
+            elsif cmd[2].start_with?("if [ -s ")
+              AgentHarness::CommandExecutor::Result.new(
+                stdout: "ASSISTANT world\n\nTokens: 10 sent, 20 received.\n",
+                stderr: "",
+                exit_code: 0
+              )
+            else
+              AgentHarness::CommandExecutor::Result.new(
+                stdout: "",
+                stderr: "",
+                exit_code: 0
+              )
+            end
+          end
+
+          response = provider.send_message(prompt: "hello")
+
+          expect(calls.size).to eq(3)
+          expect(calls[0]).to match(
+            [
+              array_including("aider", "--llm-history-file"),
+              hash_including(timeout: 600)
+            ]
+          )
+          expect(history_path).to start_with("/tmp/aider_llm_history_")
+          expect(calls[1]).to eq(
+            [
+              ["sh", "-lc", "if [ -s #{Shellwords.escape(history_path)} ]; then cat #{Shellwords.escape(history_path)}; fi"],
+              {timeout: 10}
+            ]
+          )
+          expect(calls[2]).to eq(
+            [
+              ["sh", "-lc", "rm -f -- #{Shellwords.escape(history_path)}"],
+              {timeout: 10}
+            ]
+          )
+          expect(response.tokens).to eq({input: 10, output: 20, total: 30})
+        end
+      end
     end
 
     describe "#parse_response with llm history" do

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -240,6 +240,212 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(command.first).to eq(contract[:binary_name])
         expect(command).to include(provider.execution_semantics[:non_interactive_flag])
       end
+
+      it "includes --llm-history-file when llm_history_path is set" do
+        provider.instance_variable_set(:@llm_history_path, "/tmp/test_history.jsonl")
+        command = provider.send(:build_command, "hello", {})
+
+        expect(command).to include("--llm-history-file", "/tmp/test_history.jsonl")
+      ensure
+        provider.instance_variable_set(:@llm_history_path, nil)
+      end
+
+      it "does not include --llm-history-file when llm_history_path is nil" do
+        provider.instance_variable_set(:@llm_history_path, nil)
+        command = provider.send(:build_command, "hello", {})
+
+        expect(command).not_to include("--llm-history-file")
+      end
+    end
+
+    describe "#send_message" do
+      let(:mock_executor) do
+        instance_double(AgentHarness::CommandExecutor)
+      end
+      let(:provider) { described_class.new(executor: mock_executor) }
+      let(:result) do
+        AgentHarness::CommandExecutor::Result.new(
+          stdout: "response text",
+          stderr: "",
+          exit_code: 0
+        )
+      end
+
+      before do
+        allow(mock_executor).to receive(:execute).and_return(result)
+      end
+
+      it "creates an llm history file flag in the command" do
+        expect(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          expect(cmd).to include("--llm-history-file")
+          result
+        end
+
+        provider.send_message(prompt: "hello")
+      end
+
+      it "cleans up the temp history file after execution" do
+        history_path = nil
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, "")
+          result
+        end
+
+        provider.send_message(prompt: "hello")
+        expect(File.exist?(history_path)).to be false
+      end
+
+      it "cleans up the temp history file even when execution fails" do
+        history_path = nil
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, "")
+          raise Timeout::Error, "timed out"
+        end
+
+        expect { provider.send_message(prompt: "hello") }.to raise_error(AgentHarness::TimeoutError)
+        expect(File.exist?(history_path)).to be false
+      end
+
+      it "extracts OpenAI-format tokens from the history file" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, <<~JSONL)
+            {"role":"user","content":"hello"}
+            {"role":"assistant","content":"world","usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}
+          JSONL
+          result
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to eq({input: 10, output: 20, total: 30})
+      end
+
+      it "extracts Anthropic-format tokens from the history file" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, <<~JSONL)
+            {"role":"user","content":"hello"}
+            {"role":"assistant","content":"world","usage":{"input_tokens":15,"output_tokens":25}}
+          JSONL
+          result
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to eq({input: 15, output: 25, total: 40})
+      end
+
+      it "aggregates tokens across multiple responses" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, <<~JSONL)
+            {"role":"assistant","usage":{"prompt_tokens":10,"completion_tokens":5}}
+            {"role":"assistant","usage":{"prompt_tokens":20,"completion_tokens":10}}
+          JSONL
+          result
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to eq({input: 30, output: 15, total: 45})
+      end
+
+      it "returns nil tokens when history file is empty" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, "")
+          result
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to be_nil
+      end
+
+      it "returns nil tokens when history file has no usage data" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, <<~JSONL)
+            {"role":"user","content":"hello"}
+            {"role":"assistant","content":"world"}
+          JSONL
+          result
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to be_nil
+      end
+
+      it "returns nil tokens when history file does not exist" do
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to be_nil
+      end
+
+      it "handles malformed JSON lines gracefully" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, <<~JSONL)
+            not-json
+            {"role":"assistant","usage":{"prompt_tokens":10,"completion_tokens":20}}
+            {broken
+          JSONL
+          result
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to eq({input: 10, output: 20, total: 30})
+      end
+
+      it "extracts usage from nested response objects" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, <<~JSONL)
+            {"response":{"usage":{"input_tokens":5,"output_tokens":8}}}
+          JSONL
+          result
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to eq({input: 5, output: 8, total: 13})
+      end
+    end
+
+    describe "#parse_response with llm history" do
+      let(:result) do
+        AgentHarness::CommandExecutor::Result.new(
+          stdout: "response text",
+          stderr: "",
+          exit_code: 0
+        )
+      end
+
+      it "augments the base response with tokens from the history file" do
+        Dir.mktmpdir do |dir|
+          path = File.join(dir, "history.jsonl")
+          File.write(path, '{"usage":{"prompt_tokens":100,"completion_tokens":50}}')
+          provider.instance_variable_set(:@llm_history_path, path)
+
+          response = provider.send(:parse_response, result, duration: 1.0)
+          expect(response.output).to eq("response text")
+          expect(response.exit_code).to eq(0)
+          expect(response.tokens).to eq({input: 100, output: 50, total: 150})
+        end
+      ensure
+        provider.instance_variable_set(:@llm_history_path, nil)
+      end
+
+      it "returns the base response unchanged when no tokens are found" do
+        Dir.mktmpdir do |dir|
+          path = File.join(dir, "history.jsonl")
+          File.write(path, '{"role":"user","content":"hello"}')
+          provider.instance_variable_set(:@llm_history_path, path)
+
+          response = provider.send(:parse_response, result, duration: 1.0)
+          expect(response.output).to eq("response text")
+          expect(response.tokens).to be_nil
+        end
+      ensure
+        provider.instance_variable_set(:@llm_history_path, nil)
+      end
     end
   end
 end

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -549,6 +549,29 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(response.tokens).to eq({input: 12, output: 34, total: 46})
       end
 
+      it "parses stdout token usage when aider prints edit status after the token footer" do
+        allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, "")
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: <<~TEXT,
+              response text
+
+              Tokens: 12 sent, 34 received.
+
+              lib/example.rb
+              Applied edit to lib/example.rb
+              Commit 123abc feat: update example
+            TEXT
+            stderr: "",
+            exit_code: 0
+          )
+        end
+
+        response = provider.send_message(prompt: "hello")
+        expect(response.tokens).to eq({input: 12, output: 34, total: 46})
+      end
+
       it "ignores standalone output token lines without a footer separator" do
         allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
           history_path = cmd[cmd.index("--llm-history-file") + 1]
@@ -734,6 +757,37 @@ RSpec.describe AgentHarness::Providers::Aider do
         )
 
         expect(tokens).to eq({input: 42, output: 8, total: 50})
+      end
+
+      it "parses output footer token counters when aider status lines follow" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT
+            response text
+
+            Tokens: 42 sent, 8 received.
+
+            lib/example.rb
+            Applied edit to lib/example.rb
+            Commit 123abc feat: update example
+          TEXT
+        )
+
+        expect(tokens).to eq({input: 42, output: 8, total: 50})
+      end
+
+      it "still ignores output token counters followed by arbitrary prose" do
+        tokens = provider.send(
+          :parse_token_usage_text,
+          <<~TEXT
+            response text
+
+            Tokens: 42 sent, 8 received.
+            Here is more assistant prose after the token line.
+          TEXT
+        )
+
+        expect(tokens).to be_nil
       end
 
       it "parses history footer token counters after a blank-line separator" do

--- a/spec/agent_harness/providers/provider_runtime_integration_spec.rb
+++ b/spec/agent_harness/providers/provider_runtime_integration_spec.rb
@@ -513,4 +513,31 @@ RSpec.describe "ProviderRuntime integration" do
       )
     end
   end
+
+  describe AgentHarness::Providers::Aider do
+    let(:provider) { described_class.new(executor: mock_executor) }
+
+    include_examples "runtime env passthrough"
+    include_examples "runtime hash coercion"
+
+    it "appends runtime flags without dropping the llm history flag" do
+      runtime = AgentHarness::ProviderRuntime.new(flags: ["--map-tokens", "0"])
+
+      expect(mock_executor).to receive(:execute).with(
+        array_including("aider", "--yes", "--llm-history-file", "--map-tokens", "0", "--message", "Hello"),
+        anything
+      ).and_return(success_result)
+
+      provider.send_message(prompt: "Hello", provider_runtime: runtime)
+    end
+
+    it "sets model on response from runtime when config model is nil" do
+      runtime = AgentHarness::ProviderRuntime.new(model: "gpt-5-turbo")
+
+      allow(mock_executor).to receive(:execute).and_return(success_result)
+
+      response = provider.send_message(prompt: "Hello", provider_runtime: runtime)
+      expect(response.model).to eq("gpt-5-turbo")
+    end
+  end
 end

--- a/spec/agent_harness/providers/provider_runtime_integration_spec.rb
+++ b/spec/agent_harness/providers/provider_runtime_integration_spec.rb
@@ -531,6 +531,19 @@ RSpec.describe "ProviderRuntime integration" do
       provider.send_message(prompt: "Hello", provider_runtime: runtime)
     end
 
+    it "rejects runtime flags that try to override llm history output" do
+      runtime = AgentHarness::ProviderRuntime.new(flags: ["--llm-history-file", "/tmp/override.log"])
+
+      expect(mock_executor).not_to receive(:execute)
+
+      expect {
+        provider.send_message(prompt: "Hello", provider_runtime: runtime)
+      }.to raise_error(
+        AgentHarness::ProviderError,
+        /provider-managed flags: --llm-history-file \/tmp\/override\.log/
+      )
+    end
+
     it "sets model on response from runtime when config model is nil" do
       runtime = AgentHarness::ProviderRuntime.new(model: "gpt-5-turbo")
 


### PR DESCRIPTION
## Summary

feat(aider): extract token usage via --llm-history-file

See #100 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #100