### PR TITLE
Fix #113: [P1] feat: support disabling tools for text-only send_message calls

### DIFF
--- a/lib/agent_harness/providers/adapter.rb
+++ b/lib/agent_harness/providers/adapter.rb
@@ -717,6 +717,13 @@ module AgentHarness
       # @option options [Integer] :timeout timeout in seconds
       # @option options [String] :session session identifier
       # @option options [Boolean] :dangerous_mode skip permission checks
+      # @option options [Symbol, Array<String>, nil] :tools tool access control.
+      #   Pass +:none+ to disable all tool access (pure text-in/text-out mode).
+      #   Pass an Array of tool name strings to selectively disable specific
+      #   tools via the provider's disallowed-tools mechanism. Defaults to +nil+
+      #   (tools enabled, provider default behavior).
+      #   Providers that do not support tool control will emit a warning and
+      #   ignore this option — it is never a hard failure.
       # @option options [ProviderRuntime, Hash, nil] :provider_runtime per-request
       #   runtime overrides (model, base_url, api_provider, env, flags, metadata).
       #   For providers that delegate to Providers::Base#send_message, a plain Hash
@@ -837,6 +844,13 @@ module AgentHarness
             provider: self.class.provider_name
           )
         end
+      end
+
+      # Check if provider supports tool access control (disabling tools)
+      #
+      # @return [Boolean] true if the provider supports the tools: option
+      def supports_tool_control?
+        false
       end
 
       # Check if provider supports dangerous mode

--- a/lib/agent_harness/providers/anthropic.rb
+++ b/lib/agent_harness/providers/anthropic.rb
@@ -317,6 +317,10 @@ module AgentHarness
         ["--mcp-config", config_path]
       end
 
+      def supports_tool_control?
+        true
+      end
+
       def dangerous_mode_flags
         ["--dangerously-skip-permissions"]
       end
@@ -401,6 +405,21 @@ module AgentHarness
 
       protected
 
+      # All tools the Claude CLI exposes by default.
+      # Used to build the --disallowedTools list when tools: :none is requested.
+      ALL_CLI_TOOLS = %w[
+        Bash
+        Read
+        Edit
+        Write
+        Grep
+        Glob
+        WebFetch
+        WebSearch
+        TodoWrite
+        NotebookEdit
+      ].freeze
+
       def build_command(prompt, options)
         cmd = [self.class.binary_name]
 
@@ -409,6 +428,11 @@ module AgentHarness
         # Add model if specified
         if @config.model && !@config.model.empty?
           cmd += ["--model", @config.model]
+        end
+
+        # Add permission mode for tool-disabled requests (belt-and-suspenders)
+        if options[:tools]
+          cmd += build_tool_control_flags(options[:tools])
         end
 
         # Add dangerous mode if requested
@@ -610,6 +634,22 @@ module AgentHarness
           end
           @mcp_docker_config_paths = nil
         end
+      end
+
+      def build_tool_control_flags(tools_option)
+        tool_names = case tools_option
+        when :none
+          ALL_CLI_TOOLS
+        when Array
+          tools_option
+        else
+          return []
+        end
+
+        return [] if tool_names.empty?
+
+        ["--permission-mode", "plan"] +
+          tool_names.flat_map { |tool| ["--disallowedTools", tool] }
       end
 
       def log_debug(action, **context)

--- a/lib/agent_harness/providers/anthropic.rb
+++ b/lib/agent_harness/providers/anthropic.rb
@@ -408,6 +408,7 @@ module AgentHarness
       # All tools the Claude CLI exposes by default.
       # Used to build the --disallowedTools list when tools: :none is requested.
       ALL_CLI_TOOLS = %w[
+        Agent
         Bash
         Read
         Edit
@@ -432,7 +433,10 @@ module AgentHarness
 
         # Add permission mode for tool-disabled requests (belt-and-suspenders)
         if options[:tools]
-          cmd += build_tool_control_flags(options[:tools])
+          # Skip --permission-mode plan when dangerous_mode is active, since
+          # --dangerously-skip-permissions would override it anyway.
+          # The --disallowedTools flags still provide the primary protection.
+          cmd += build_tool_control_flags(options[:tools], skip_permission_mode: options[:dangerous_mode])
         end
 
         # Add dangerous mode if requested
@@ -636,7 +640,7 @@ module AgentHarness
         end
       end
 
-      def build_tool_control_flags(tools_option)
+      def build_tool_control_flags(tools_option, skip_permission_mode: false)
         tool_names = case tools_option
         when :none
           ALL_CLI_TOOLS
@@ -648,8 +652,9 @@ module AgentHarness
 
         return [] if tool_names.empty?
 
-        ["--permission-mode", "plan"] +
-          tool_names.flat_map { |tool| ["--disallowedTools", tool] }
+        flags = tool_names.flat_map { |tool| ["--disallowedTools", tool] }
+        flags = ["--permission-mode", "plan"] + flags unless skip_permission_mode
+        flags
       end
 
       def log_debug(action, **context)

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -104,6 +104,17 @@ module AgentHarness
       def send_message(prompt:, **options)
         log_debug("send_message_start", prompt_length: prompt.length, options: options.keys)
 
+        # Warn when tools option is passed to a provider that doesn't support it
+        if options[:tools] && !supports_tool_control?
+          log_debug("tools_option_unsupported",
+            provider: self.class.provider_name,
+            tools: options[:tools])
+          @logger&.warn(
+            "[AgentHarness::#{self.class.provider_name}] tools option is not supported " \
+            "by this provider and will be ignored"
+          )
+        end
+
         # Coerce provider_runtime from Hash if needed
         options = normalize_provider_runtime(options)
 

--- a/spec/agent_harness/providers/anthropic_spec.rb
+++ b/spec/agent_harness/providers/anthropic_spec.rb
@@ -837,6 +837,109 @@ RSpec.describe AgentHarness::Providers::Anthropic do
       end
     end
 
+    describe "#supports_tool_control?" do
+      it "returns true" do
+        expect(provider.supports_tool_control?).to be true
+      end
+    end
+
+    describe "tool control via tools option" do
+      let(:success_result) do
+        AgentHarness::CommandExecutor::Result.new(
+          stdout: '{"result":"response","usage":{"input_tokens":10,"output_tokens":5}}',
+          stderr: "",
+          exit_code: 0,
+          duration: 1.0
+        )
+      end
+
+      before do
+        allow(mock_executor).to receive(:execute).and_return(success_result)
+      end
+
+      context "when tools: :none" do
+        it "includes --permission-mode plan flag" do
+          expect(mock_executor).to receive(:execute).with(
+            array_including("--permission-mode", "plan"),
+            anything
+          )
+
+          provider.send_message(prompt: "Summarize this", tools: :none)
+        end
+
+        it "includes --disallowedTools for all CLI tools" do
+          allow(mock_executor).to receive(:execute) do |cmd, **_opts|
+            AgentHarness::Providers::Anthropic::ALL_CLI_TOOLS.each do |tool|
+              expect(cmd).to include("--disallowedTools", tool),
+                "Expected command to include --disallowedTools #{tool}"
+            end
+            success_result
+          end
+
+          provider.send_message(prompt: "Summarize this", tools: :none)
+        end
+
+        it "disallows all known CLI tools" do
+          expected_tools = %w[Bash Read Edit Write Grep Glob WebFetch WebSearch TodoWrite NotebookEdit]
+
+          allow(mock_executor).to receive(:execute) do |cmd, **_opts|
+            expected_tools.each do |tool|
+              expect(cmd).to include(tool)
+            end
+            success_result
+          end
+
+          provider.send_message(prompt: "Summarize this", tools: :none)
+        end
+      end
+
+      context "when tools: is an explicit list" do
+        it "includes --disallowedTools only for the specified tools" do
+          allow(mock_executor).to receive(:execute) do |cmd, **_opts|
+            expect(cmd).to include("--disallowedTools", "Bash")
+            expect(cmd).to include("--disallowedTools", "Read")
+            expect(cmd).not_to include("Edit")
+            success_result
+          end
+
+          provider.send_message(prompt: "Hello", tools: %w[Bash Read])
+        end
+
+        it "includes --permission-mode plan flag" do
+          expect(mock_executor).to receive(:execute).with(
+            array_including("--permission-mode", "plan"),
+            anything
+          )
+
+          provider.send_message(prompt: "Hello", tools: %w[Bash])
+        end
+      end
+
+      context "when tools option is not provided" do
+        it "does not include --disallowedTools or --permission-mode" do
+          allow(mock_executor).to receive(:execute) do |cmd, **_opts|
+            expect(cmd).not_to include("--disallowedTools")
+            expect(cmd).not_to include("--permission-mode")
+            success_result
+          end
+
+          provider.send_message(prompt: "Hello")
+        end
+      end
+
+      context "when tools: is an empty array" do
+        it "does not include --disallowedTools or --permission-mode" do
+          allow(mock_executor).to receive(:execute) do |cmd, **_opts|
+            expect(cmd).not_to include("--disallowedTools")
+            expect(cmd).not_to include("--permission-mode")
+            success_result
+          end
+
+          provider.send_message(prompt: "Hello", tools: [])
+        end
+      end
+    end
+
     describe "#execution_semantics" do
       it "returns the full provider contract" do
         semantics = provider.execution_semantics

--- a/spec/agent_harness/providers/anthropic_spec.rb
+++ b/spec/agent_harness/providers/anthropic_spec.rb
@@ -880,7 +880,7 @@ RSpec.describe AgentHarness::Providers::Anthropic do
         end
 
         it "disallows all known CLI tools" do
-          expected_tools = %w[Bash Read Edit Write Grep Glob WebFetch WebSearch TodoWrite NotebookEdit]
+          expected_tools = %w[Agent Bash Read Edit Write Grep Glob WebFetch WebSearch TodoWrite NotebookEdit]
 
           allow(mock_executor).to receive(:execute) do |cmd, **_opts|
             expected_tools.each do |tool|
@@ -936,6 +936,21 @@ RSpec.describe AgentHarness::Providers::Anthropic do
           end
 
           provider.send_message(prompt: "Hello", tools: [])
+        end
+      end
+
+      context "when tools: :none combined with dangerous_mode: true" do
+        it "includes --disallowedTools but omits --permission-mode plan" do
+          allow(mock_executor).to receive(:execute) do |cmd, **_opts|
+            AgentHarness::Providers::Anthropic::ALL_CLI_TOOLS.each do |tool|
+              expect(cmd).to include("--disallowedTools", tool)
+            end
+            expect(cmd).not_to include("--permission-mode")
+            expect(cmd).to include("--dangerously-skip-permissions")
+            success_result
+          end
+
+          provider.send_message(prompt: "Hello", tools: :none, dangerous_mode: true)
         end
       end
     end

--- a/spec/agent_harness/providers/base_send_message_spec.rb
+++ b/spec/agent_harness/providers/base_send_message_spec.rb
@@ -328,4 +328,31 @@ RSpec.describe AgentHarness::Providers::Base, "#send_message" do
       )
     end
   end
+
+  describe "tools option on unsupported provider" do
+    let(:logger) { double("Logger", debug: nil, warn: nil, error: nil) }
+
+    subject(:provider) do
+      test_provider_class.new(config: config, executor: mock_executor, logger: logger)
+    end
+
+    it "emits a warning when tools option is passed" do
+      expect(logger).to receive(:warn).with(/tools option is not supported/)
+
+      provider.send_message(prompt: "Hello", tools: :none)
+    end
+
+    it "still returns a successful response" do
+      response = provider.send_message(prompt: "Hello", tools: :none)
+
+      expect(response).to be_a(AgentHarness::Response)
+      expect(response.output).to eq("response output")
+    end
+
+    it "does not warn when tools option is not provided" do
+      expect(logger).not_to receive(:warn)
+
+      provider.send_message(prompt: "Hello")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Prevent tool access from contaminating text-only LLM calls by adding a `tools:` option to `AgentHarness.send_message`. This fixes #1140, where Claude Code's tool use pulled git state from the host's working directory and generated a PR description for the wrong branch.

## Changes

**Public API (`send_message`)**
- New `tools:` keyword argument: pass `:none` to disable all provider tools, or an array of tool names (e.g., `%w[Bash Read]`) to selectively disable specific tools
- Option is forwarded through `AgentHarness.send_message` to the provider layer

**Anthropic provider** (`lib/agent_harness/providers/anthropic.rb`)
- `supports_tool_control?` returns `true`
- `ALL_CLI_TOOLS` constant enumerates all 10 Claude CLI tools (Bash, Read, Edit, Write, Grep, Glob, WebFetch, WebSearch, TodoWrite, NotebookEdit)
- `build_tool_control_flags` translates `tools: :none` into `--disallowedTools` flags for every tool, plus `--permission-mode plan` as belt-and-suspenders

**Base / Adapter contracts**
- `Providers::Base#send_message` emits a warning (not a hard failure) when `tools:` is passed to a provider that doesn't support it
- `Providers::Adapter` adds `supports_tool_control?` (default `false`) so future providers can opt in individually

**Tests**
- 12 new specs covering: all-tools-disabled flags, selective disable, default path unchanged, empty-array no-op, and unsupported-provider warning behavior

## Design Decisions

- **`:none` symbol vs explicit list** — `:none` is sugar that expands to the full tool list at the provider level, keeping callers decoupled from which tools a provider exposes. Explicit arrays are supported for callers that need surgical control.
- **Soft warning over hard failure for unsupported providers** — text-only calls should succeed regardless of provider; the `tools:` option is a safety constraint, not a feature gate.
- **`--permission-mode plan` as secondary guard** — even if a tool slips through the disallowed list (e.g., a newly added CLI tool), plan mode prevents execution. Defense in depth.
- **Scoped to Anthropic only** — other providers can add `supports_tool_control?` individually; Anthropic is the P1 because it's the provider behind the #1140 bug.

---

Closes #113