### PR TITLE
Fix #101: [P2] codex: return AuthenticationError for refresh_token_reused and similar OAuth refresh failures

### DIFF
--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -191,7 +191,7 @@ module AgentHarness
           rate_limited: COMMON_ERROR_PATTERNS[:rate_limited],
           timeout: [
             /your access token could not be refreshed.*(?:timeout|timed.?out)/i,
-            /failed to refresh token:.*(?:timeout|timed.?out)/i
+            /failed to refresh token\b.*(?:timeout|timed.?out)/i
           ],
           transient: COMMON_ERROR_PATTERNS[:transient] + [
             /connection.*reset/i

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -172,7 +172,14 @@ module AgentHarness
 
       def error_patterns
         COMMON_ERROR_PATTERNS.merge(
-          auth_expired: COMMON_ERROR_PATTERNS[:auth_expired] + [/\b401\b/, /incorrect.*api.*key/i],
+          auth_expired: COMMON_ERROR_PATTERNS[:auth_expired] + [
+            /\b401\b/,
+            /incorrect.*api.*key/i,
+            /refresh_token_reused/i,
+            /failed to refresh token/i,
+            /please log out and sign in again/i,
+            /your access token could not be refreshed/i
+          ],
           transient: COMMON_ERROR_PATTERNS[:transient] + [/connection.*reset/i],
           sandbox_failure: [
             /bwrap.*no permissions/i,

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -20,6 +20,12 @@ module AgentHarness
         /your access token could not be refreshed because your refresh token .*already (?:been )?used/i,
         /refresh token .*already been used/i
       ].freeze
+      OAUTH_REFRESH_TRANSIENT_PATTERNS = [
+        /your access token could not be refreshed because the auth(?:entication)? service was unavailable/i,
+        /your access token could not be refreshed because .*connection.*error/i,
+        /failed to refresh token:.*connection.*error/i,
+        /failed to refresh token:.*service.*unavailable/i
+      ].freeze
 
       class << self
         def provider_name
@@ -187,18 +193,14 @@ module AgentHarness
             /your access token could not be refreshed.*(?:timeout|timed out)/i,
             /failed to refresh token:.*(?:timeout|timed out)/i
           ],
+          transient: COMMON_ERROR_PATTERNS[:transient] + [
+            /connection.*reset/i
+          ] + OAUTH_REFRESH_TRANSIENT_PATTERNS,
           auth_expired: COMMON_ERROR_PATTERNS[:auth_expired] + [
             /\b401\b/,
             /incorrect.*api.*key/i
           ] + OAUTH_REFRESH_FAILURE_PATTERNS,
           quota_exceeded: COMMON_ERROR_PATTERNS[:quota_exceeded],
-          transient: COMMON_ERROR_PATTERNS[:transient] + [
-            /connection.*reset/i,
-            /your access token could not be refreshed because .*connection.*error/i,
-            /your access token could not be refreshed because .*service.*unavailable/i,
-            /failed to refresh token:.*connection.*error/i,
-            /failed to refresh token:.*service.*unavailable/i
-          ],
           sandbox_failure: [
             /bwrap.*no permissions/i,
             /no permissions to create a new namespace/i,

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -17,6 +17,11 @@ module AgentHarness
         /failed to refresh token\b.*\binvalid_client\b/im,
         /failed to refresh token\b.*\binvalid_grant\b/im,
         /failed to refresh token\b.*invalid.*refresh.*token/im,
+        /your access token could not be refreshed because\b.*\b401\b/im,
+        /your access token could not be refreshed because\b.*unauthorized/im,
+        /your access token could not be refreshed because\b.*\binvalid_client\b/im,
+        /your access token could not be refreshed because\b.*\binvalid_grant\b/im,
+        /your access token could not be refreshed because\b.*invalid.*refresh.*token/im,
         /your access token could not be refreshed because\s+your refresh token .*already (?:been )?used/im,
         /refresh token .*already (?:been )?used/im
       ].freeze

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -17,11 +17,13 @@ module AgentHarness
         /failed to refresh token\b.*\binvalid_client\b/im,
         /failed to refresh token\b.*\binvalid_grant\b/im,
         /failed to refresh token\b.*invalid.*refresh.*token/im,
+        /failed to refresh token\b.*refresh.*token.*invalid/im,
         /your access token could not be refreshed because\b.*\b401\b/im,
         /your access token could not be refreshed because\b.*unauthorized/im,
         /your access token could not be refreshed because\b.*\binvalid_client\b/im,
         /your access token could not be refreshed because\b.*\binvalid_grant\b/im,
         /your access token could not be refreshed because\b.*invalid.*refresh.*token/im,
+        /your access token could not be refreshed because\b.*refresh.*token.*invalid/im,
         /your access token could not be refreshed because\s+your refresh token .*already (?:been )?used/im,
         /refresh token .*already (?:been )?used/im
       ].freeze

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -21,7 +21,7 @@ module AgentHarness
         /refresh token .*already been used/i
       ].freeze
       OAUTH_REFRESH_TRANSIENT_PATTERNS = [
-        /your access token could not be refreshed because the auth(?:entication)? service(?:\s+(?:is|was))?\s+unavailable/i,
+        /your access token could not be refreshed because (?:the )?auth(?:entication)? service(?:\s+(?:is|was))?\s+unavailable/i,
         /your access token could not be refreshed because .*connection.*error/i,
         /failed to refresh token:.*connection.*error/i,
         /failed to refresh token:.*service(?:\s+(?:is|was))?\s+unavailable/i

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -17,12 +17,12 @@ module AgentHarness
         /failed to refresh token\b.*\binvalid_client\b/im,
         /failed to refresh token\b.*\binvalid_grant\b/im,
         /failed to refresh token\b.*invalid.*refresh.*token/im,
-        /your access token could not be refreshed because your refresh token .*already (?:been )?used/i,
-        /refresh token .*already (?:been )?used/i
+        /your access token could not be refreshed because\s+your refresh token .*already (?:been )?used/im,
+        /refresh token .*already (?:been )?used/im
       ].freeze
       OAUTH_REFRESH_TRANSIENT_PATTERNS = [
-        /your access token could not be refreshed because (?:the )?auth(?:entication)? service(?:\s+(?:is|was))?\s+unavailable/i,
-        /your access token could not be refreshed because .*connection.*error/i,
+        /your access token could not be refreshed because\s+(?:the\s+)?auth(?:entication)? service(?:\s+(?:is|was))?\s+unavailable/im,
+        /your access token could not be refreshed because .*connection.*error/im,
         /failed to refresh token:.*connection.*error/im,
         /failed to refresh token\b.*service(?:\s+(?:is|was))?\s+unavailable/im
       ].freeze
@@ -190,7 +190,7 @@ module AgentHarness
         {
           rate_limited: COMMON_ERROR_PATTERNS[:rate_limited],
           timeout: [
-            /your access token could not be refreshed.*(?:timeout|timed.?out)/i,
+            /your access token could not be refreshed.*(?:timeout|timed.?out)/im,
             /failed to refresh token\b.*(?:timeout|timed.?out)/im
           ],
           transient: COMMON_ERROR_PATTERNS[:transient] + [

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -12,11 +12,11 @@ module AgentHarness
       SUPPORTED_CLI_REQUIREMENT = Gem::Requirement.new(">= #{SUPPORTED_CLI_VERSION}", "< 0.117.0").freeze
       OAUTH_REFRESH_FAILURE_PATTERNS = [
         /refresh_token_reused/i,
-        /failed to refresh token:.*\b401\b/i,
-        /failed to refresh token:.*unauthorized/i,
-        /failed to refresh token:.*invalid_client/i,
-        /failed to refresh token:.*invalid_grant/i,
-        /failed to refresh token:.*invalid.*refresh.*token/i,
+        /failed to refresh token\b.*\b401\b/i,
+        /failed to refresh token\b.*unauthorized/i,
+        /failed to refresh token\b.*invalid_client/i,
+        /failed to refresh token\b.*invalid_grant/i,
+        /failed to refresh token\b.*invalid.*refresh.*token/i,
         /your access token could not be refreshed because your refresh token .*already (?:been )?used/i,
         /refresh token .*already (?:been )?used/i
       ].freeze

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -14,11 +14,11 @@ module AgentHarness
         /refresh_token_reused/i,
         /failed to refresh token:.*\b401\b/i,
         /failed to refresh token:.*unauthorized/i,
+        /failed to refresh token:.*invalid_client/i,
         /failed to refresh token:.*invalid_grant/i,
         /failed to refresh token:.*invalid.*refresh.*token/i,
         /your access token could not be refreshed/i,
-        /refresh token .*already been used/i,
-        /please log out and sign in again/i
+        /refresh token .*already been used/i
       ].freeze
 
       class << self

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -24,7 +24,7 @@ module AgentHarness
         /your access token could not be refreshed because (?:the )?auth(?:entication)? service(?:\s+(?:is|was))?\s+unavailable/i,
         /your access token could not be refreshed because .*connection.*error/i,
         /failed to refresh token:.*connection.*error/i,
-        /failed to refresh token:.*service(?:\s+(?:is|was))?\s+unavailable/i
+        /failed to refresh token\b.*service(?:\s+(?:is|was))?\s+unavailable/i
       ].freeze
 
       class << self

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -18,7 +18,7 @@ module AgentHarness
         /failed to refresh token:.*invalid_grant/i,
         /failed to refresh token:.*invalid.*refresh.*token/i,
         /your access token could not be refreshed because your refresh token .*already (?:been )?used/i,
-        /refresh token .*already been used/i
+        /refresh token .*already (?:been )?used/i
       ].freeze
       OAUTH_REFRESH_TRANSIENT_PATTERNS = [
         /your access token could not be refreshed because (?:the )?auth(?:entication)? service(?:\s+(?:is|was))?\s+unavailable/i,

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -194,6 +194,8 @@ module AgentHarness
           quota_exceeded: COMMON_ERROR_PATTERNS[:quota_exceeded],
           transient: COMMON_ERROR_PATTERNS[:transient] + [
             /connection.*reset/i,
+            /your access token could not be refreshed because .*connection.*error/i,
+            /your access token could not be refreshed because .*service.*unavailable/i,
             /failed to refresh token:.*connection.*error/i,
             /failed to refresh token:.*service.*unavailable/i
           ],

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -17,7 +17,7 @@ module AgentHarness
         /failed to refresh token:.*invalid_client/i,
         /failed to refresh token:.*invalid_grant/i,
         /failed to refresh token:.*invalid.*refresh.*token/i,
-        /your access token could not be refreshed/i,
+        /your access token could not be refreshed because your refresh token .*already (?:been )?used/i,
         /refresh token .*already been used/i
       ].freeze
 
@@ -181,14 +181,19 @@ module AgentHarness
       end
 
       def error_patterns
-        COMMON_ERROR_PATTERNS.merge(
+        {
+          rate_limited: COMMON_ERROR_PATTERNS[:rate_limited],
+          timeout: [
+            /your access token could not be refreshed.*(?:timeout|timed out)/i,
+            /failed to refresh token:.*(?:timeout|timed out)/i
+          ],
           auth_expired: COMMON_ERROR_PATTERNS[:auth_expired] + [
             /\b401\b/,
             /incorrect.*api.*key/i
           ] + OAUTH_REFRESH_FAILURE_PATTERNS,
+          quota_exceeded: COMMON_ERROR_PATTERNS[:quota_exceeded],
           transient: COMMON_ERROR_PATTERNS[:transient] + [
             /connection.*reset/i,
-            /failed to refresh token:.*(?:timeout|timed out)/i,
             /failed to refresh token:.*connection.*error/i,
             /failed to refresh token:.*service.*unavailable/i
           ],
@@ -197,7 +202,7 @@ module AgentHarness
             /no permissions to create a new namespace/i,
             /unprivileged.*namespace/i
           ]
-        )
+        }
       end
 
       def auth_status

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -21,10 +21,10 @@ module AgentHarness
         /refresh token .*already been used/i
       ].freeze
       OAUTH_REFRESH_TRANSIENT_PATTERNS = [
-        /your access token could not be refreshed because the auth(?:entication)? service was unavailable/i,
+        /your access token could not be refreshed because the auth(?:entication)? service(?:\s+(?:is|was))?\s+unavailable/i,
         /your access token could not be refreshed because .*connection.*error/i,
         /failed to refresh token:.*connection.*error/i,
-        /failed to refresh token:.*service.*unavailable/i
+        /failed to refresh token:.*service(?:\s+(?:is|was))?\s+unavailable/i
       ].freeze
 
       class << self

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -190,8 +190,8 @@ module AgentHarness
         {
           rate_limited: COMMON_ERROR_PATTERNS[:rate_limited],
           timeout: [
-            /your access token could not be refreshed.*(?:timeout|timed out)/i,
-            /failed to refresh token:.*(?:timeout|timed out)/i
+            /your access token could not be refreshed.*(?:timeout|timed.?out)/i,
+            /failed to refresh token:.*(?:timeout|timed.?out)/i
           ],
           transient: COMMON_ERROR_PATTERNS[:transient] + [
             /connection.*reset/i

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -28,7 +28,7 @@ module AgentHarness
       OAUTH_REFRESH_TRANSIENT_PATTERNS = [
         /your access token could not be refreshed because\s+(?:the\s+)?auth(?:entication)? service(?:\s+(?:is|was))?\s+unavailable/im,
         /your access token could not be refreshed because .*connection.*error/im,
-        /failed to refresh token:.*connection.*error/im,
+        /failed to refresh token\b.*connection.*error/im,
         /failed to refresh token\b.*service(?:\s+(?:is|was))?\s+unavailable/im
       ].freeze
 

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -12,11 +12,11 @@ module AgentHarness
       SUPPORTED_CLI_REQUIREMENT = Gem::Requirement.new(">= #{SUPPORTED_CLI_VERSION}", "< 0.117.0").freeze
       OAUTH_REFRESH_FAILURE_PATTERNS = [
         /refresh_token_reused/i,
-        /failed to refresh token\b.*\b401\b/i,
-        /failed to refresh token\b.*unauthorized/i,
-        /failed to refresh token\b.*invalid_client/i,
-        /failed to refresh token\b.*invalid_grant/i,
-        /failed to refresh token\b.*invalid.*refresh.*token/i,
+        /failed to refresh token\b.*\b401\b/im,
+        /failed to refresh token\b.*unauthorized/im,
+        /failed to refresh token\b.*\binvalid_client\b/im,
+        /failed to refresh token\b.*\binvalid_grant\b/im,
+        /failed to refresh token\b.*invalid.*refresh.*token/im,
         /your access token could not be refreshed because your refresh token .*already (?:been )?used/i,
         /refresh token .*already (?:been )?used/i
       ].freeze

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -23,8 +23,8 @@ module AgentHarness
       OAUTH_REFRESH_TRANSIENT_PATTERNS = [
         /your access token could not be refreshed because (?:the )?auth(?:entication)? service(?:\s+(?:is|was))?\s+unavailable/i,
         /your access token could not be refreshed because .*connection.*error/i,
-        /failed to refresh token:.*connection.*error/i,
-        /failed to refresh token\b.*service(?:\s+(?:is|was))?\s+unavailable/i
+        /failed to refresh token:.*connection.*error/im,
+        /failed to refresh token\b.*service(?:\s+(?:is|was))?\s+unavailable/im
       ].freeze
 
       class << self
@@ -191,7 +191,7 @@ module AgentHarness
           rate_limited: COMMON_ERROR_PATTERNS[:rate_limited],
           timeout: [
             /your access token could not be refreshed.*(?:timeout|timed.?out)/i,
-            /failed to refresh token\b.*(?:timeout|timed.?out)/i
+            /failed to refresh token\b.*(?:timeout|timed.?out)/im
           ],
           transient: COMMON_ERROR_PATTERNS[:transient] + [
             /connection.*reset/i

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -26,10 +26,10 @@ module AgentHarness
         /refresh token .*already (?:been )?used/im
       ].freeze
       OAUTH_REFRESH_TRANSIENT_PATTERNS = [
-        /your access token could not be refreshed because\s+(?:the\s+)?auth(?:entication)? service(?:\s+(?:is|was))?\s+unavailable/im,
+        /your access token could not be refreshed because\s+(?:the\s+)?auth(?:entication)? service(?:\s+(?:is|was))?\s+(?:temporarily\s+)?unavailable/im,
         /your access token could not be refreshed because .*connection.*error/im,
         /failed to refresh token\b.*connection.*error/im,
-        /failed to refresh token\b.*service(?:\s+(?:is|was))?\s+unavailable/im
+        /failed to refresh token\b.*service(?:\s+(?:is|was))?\s+(?:temporarily\s+)?unavailable/im
       ].freeze
 
       class << self

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -10,6 +10,16 @@ module AgentHarness
     class Codex < Base
       SUPPORTED_CLI_VERSION = "0.116.0"
       SUPPORTED_CLI_REQUIREMENT = Gem::Requirement.new(">= #{SUPPORTED_CLI_VERSION}", "< 0.117.0").freeze
+      OAUTH_REFRESH_FAILURE_PATTERNS = [
+        /refresh_token_reused/i,
+        /failed to refresh token:.*\b401\b/i,
+        /failed to refresh token:.*unauthorized/i,
+        /failed to refresh token:.*invalid_grant/i,
+        /failed to refresh token:.*invalid.*refresh.*token/i,
+        /your access token could not be refreshed/i,
+        /refresh token .*already been used/i,
+        /please log out and sign in again/i
+      ].freeze
 
       class << self
         def provider_name
@@ -174,13 +184,14 @@ module AgentHarness
         COMMON_ERROR_PATTERNS.merge(
           auth_expired: COMMON_ERROR_PATTERNS[:auth_expired] + [
             /\b401\b/,
-            /incorrect.*api.*key/i,
-            /refresh_token_reused/i,
-            /failed to refresh token/i,
-            /please log out and sign in again/i,
-            /your access token could not be refreshed/i
+            /incorrect.*api.*key/i
+          ] + OAUTH_REFRESH_FAILURE_PATTERNS,
+          transient: COMMON_ERROR_PATTERNS[:transient] + [
+            /connection.*reset/i,
+            /failed to refresh token:.*(?:timeout|timed out)/i,
+            /failed to refresh token:.*connection.*error/i,
+            /failed to refresh token:.*service.*unavailable/i
           ],
-          transient: COMMON_ERROR_PATTERNS[:transient] + [/connection.*reset/i],
           sandbox_failure: [
             /bwrap.*no permissions/i,
             /no permissions to create a new namespace/i,

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -344,6 +344,16 @@ RSpec.describe AgentHarness::Providers::Codex do
         end
       end
 
+      it "raises AuthenticationError for failed-refresh OAuth invalid_grant failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new("Failed to refresh token because invalid_grant")
+        )
+
+        expect { provider.send_message(prompt: "Hello") }.to raise_error(AgentHarness::AuthenticationError) do |error|
+          expect(error.provider).to eq(:codex)
+        end
+      end
+
       it "does not raise AuthenticationError for transient OAuth refresh failures" do
         allow(mock_executor).to receive(:execute).and_raise(
           StandardError.new(
@@ -608,6 +618,13 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:auth_expired)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new("Failed to refresh token because invalid_grant"),
+            patterns
+          )
+        ).to eq(:auth_expired)
       end
 
       it "does not classify transient refresh failures as auth_expired" do
@@ -729,6 +746,22 @@ RSpec.describe AgentHarness::Providers::Codex do
               "code": "refresh_token_reused"
               Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.
             ERROR
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:auth_expired)
+      end
+
+      it "normalizes failed-refresh OAuth invalid_grant failures to auth_expired" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: "Failed to refresh token because invalid_grant",
             exit_code: 1,
             duration: 1.0
           )

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -345,6 +345,17 @@ RSpec.describe AgentHarness::Providers::Codex do
           .to raise_error(AgentHarness::ProviderError, /auth service was unavailable/)
       end
 
+      it "raises TimeoutError for OAuth refresh timeout failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(
+            "Your access token could not be refreshed because the auth service timed out."
+          )
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::TimeoutError, /auth service timed out/)
+      end
+
       context "with dangerous_mode option" do
         it "includes --full-auto flag" do
           expect(mock_executor).to receive(:execute).with(
@@ -593,6 +604,22 @@ RSpec.describe AgentHarness::Providers::Codex do
 
         expect(result[:ok]).to be false
         expect(result[:error_category]).to eq(:transient)
+      end
+
+      it "classifies OAuth refresh timeout failures as timeout" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: "Your access token could not be refreshed because the auth service timed out.",
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:timeout)
       end
     end
 

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -510,6 +510,15 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:transient)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(
+              "Your access token could not be refreshed because the auth service was unavailable."
+            ),
+            patterns
+          )
+        ).to eq(:transient)
       end
 
       it "does not classify generic re-login prompts as refresh auth failures" do

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -437,6 +437,17 @@ RSpec.describe AgentHarness::Providers::Codex do
           .to raise_error(AgentHarness::ProviderError, /authentication service is unavailable/)
       end
 
+      it "does not raise AuthenticationError for temporarily unavailable authentication service refresh failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(
+            "Your access token could not be refreshed because the authentication service was temporarily unavailable."
+          )
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::ProviderError, /authentication service was temporarily unavailable/)
+      end
+
       it "does not raise AuthenticationError for multiline access-token authentication service refresh failures" do
         allow(mock_executor).to receive(:execute).and_raise(
           StandardError.new(<<~ERROR)
@@ -470,6 +481,17 @@ RSpec.describe AgentHarness::Providers::Codex do
 
         expect { provider.send_message(prompt: "Hello") }
           .to raise_error(AgentHarness::ProviderError, /authentication service was unavailable/)
+      end
+
+      it "does not raise AuthenticationError for failed-refresh temporarily unavailable failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(
+            "Failed to refresh token because the authentication service was temporarily unavailable."
+          )
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::ProviderError, /authentication service was temporarily unavailable/)
       end
 
       it "does not raise AuthenticationError for failed-refresh connection error failures" do
@@ -804,7 +826,25 @@ RSpec.describe AgentHarness::Providers::Codex do
         expect(
           AgentHarness::ErrorTaxonomy.classify(
             StandardError.new(
+              "Your access token could not be refreshed because the authentication service was temporarily unavailable."
+            ),
+            patterns
+          )
+        ).to eq(:transient)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(
               "Failed to refresh token because the authentication service was unavailable."
+            ),
+            patterns
+          )
+        ).to eq(:transient)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(
+              "Failed to refresh token because the authentication service was temporarily unavailable."
             ),
             patterns
           )
@@ -1071,6 +1111,22 @@ RSpec.describe AgentHarness::Providers::Codex do
         expect(result[:error_category]).to eq(:transient)
       end
 
+      it "keeps temporarily unavailable authentication service refresh failures retryable" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: "Your access token could not be refreshed because the authentication service was temporarily unavailable.",
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:transient)
+      end
+
       it "keeps multiline access-token authentication service refresh failures retryable" do
         allow(mock_executor).to receive(:execute).and_return(
           AgentHarness::CommandExecutor::Result.new(
@@ -1114,6 +1170,22 @@ RSpec.describe AgentHarness::Providers::Codex do
               Failed to refresh token:
               the authentication service was unavailable.
             ERROR
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:transient)
+      end
+
+      it "keeps failed-refresh temporarily unavailable failures retryable" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: "Failed to refresh token because the authentication service was temporarily unavailable.",
             exit_code: 1,
             duration: 1.0
           )

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -319,6 +319,21 @@ RSpec.describe AgentHarness::Providers::Codex do
         expect(response.output).to eq("response output")
       end
 
+      it "raises AuthenticationError for OAuth refresh token reuse failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(<<~ERROR)
+            Failed to refresh token: 401 Unauthorized
+            "message": "Your refresh token has already been used to generate a new access token. Please try signing in again."
+            "code": "refresh_token_reused"
+            Failed to refresh token: Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.
+          ERROR
+        )
+
+        expect { provider.send_message(prompt: "Hello") }.to raise_error(AgentHarness::AuthenticationError) do |error|
+          expect(error.provider).to eq(:codex)
+        end
+      end
+
       context "with dangerous_mode option" do
         it "includes --full-auto flag" do
           expect(mock_executor).to receive(:execute).with(
@@ -457,6 +472,49 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:unknown)
+      end
+
+      it "classifies OAuth refresh failures as auth_expired" do
+        patterns = provider.error_patterns
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new('Failed to refresh token: "code": "refresh_token_reused"'),
+            patterns
+          )
+        ).to eq(:auth_expired)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new("Your access token could not be refreshed. Please log out and sign in again."),
+            patterns
+          )
+        ).to eq(:auth_expired)
+      end
+    end
+
+    describe "#smoke_test" do
+      let(:mock_executor) { instance_double(AgentHarness::CommandExecutor) }
+      subject(:provider) { described_class.new(executor: mock_executor) }
+
+      it "normalizes OAuth refresh failures to auth_expired" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: <<~ERROR,
+              Failed to refresh token: 401 Unauthorized
+              "code": "refresh_token_reused"
+              Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.
+            ERROR
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:auth_expired)
       end
     end
 

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -367,6 +367,17 @@ RSpec.describe AgentHarness::Providers::Codex do
           .to raise_error(AgentHarness::TimeoutError, /auth service timed out/)
       end
 
+      it "raises TimeoutError for authentication service refresh timeout failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(
+            "Your access token could not be refreshed because the authentication service timed out."
+          )
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::TimeoutError, /authentication service timed out/)
+      end
+
       context "with dangerous_mode option" do
         it "includes --full-auto flag" do
           expect(mock_executor).to receive(:execute).with(
@@ -583,6 +594,15 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:timeout)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(
+              "Your access token could not be refreshed because the authentication service timed out."
+            ),
+            patterns
+          )
+        ).to eq(:timeout)
       end
     end
 
@@ -647,6 +667,22 @@ RSpec.describe AgentHarness::Providers::Codex do
           AgentHarness::CommandExecutor::Result.new(
             stdout: "",
             stderr: "Your access token could not be refreshed because the auth service timed out.",
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:timeout)
+      end
+
+      it "classifies authentication service refresh timeout failures as timeout" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: "Your access token could not be refreshed because the authentication service timed out.",
             exit_code: 1,
             duration: 1.0
           )

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -486,7 +486,9 @@ RSpec.describe AgentHarness::Providers::Codex do
 
         expect(
           AgentHarness::ErrorTaxonomy.classify(
-            StandardError.new("Your access token could not be refreshed. Please log out and sign in again."),
+            StandardError.new(
+              "Your access token could not be refreshed because your refresh token has already been used. Please log out and sign in again."
+            ),
             patterns
           )
         ).to eq(:auth_expired)
@@ -519,6 +521,17 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:unknown)
+      end
+
+      it "does not classify non-auth refresh failures as auth_expired" do
+        patterns = provider.error_patterns
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new("Your access token could not be refreshed because the auth service timed out."),
+            patterns
+          )
+        ).to eq(:timeout)
       end
     end
 

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -472,6 +472,17 @@ RSpec.describe AgentHarness::Providers::Codex do
           .to raise_error(AgentHarness::ProviderError, /authentication service was unavailable/)
       end
 
+      it "does not raise AuthenticationError for failed-refresh connection error failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(
+            "Failed to refresh token because connection error while contacting oauth endpoint."
+          )
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::ProviderError, /connection error while contacting oauth endpoint/)
+      end
+
       it "raises TimeoutError for OAuth refresh timeout failures" do
         allow(mock_executor).to receive(:execute).and_raise(
           StandardError.new(
@@ -801,6 +812,15 @@ RSpec.describe AgentHarness::Providers::Codex do
 
         expect(
           AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(
+              "Failed to refresh token because connection error while contacting oauth endpoint."
+            ),
+            patterns
+          )
+        ).to eq(:transient)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
             StandardError.new(<<~ERROR),
               Failed to refresh token:
               the authentication service was unavailable.
@@ -1094,6 +1114,22 @@ RSpec.describe AgentHarness::Providers::Codex do
               Failed to refresh token:
               the authentication service was unavailable.
             ERROR
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:transient)
+      end
+
+      it "keeps failed-refresh connection error failures retryable" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: "Failed to refresh token because connection error while contacting oauth endpoint.",
             exit_code: 1,
             duration: 1.0
           )

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -388,6 +388,17 @@ RSpec.describe AgentHarness::Providers::Codex do
           .to raise_error(AgentHarness::ProviderError, /authentication service is unavailable/)
       end
 
+      it "does not raise AuthenticationError for failed-refresh authentication service unavailable failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(
+            "Failed to refresh token because the authentication service was unavailable."
+          )
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::ProviderError, /authentication service was unavailable/)
+      end
+
       it "raises TimeoutError for OAuth refresh timeout failures" do
         allow(mock_executor).to receive(:execute).and_raise(
           StandardError.new(
@@ -644,6 +655,15 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:transient)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(
+              "Failed to refresh token because the authentication service was unavailable."
+            ),
+            patterns
+          )
+        ).to eq(:transient)
       end
 
       it "does not classify generic re-login prompts as refresh auth failures" do
@@ -773,6 +793,22 @@ RSpec.describe AgentHarness::Providers::Codex do
           AgentHarness::CommandExecutor::Result.new(
             stdout: "",
             stderr: "Your access token could not be refreshed because the authentication service is unavailable.",
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:transient)
+      end
+
+      it "keeps failed-refresh authentication service unavailable failures retryable" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: "Failed to refresh token because the authentication service was unavailable.",
             exit_code: 1,
             duration: 1.0
           )

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -354,6 +354,19 @@ RSpec.describe AgentHarness::Providers::Codex do
         end
       end
 
+      it "raises AuthenticationError for multiline failed-refresh OAuth invalid_client failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(<<~ERROR)
+            Failed to refresh token:
+            "code": "invalid_client"
+          ERROR
+        )
+
+        expect { provider.send_message(prompt: "Hello") }.to raise_error(AgentHarness::AuthenticationError) do |error|
+          expect(error.provider).to eq(:codex)
+        end
+      end
+
       it "does not raise AuthenticationError for transient OAuth refresh failures" do
         allow(mock_executor).to receive(:execute).and_raise(
           StandardError.new(
@@ -625,6 +638,16 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:auth_expired)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(<<~ERROR),
+              Failed to refresh token:
+              "code": "invalid_grant"
+            ERROR
+            patterns
+          )
+        ).to eq(:auth_expired)
       end
 
       it "does not classify transient refresh failures as auth_expired" do
@@ -762,6 +785,25 @@ RSpec.describe AgentHarness::Providers::Codex do
           AgentHarness::CommandExecutor::Result.new(
             stdout: "",
             stderr: "Failed to refresh token because invalid_grant",
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:auth_expired)
+      end
+
+      it "normalizes multiline failed-refresh OAuth invalid_client failures to auth_expired" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: <<~ERROR,
+              Failed to refresh token:
+              "code": "invalid_client"
+            ERROR
             exit_code: 1,
             duration: 1.0
           )

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -421,6 +421,17 @@ RSpec.describe AgentHarness::Providers::Codex do
           .to raise_error(AgentHarness::TimeoutError, /authentication service timed-out/)
       end
 
+      it "raises TimeoutError for failed-refresh authentication service timeout failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(
+            "Failed to refresh token because the authentication service timed out."
+          )
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::TimeoutError, /authentication service timed out/)
+      end
+
       context "with dangerous_mode option" do
         it "includes --full-auto flag" do
           expect(mock_executor).to receive(:execute).with(
@@ -673,6 +684,15 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:timeout)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(
+              "Failed to refresh token because the authentication service timed out."
+            ),
+            patterns
+          )
+        ).to eq(:timeout)
       end
     end
 
@@ -801,6 +821,22 @@ RSpec.describe AgentHarness::Providers::Codex do
           AgentHarness::CommandExecutor::Result.new(
             stdout: "",
             stderr: "Your access token could not be refreshed because the authentication service timed-out.",
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:timeout)
+      end
+
+      it "classifies failed-refresh authentication service timeout failures as timeout" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: "Failed to refresh token because the authentication service timed out.",
             exit_code: 1,
             duration: 1.0
           )

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -356,6 +356,17 @@ RSpec.describe AgentHarness::Providers::Codex do
           .to raise_error(AgentHarness::ProviderError, /authentication service was unavailable/)
       end
 
+      it "does not raise AuthenticationError for no-article authentication service refresh failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(
+            "Your access token could not be refreshed because authentication service was unavailable."
+          )
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::ProviderError, /authentication service was unavailable/)
+      end
+
       it "does not raise AuthenticationError for authentication service is-unavailable refresh failures" do
         allow(mock_executor).to receive(:execute).and_raise(
           StandardError.new(
@@ -587,6 +598,15 @@ RSpec.describe AgentHarness::Providers::Codex do
         expect(
           AgentHarness::ErrorTaxonomy.classify(
             StandardError.new(
+              "Your access token could not be refreshed because authentication service was unavailable."
+            ),
+            patterns
+          )
+        ).to eq(:transient)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(
               "Your access token could not be refreshed because the authentication service is unavailable."
             ),
             patterns
@@ -671,6 +691,22 @@ RSpec.describe AgentHarness::Providers::Codex do
           AgentHarness::CommandExecutor::Result.new(
             stdout: "",
             stderr: "Your access token could not be refreshed because the authentication service was unavailable.",
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:transient)
+      end
+
+      it "keeps no-article authentication service refresh failures retryable" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: "Your access token could not be refreshed because authentication service was unavailable.",
             exit_code: 1,
             duration: 1.0
           )

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -354,6 +354,16 @@ RSpec.describe AgentHarness::Providers::Codex do
         end
       end
 
+      it "raises AuthenticationError for failed-refresh invalid refresh token wording" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new("Failed to refresh token because refresh token is invalid.")
+        )
+
+        expect { provider.send_message(prompt: "Hello") }.to raise_error(AgentHarness::AuthenticationError) do |error|
+          expect(error.provider).to eq(:codex)
+        end
+      end
+
       it "raises AuthenticationError for multiline failed-refresh OAuth invalid_client failures" do
         allow(mock_executor).to receive(:execute).and_raise(
           StandardError.new(<<~ERROR)
@@ -386,6 +396,18 @@ RSpec.describe AgentHarness::Providers::Codex do
             Your access token could not be refreshed because
             invalid_grant
           ERROR
+        )
+
+        expect { provider.send_message(prompt: "Hello") }.to raise_error(AgentHarness::AuthenticationError) do |error|
+          expect(error.provider).to eq(:codex)
+        end
+      end
+
+      it "raises AuthenticationError for access-token invalid refresh token wording" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(
+            "Your access token could not be refreshed because your refresh token is invalid."
+          )
         )
 
         expect { provider.send_message(prompt: "Hello") }.to raise_error(AgentHarness::AuthenticationError) do |error|
@@ -748,6 +770,13 @@ RSpec.describe AgentHarness::Providers::Codex do
 
         expect(
           AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new("Failed to refresh token because refresh token is invalid."),
+            patterns
+          )
+        ).to eq(:auth_expired)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
             StandardError.new(<<~ERROR),
               Failed to refresh token:
               "code": "invalid_grant"
@@ -772,6 +801,15 @@ RSpec.describe AgentHarness::Providers::Codex do
               Your access token could not be refreshed because
               invalid_client
             ERROR
+            patterns
+          )
+        ).to eq(:auth_expired)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(
+              "Your access token could not be refreshed because your refresh token is invalid."
+            ),
             patterns
           )
         ).to eq(:auth_expired)
@@ -990,6 +1028,22 @@ RSpec.describe AgentHarness::Providers::Codex do
         expect(result[:error_category]).to eq(:auth_expired)
       end
 
+      it "normalizes failed-refresh invalid refresh token wording to auth_expired" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: "Failed to refresh token because refresh token is invalid.",
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:auth_expired)
+      end
+
       it "normalizes multiline failed-refresh OAuth invalid_client failures to auth_expired" do
         allow(mock_executor).to receive(:execute).and_return(
           AgentHarness::CommandExecutor::Result.new(
@@ -1036,6 +1090,22 @@ RSpec.describe AgentHarness::Providers::Codex do
               Your access token could not be refreshed because
               invalid_client
             ERROR
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:auth_expired)
+      end
+
+      it "normalizes access-token invalid refresh token wording to auth_expired" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: "Your access token could not be refreshed because your refresh token is invalid.",
             exit_code: 1,
             duration: 1.0
           )

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -334,6 +334,16 @@ RSpec.describe AgentHarness::Providers::Codex do
         end
       end
 
+      it "raises AuthenticationError for shorter OAuth refresh token reuse wording" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new("Failed to refresh token: refresh token already used")
+        )
+
+        expect { provider.send_message(prompt: "Hello") }.to raise_error(AgentHarness::AuthenticationError) do |error|
+          expect(error.provider).to eq(:codex)
+        end
+      end
+
       it "does not raise AuthenticationError for transient OAuth refresh failures" do
         allow(mock_executor).to receive(:execute).and_raise(
           StandardError.new(

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -345,6 +345,17 @@ RSpec.describe AgentHarness::Providers::Codex do
           .to raise_error(AgentHarness::ProviderError, /auth service was unavailable/)
       end
 
+      it "does not raise AuthenticationError for authentication service refresh failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(
+            "Your access token could not be refreshed because the authentication service was unavailable."
+          )
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::ProviderError, /authentication service was unavailable/)
+      end
+
       it "raises TimeoutError for OAuth refresh timeout failures" do
         allow(mock_executor).to receive(:execute).and_raise(
           StandardError.new(
@@ -541,6 +552,15 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:transient)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(
+              "Your access token could not be refreshed because the authentication service was unavailable."
+            ),
+            patterns
+          )
+        ).to eq(:transient)
       end
 
       it "does not classify generic re-login prompts as refresh auth failures" do
@@ -595,6 +615,22 @@ RSpec.describe AgentHarness::Providers::Codex do
           AgentHarness::CommandExecutor::Result.new(
             stdout: "",
             stderr: "Your access token could not be refreshed because the auth service was unavailable.",
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:transient)
+      end
+
+      it "keeps authentication service refresh failures retryable" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: "Your access token could not be refreshed because the authentication service was unavailable.",
             exit_code: 1,
             duration: 1.0
           )

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -367,6 +367,19 @@ RSpec.describe AgentHarness::Providers::Codex do
         end
       end
 
+      it "raises AuthenticationError for multiline access-token refresh reuse failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(<<~ERROR)
+            Your access token could not be refreshed because
+            your refresh token was already used. Please log out and sign in again.
+          ERROR
+        )
+
+        expect { provider.send_message(prompt: "Hello") }.to raise_error(AgentHarness::AuthenticationError) do |error|
+          expect(error.provider).to eq(:codex)
+        end
+      end
+
       it "does not raise AuthenticationError for transient OAuth refresh failures" do
         allow(mock_executor).to receive(:execute).and_raise(
           StandardError.new(
@@ -411,6 +424,18 @@ RSpec.describe AgentHarness::Providers::Codex do
           .to raise_error(AgentHarness::ProviderError, /authentication service is unavailable/)
       end
 
+      it "does not raise AuthenticationError for multiline access-token authentication service refresh failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(<<~ERROR)
+            Your access token could not be refreshed because
+            the authentication service was unavailable.
+          ERROR
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::ProviderError, /authentication service was unavailable/)
+      end
+
       it "does not raise AuthenticationError for failed-refresh authentication service unavailable failures" do
         allow(mock_executor).to receive(:execute).and_raise(
           StandardError.new(
@@ -450,6 +475,18 @@ RSpec.describe AgentHarness::Providers::Codex do
           StandardError.new(
             "Your access token could not be refreshed because the authentication service timed out."
           )
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::TimeoutError, /authentication service timed out/)
+      end
+
+      it "raises TimeoutError for multiline access-token authentication service timeout failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(<<~ERROR)
+            Your access token could not be refreshed because
+            the authentication service timed out.
+          ERROR
         )
 
         expect { provider.send_message(prompt: "Hello") }
@@ -672,6 +709,16 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:auth_expired)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(<<~ERROR),
+              Your access token could not be refreshed because
+              your refresh token was already used. Please log out and sign in again.
+            ERROR
+            patterns
+          )
+        ).to eq(:auth_expired)
       end
 
       it "does not classify transient refresh failures as auth_expired" do
@@ -738,6 +785,16 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:transient)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(<<~ERROR),
+              Your access token could not be refreshed because
+              the authentication service was unavailable.
+            ERROR
+            patterns
+          )
+        ).to eq(:transient)
       end
 
       it "does not classify generic re-login prompts as refresh auth failures" do
@@ -797,6 +854,16 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:timeout)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(<<~ERROR),
+              Your access token could not be refreshed because
+              the authentication service timed out.
+            ERROR
+            patterns
+          )
+        ).to eq(:timeout)
       end
     end
 
@@ -847,6 +914,25 @@ RSpec.describe AgentHarness::Providers::Codex do
             stderr: <<~ERROR,
               Failed to refresh token:
               "code": "invalid_client"
+            ERROR
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:auth_expired)
+      end
+
+      it "normalizes multiline access-token refresh reuse failures to auth_expired" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: <<~ERROR,
+              Your access token could not be refreshed because
+              your refresh token was already used. Please log out and sign in again.
             ERROR
             exit_code: 1,
             duration: 1.0
@@ -923,6 +1009,25 @@ RSpec.describe AgentHarness::Providers::Codex do
         expect(result[:error_category]).to eq(:transient)
       end
 
+      it "keeps multiline access-token authentication service refresh failures retryable" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: <<~ERROR,
+              Your access token could not be refreshed because
+              the authentication service was unavailable.
+            ERROR
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:transient)
+      end
+
       it "keeps failed-refresh authentication service unavailable failures retryable" do
         allow(mock_executor).to receive(:execute).and_return(
           AgentHarness::CommandExecutor::Result.new(
@@ -979,6 +1084,25 @@ RSpec.describe AgentHarness::Providers::Codex do
           AgentHarness::CommandExecutor::Result.new(
             stdout: "",
             stderr: "Your access token could not be refreshed because the authentication service timed out.",
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:timeout)
+      end
+
+      it "classifies multiline access-token authentication service timeout failures as timeout" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: <<~ERROR,
+              Your access token could not be refreshed because
+              the authentication service timed out.
+            ERROR
             exit_code: 1,
             duration: 1.0
           )

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -356,6 +356,17 @@ RSpec.describe AgentHarness::Providers::Codex do
           .to raise_error(AgentHarness::ProviderError, /authentication service was unavailable/)
       end
 
+      it "does not raise AuthenticationError for authentication service is-unavailable refresh failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(
+            "Your access token could not be refreshed because the authentication service is unavailable."
+          )
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::ProviderError, /authentication service is unavailable/)
+      end
+
       it "raises TimeoutError for OAuth refresh timeout failures" do
         allow(mock_executor).to receive(:execute).and_raise(
           StandardError.new(
@@ -572,6 +583,15 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:transient)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(
+              "Your access token could not be refreshed because the authentication service is unavailable."
+            ),
+            patterns
+          )
+        ).to eq(:transient)
       end
 
       it "does not classify generic re-login prompts as refresh auth failures" do
@@ -651,6 +671,22 @@ RSpec.describe AgentHarness::Providers::Codex do
           AgentHarness::CommandExecutor::Result.new(
             stdout: "",
             stderr: "Your access token could not be refreshed because the authentication service was unavailable.",
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:transient)
+      end
+
+      it "keeps authentication service is-unavailable refresh failures retryable" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: "Your access token could not be refreshed because the authentication service is unavailable.",
             exit_code: 1,
             duration: 1.0
           )

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -334,6 +334,17 @@ RSpec.describe AgentHarness::Providers::Codex do
         end
       end
 
+      it "does not raise AuthenticationError for transient OAuth refresh failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(
+            "Your access token could not be refreshed because the auth service was unavailable."
+          )
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::ProviderError, /auth service was unavailable/)
+      end
+
       context "with dangerous_mode option" do
         it "includes --full-auto flag" do
           expect(mock_executor).to receive(:execute).with(
@@ -566,6 +577,22 @@ RSpec.describe AgentHarness::Providers::Codex do
 
         expect(result[:ok]).to be false
         expect(result[:error_category]).to eq(:auth_expired)
+      end
+
+      it "keeps transient OAuth refresh failures retryable" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: "Your access token could not be refreshed because the auth service was unavailable.",
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:transient)
       end
     end
 

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -422,6 +422,18 @@ RSpec.describe AgentHarness::Providers::Codex do
           .to raise_error(AgentHarness::ProviderError, /authentication service was unavailable/)
       end
 
+      it "does not raise AuthenticationError for multiline failed-refresh authentication service unavailable failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(<<~ERROR)
+            Failed to refresh token:
+            the authentication service was unavailable.
+          ERROR
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::ProviderError, /authentication service was unavailable/)
+      end
+
       it "raises TimeoutError for OAuth refresh timeout failures" do
         allow(mock_executor).to receive(:execute).and_raise(
           StandardError.new(
@@ -438,6 +450,18 @@ RSpec.describe AgentHarness::Providers::Codex do
           StandardError.new(
             "Your access token could not be refreshed because the authentication service timed out."
           )
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::TimeoutError, /authentication service timed out/)
+      end
+
+      it "raises TimeoutError for multiline failed-refresh authentication service timeout failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(<<~ERROR)
+            Failed to refresh token:
+            the authentication service timed out.
+          ERROR
         )
 
         expect { provider.send_message(prompt: "Hello") }
@@ -704,6 +728,16 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:transient)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(<<~ERROR),
+              Failed to refresh token:
+              the authentication service was unavailable.
+            ERROR
+            patterns
+          )
+        ).to eq(:transient)
       end
 
       it "does not classify generic re-login prompts as refresh auth failures" do
@@ -750,6 +784,16 @@ RSpec.describe AgentHarness::Providers::Codex do
             StandardError.new(
               "Failed to refresh token because the authentication service timed out."
             ),
+            patterns
+          )
+        ).to eq(:timeout)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(<<~ERROR),
+              Failed to refresh token:
+              the authentication service timed out.
+            ERROR
             patterns
           )
         ).to eq(:timeout)
@@ -895,6 +939,25 @@ RSpec.describe AgentHarness::Providers::Codex do
         expect(result[:error_category]).to eq(:transient)
       end
 
+      it "keeps multiline failed-refresh authentication service unavailable failures retryable" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: <<~ERROR,
+              Failed to refresh token:
+              the authentication service was unavailable.
+            ERROR
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:transient)
+      end
+
       it "classifies OAuth refresh timeout failures as timeout" do
         allow(mock_executor).to receive(:execute).and_return(
           AgentHarness::CommandExecutor::Result.new(
@@ -948,6 +1011,25 @@ RSpec.describe AgentHarness::Providers::Codex do
           AgentHarness::CommandExecutor::Result.new(
             stdout: "",
             stderr: "Failed to refresh token because the authentication service timed out.",
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:timeout)
+      end
+
+      it "classifies multiline failed-refresh authentication service timeout failures as timeout" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: <<~ERROR,
+              Failed to refresh token:
+              the authentication service timed out.
+            ERROR
             exit_code: 1,
             duration: 1.0
           )

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -410,6 +410,17 @@ RSpec.describe AgentHarness::Providers::Codex do
           .to raise_error(AgentHarness::TimeoutError, /authentication service timed out/)
       end
 
+      it "raises TimeoutError for hyphenated authentication service refresh timeout failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(
+            "Your access token could not be refreshed because the authentication service timed-out."
+          )
+        )
+
+        expect { provider.send_message(prompt: "Hello") }
+          .to raise_error(AgentHarness::TimeoutError, /authentication service timed-out/)
+      end
+
       context "with dangerous_mode option" do
         it "includes --full-auto flag" do
           expect(mock_executor).to receive(:execute).with(
@@ -653,6 +664,15 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:timeout)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(
+              "Your access token could not be refreshed because the authentication service timed-out."
+            ),
+            patterns
+          )
+        ).to eq(:timeout)
       end
     end
 
@@ -765,6 +785,22 @@ RSpec.describe AgentHarness::Providers::Codex do
           AgentHarness::CommandExecutor::Result.new(
             stdout: "",
             stderr: "Your access token could not be refreshed because the authentication service timed out.",
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:timeout)
+      end
+
+      it "classifies hyphenated authentication service refresh timeout failures as timeout" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: "Your access token could not be refreshed because the authentication service timed-out.",
             exit_code: 1,
             duration: 1.0
           )

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -491,6 +491,17 @@ RSpec.describe AgentHarness::Providers::Codex do
           )
         ).to eq(:auth_expired)
       end
+
+      it "does not classify transient refresh failures as auth_expired" do
+        patterns = provider.error_patterns
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new("Failed to refresh token: connection error while contacting oauth endpoint"),
+            patterns
+          )
+        ).to eq(:transient)
+      end
     end
 
     describe "#smoke_test" do

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -490,6 +490,13 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:auth_expired)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new("Failed to refresh token: invalid_client"),
+            patterns
+          )
+        ).to eq(:auth_expired)
       end
 
       it "does not classify transient refresh failures as auth_expired" do
@@ -501,6 +508,17 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:transient)
+      end
+
+      it "does not classify generic re-login prompts as refresh auth failures" do
+        patterns = provider.error_patterns
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new("Please log out and sign in again."),
+            patterns
+          )
+        ).to eq(:unknown)
       end
     end
 

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -380,6 +380,19 @@ RSpec.describe AgentHarness::Providers::Codex do
         end
       end
 
+      it "raises AuthenticationError for multiline access-token OAuth invalid_grant failures" do
+        allow(mock_executor).to receive(:execute).and_raise(
+          StandardError.new(<<~ERROR)
+            Your access token could not be refreshed because
+            invalid_grant
+          ERROR
+        )
+
+        expect { provider.send_message(prompt: "Hello") }.to raise_error(AgentHarness::AuthenticationError) do |error|
+          expect(error.provider).to eq(:codex)
+        end
+      end
+
       it "does not raise AuthenticationError for transient OAuth refresh failures" do
         allow(mock_executor).to receive(:execute).and_raise(
           StandardError.new(
@@ -719,6 +732,16 @@ RSpec.describe AgentHarness::Providers::Codex do
             patterns
           )
         ).to eq(:auth_expired)
+
+        expect(
+          AgentHarness::ErrorTaxonomy.classify(
+            StandardError.new(<<~ERROR),
+              Your access token could not be refreshed because
+              invalid_client
+            ERROR
+            patterns
+          )
+        ).to eq(:auth_expired)
       end
 
       it "does not classify transient refresh failures as auth_expired" do
@@ -933,6 +956,25 @@ RSpec.describe AgentHarness::Providers::Codex do
             stderr: <<~ERROR,
               Your access token could not be refreshed because
               your refresh token was already used. Please log out and sign in again.
+            ERROR
+            exit_code: 1,
+            duration: 1.0
+          )
+        )
+
+        result = provider.smoke_test
+
+        expect(result[:ok]).to be false
+        expect(result[:error_category]).to eq(:auth_expired)
+      end
+
+      it "normalizes multiline access-token OAuth invalid_client failures to auth_expired" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "",
+            stderr: <<~ERROR,
+              Your access token could not be refreshed because
+              invalid_client
             ERROR
             exit_code: 1,
             duration: 1.0


### PR DESCRIPTION
## Summary

[P2] codex: return AuthenticationError for refresh_token_reused and similar OAuth refresh failures

See #101 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #101