### PR TITLE
Fix #114: feat: add text-only transport that bypasses the CLI for pure text generation

### DIFF
--- a/lib/agent_harness.rb
+++ b/lib/agent_harness.rb
@@ -245,6 +245,7 @@ require_relative "agent_harness/docker_command_executor"
 require_relative "agent_harness/response"
 require_relative "agent_harness/token_tracker"
 require_relative "agent_harness/error_taxonomy"
+require_relative "agent_harness/text_transport"
 require_relative "agent_harness/authentication"
 require_relative "agent_harness/provider_health_check"
 

--- a/lib/agent_harness/errors.rb
+++ b/lib/agent_harness/errors.rb
@@ -59,6 +59,13 @@ module AgentHarness
     end
   end
 
+  # Auth mismatch errors — raised when the requested transport mode
+  # requires credentials that differ from the caller's current auth mode.
+  # For example, requesting HTTP text mode with only OAuth/subscription
+  # credentials (no API key) would silently shift billing from
+  # subscription to API-metered usage.
+  class AuthMismatchError < AuthenticationError; end
+
   # Configuration errors
   class ConfigurationError < Error; end
 

--- a/lib/agent_harness/providers/adapter.rb
+++ b/lib/agent_harness/providers/adapter.rb
@@ -862,6 +862,17 @@ module AgentHarness
         false
       end
 
+      # Check if provider supports text-only mode via direct HTTP transport.
+      #
+      # Providers that return +true+ will route +mode: :text+ requests
+      # through their REST API instead of the CLI. Providers that return
+      # +false+ fall back to the CLI path with tools forcibly disabled.
+      #
+      # @return [Boolean] true if the provider has an HTTP text transport
+      def supports_text_mode?
+        false
+      end
+
       # Check if provider supports dangerous mode
       #
       # @return [Boolean] true if dangerous mode is supported

--- a/lib/agent_harness/providers/anthropic.rb
+++ b/lib/agent_harness/providers/anthropic.rb
@@ -297,6 +297,10 @@ module AgentHarness
       end
 
       def send_message(prompt:, **options)
+        if options[:mode] == :text
+          return send_text_message(prompt, **options.except(:mode))
+        end
+
         super
       ensure
         cleanup_mcp_tempfiles!
@@ -318,6 +322,10 @@ module AgentHarness
       end
 
       def supports_tool_control?
+        true
+      end
+
+      def supports_text_mode?
         true
       end
 
@@ -494,6 +502,67 @@ module AgentHarness
       end
 
       private
+
+      def send_text_message(prompt, **options)
+        api_key = resolve_text_mode_api_key
+        model = options[:model] || @config.model
+        timeout = options[:timeout] || @config.timeout || default_timeout
+        max_tokens = options[:max_tokens]
+
+        transport = TextTransport.new(api_key: api_key, logger: @logger)
+
+        kwargs = {model: model, timeout: timeout}
+        kwargs[:max_tokens] = max_tokens if max_tokens
+
+        response = transport.send_message(prompt, **kwargs)
+
+        # Apply runtime model override if present
+        runtime = options[:provider_runtime]
+        runtime = ProviderRuntime.wrap(runtime) if runtime.is_a?(Hash)
+        if runtime&.model
+          response = Response.new(
+            output: response.output,
+            exit_code: response.exit_code,
+            duration: response.duration,
+            provider: response.provider,
+            model: runtime.model,
+            tokens: response.tokens,
+            metadata: response.metadata,
+            error: response.error
+          )
+        end
+
+        track_tokens(response) if response.tokens
+
+        log_debug("send_text_message_complete",
+          duration: response.duration,
+          tokens: response.tokens,
+          transport: :http)
+
+        response
+      end
+
+      # Resolve the API key for text mode, validating that the caller's
+      # credentials support direct API access without silently shifting
+      # billing from subscription to API-metered usage.
+      #
+      # @return [String] the API key
+      # @raise [AuthMismatchError] if no API key is available
+      def resolve_text_mode_api_key
+        api_key = ENV["ANTHROPIC_API_KEY"]
+
+        if api_key.nil? || api_key.strip.empty?
+          raise AuthMismatchError.new(
+            "Text mode requires an ANTHROPIC_API_KEY for direct API access. " \
+            "OAuth/subscription credentials cannot be used for HTTP transport " \
+            "because it would silently shift billing to API-metered usage. " \
+            "Set ANTHROPIC_API_KEY or use the default CLI mode instead.",
+            provider: :claude
+          )
+        end
+
+        api_key.strip
+      end
 
       def parse_json_output(output)
         return nil if output.nil? || output.empty?

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -104,6 +104,15 @@ module AgentHarness
       def send_message(prompt:, **options)
         log_debug("send_message_start", prompt_length: prompt.length, options: options.keys)
 
+        # Text mode: fall back to CLI with tools disabled when the provider
+        # does not have an HTTP text transport.  Providers that support text
+        # mode (e.g. Anthropic) override send_message to intercept this
+        # before reaching Base.
+        if options[:mode] == :text && !supports_text_mode?
+          log_debug("text_mode_cli_fallback", provider: self.class.provider_name)
+          options = options.except(:mode).merge(tools: :none)
+        end
+
         # Warn when tools option is passed to a provider that doesn't support it
         if options[:tools] && !supports_tool_control?
           log_debug("tools_option_unsupported",

--- a/lib/agent_harness/text_transport.rb
+++ b/lib/agent_harness/text_transport.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "json"
+require "uri"
+
+module AgentHarness
+  # Direct HTTP transport for text-only provider interactions.
+  #
+  # Bypasses the CLI entirely by calling the provider's REST API directly.
+  # Currently supports Anthropic's Messages API. This transport is used when
+  # callers declare a task as text-only via +mode: :text+ on +send_message+.
+  #
+  # The transport preserves the same Response structure, token tracking,
+  # and error classification semantics as the CLI path so that callers
+  # do not need to distinguish between transport modes after the call.
+  #
+  # @example
+  #   transport = AgentHarness::TextTransport.new(api_key: "sk-ant-...")
+  #   response = transport.send_message("Summarize this PR", model: "claude-sonnet-4-20250514")
+  class TextTransport
+    ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
+    ANTHROPIC_API_VERSION = "2023-06-01"
+    DEFAULT_MODEL = "claude-sonnet-4-20250514"
+    DEFAULT_MAX_TOKENS = 4096
+    DEFAULT_TIMEOUT = 300
+
+    # @param api_key [String] Anthropic API key
+    # @param logger [Logger, nil] optional logger
+    def initialize(api_key:, logger: nil)
+      @api_key = api_key
+      @logger = logger
+    end
+
+    # Send a text-only message via the Anthropic Messages API.
+    #
+    # @param prompt [String] the user prompt
+    # @param model [String, nil] model to use (defaults to DEFAULT_MODEL)
+    # @param timeout [Integer, nil] request timeout in seconds
+    # @param max_tokens [Integer, nil] maximum tokens in the response
+    # @return [Response] the response
+    # @raise [AuthenticationError] on 401 responses
+    # @raise [RateLimitError] on 429 responses
+    # @raise [TimeoutError] on network timeouts
+    # @raise [ProviderError] on other HTTP errors
+    def send_message(prompt, model: nil, timeout: nil, max_tokens: nil)
+      model ||= DEFAULT_MODEL
+      timeout ||= DEFAULT_TIMEOUT
+      max_tokens ||= DEFAULT_MAX_TOKENS
+
+      uri = URI(ANTHROPIC_API_URL)
+      body = {
+        model: model,
+        max_tokens: max_tokens,
+        messages: [{role: "user", content: prompt}]
+      }
+
+      start_time = Time.now
+      http_response = make_request(uri, body, timeout: timeout)
+      duration = Time.now - start_time
+
+      parse_response(http_response, duration: duration, model: model)
+    end
+
+    private
+
+    def make_request(uri, body, timeout:)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.open_timeout = [timeout, 30].min
+      http.read_timeout = timeout
+
+      request = Net::HTTP::Post.new(uri)
+      request["Content-Type"] = "application/json"
+      request["x-api-key"] = @api_key
+      request["anthropic-version"] = ANTHROPIC_API_VERSION
+      request.body = JSON.generate(body)
+
+      @logger&.debug("[AgentHarness::TextTransport] POST #{uri} model=#{body[:model]}")
+
+      http.request(request)
+    rescue Net::OpenTimeout, Net::ReadTimeout => e
+      raise TimeoutError.new(e.message, original_error: e)
+    rescue SocketError, Errno::ECONNREFUSED, Errno::ECONNRESET, IOError => e
+      raise ProviderError.new("HTTP connection error: #{e.message}", original_error: e)
+    end
+
+    def parse_response(http_response, duration:, model:)
+      status_code = http_response.code.to_i
+
+      unless status_code == 200
+        handle_error_response(http_response, status_code)
+      end
+
+      body = JSON.parse(http_response.body)
+      output = extract_text_content(body)
+      tokens = extract_tokens(body)
+
+      Response.new(
+        output: output,
+        exit_code: 0,
+        duration: duration,
+        provider: :claude,
+        model: body["model"] || model,
+        tokens: tokens,
+        metadata: {transport: :http}
+      )
+    rescue JSON::ParserError => e
+      raise ProviderError.new(
+        "Invalid JSON in API response: #{e.message}",
+        original_error: e
+      )
+    end
+
+    def extract_text_content(body)
+      content = body["content"]
+      return "" unless content.is_a?(Array)
+
+      content
+        .select { |block| block["type"] == "text" }
+        .map { |block| block["text"] }
+        .join
+    end
+
+    def extract_tokens(body)
+      usage = body["usage"]
+      return nil unless usage
+
+      input = usage["input_tokens"] || 0
+      output = usage["output_tokens"] || 0
+
+      {input: input, output: output, total: input + output}
+    end
+
+    def handle_error_response(http_response, status_code)
+      message = begin
+        body = JSON.parse(http_response.body)
+        body.dig("error", "message") || body.dig("error", "type") || http_response.body
+      rescue JSON::ParserError
+        http_response.body
+      end
+
+      case status_code
+      when 401
+        raise AuthenticationError.new(
+          "API authentication failed: #{message}",
+          provider: :claude
+        )
+      when 403
+        raise AuthenticationError.new(
+          "API access forbidden: #{message}",
+          provider: :claude
+        )
+      when 429
+        raise RateLimitError.new(
+          "API rate limit exceeded: #{message}",
+          provider: :claude
+        )
+      when 400
+        raise ProviderError.new("Bad request: #{message}")
+      when 500, 502, 503, 529
+        raise ProviderError.new("Server error (#{status_code}): #{message}")
+      else
+        raise ProviderError.new("HTTP #{status_code}: #{message}")
+      end
+    end
+  end
+end

--- a/spec/agent_harness/providers/anthropic_spec.rb
+++ b/spec/agent_harness/providers/anthropic_spec.rb
@@ -961,6 +961,186 @@ RSpec.describe AgentHarness::Providers::Anthropic do
       end
     end
 
+    describe "#supports_text_mode?" do
+      it "returns true" do
+        expect(provider.supports_text_mode?).to be true
+      end
+    end
+
+    describe "text mode (mode: :text)" do
+      context "with ANTHROPIC_API_KEY set" do
+        let(:api_key) { "sk-ant-test-key-456" }
+
+        before do
+          allow(ENV).to receive(:[]).and_call_original
+          allow(ENV).to receive(:[]).with("ANTHROPIC_API_KEY").and_return(api_key)
+        end
+
+        it "sends via HTTP transport instead of CLI" do
+          http_response = instance_double(Net::HTTPOK,
+            code: "200",
+            body: JSON.generate({
+              "content" => [{"type" => "text", "text" => "HTTP response"}],
+              "model" => "claude-sonnet-4-20250514",
+              "usage" => {"input_tokens" => 20, "output_tokens" => 10}
+            }))
+
+          http = instance_double(Net::HTTP)
+          allow(Net::HTTP).to receive(:new).and_return(http)
+          allow(http).to receive(:use_ssl=)
+          allow(http).to receive(:open_timeout=)
+          allow(http).to receive(:read_timeout=)
+          allow(http).to receive(:request).and_return(http_response)
+
+          # CLI executor should NOT be called
+          expect(mock_executor).not_to receive(:execute)
+
+          response = provider.send_message(prompt: "Summarize this", mode: :text)
+
+          expect(response.output).to eq("HTTP response")
+          expect(response.success?).to be true
+          expect(response.provider).to eq(:claude)
+          expect(response.metadata[:transport]).to eq(:http)
+        end
+
+        it "extracts tokens from HTTP response" do
+          http_response = instance_double(Net::HTTPOK,
+            code: "200",
+            body: JSON.generate({
+              "content" => [{"type" => "text", "text" => "response"}],
+              "usage" => {"input_tokens" => 50, "output_tokens" => 25}
+            }))
+
+          http = instance_double(Net::HTTP)
+          allow(Net::HTTP).to receive(:new).and_return(http)
+          allow(http).to receive(:use_ssl=)
+          allow(http).to receive(:open_timeout=)
+          allow(http).to receive(:read_timeout=)
+          allow(http).to receive(:request).and_return(http_response)
+
+          response = provider.send_message(prompt: "prompt", mode: :text)
+
+          expect(response.tokens).to eq({input: 50, output: 25, total: 75})
+        end
+
+        it "records tokens with the global token tracker" do
+          http_response = instance_double(Net::HTTPOK,
+            code: "200",
+            body: JSON.generate({
+              "content" => [{"type" => "text", "text" => "response"}],
+              "usage" => {"input_tokens" => 30, "output_tokens" => 15}
+            }))
+
+          http = instance_double(Net::HTTP)
+          allow(Net::HTTP).to receive(:new).and_return(http)
+          allow(http).to receive(:use_ssl=)
+          allow(http).to receive(:open_timeout=)
+          allow(http).to receive(:read_timeout=)
+          allow(http).to receive(:request).and_return(http_response)
+
+          tracker = AgentHarness.token_tracker
+          tracker.clear!
+
+          provider.send_message(prompt: "prompt", mode: :text)
+
+          summary = tracker.summary
+          expect(summary[:total_input_tokens]).to eq(30)
+          expect(summary[:total_output_tokens]).to eq(15)
+          expect(summary[:total_tokens]).to eq(45)
+        end
+
+        it "uses configured model" do
+          http = instance_double(Net::HTTP)
+          allow(Net::HTTP).to receive(:new).and_return(http)
+          allow(http).to receive(:use_ssl=)
+          allow(http).to receive(:open_timeout=)
+          allow(http).to receive(:read_timeout=)
+
+          expect(http).to receive(:request) do |req|
+            body = JSON.parse(req.body)
+            expect(body["model"]).to eq("claude-3-5-sonnet")
+
+            instance_double(Net::HTTPOK,
+              code: "200",
+              body: JSON.generate({
+                "content" => [{"type" => "text", "text" => "ok"}],
+                "model" => "claude-3-5-sonnet",
+                "usage" => {"input_tokens" => 1, "output_tokens" => 1}
+              }))
+          end
+
+          provider.send_message(prompt: "prompt", mode: :text)
+        end
+
+        it "raises AuthenticationError on 401 from API" do
+          http_response = instance_double(Net::HTTPOK,
+            code: "401",
+            body: JSON.generate({
+              "error" => {"type" => "authentication_error", "message" => "invalid api key"}
+            }))
+
+          http = instance_double(Net::HTTP)
+          allow(Net::HTTP).to receive(:new).and_return(http)
+          allow(http).to receive(:use_ssl=)
+          allow(http).to receive(:open_timeout=)
+          allow(http).to receive(:read_timeout=)
+          allow(http).to receive(:request).and_return(http_response)
+
+          expect { provider.send_message(prompt: "prompt", mode: :text) }
+            .to raise_error(AgentHarness::AuthenticationError)
+        end
+
+        it "raises RateLimitError on 429 from API" do
+          http_response = instance_double(Net::HTTPOK,
+            code: "429",
+            body: JSON.generate({
+              "error" => {"type" => "rate_limit_error", "message" => "rate limited"}
+            }))
+
+          http = instance_double(Net::HTTP)
+          allow(Net::HTTP).to receive(:new).and_return(http)
+          allow(http).to receive(:use_ssl=)
+          allow(http).to receive(:open_timeout=)
+          allow(http).to receive(:read_timeout=)
+          allow(http).to receive(:request).and_return(http_response)
+
+          expect { provider.send_message(prompt: "prompt", mode: :text) }
+            .to raise_error(AgentHarness::RateLimitError)
+        end
+      end
+
+      context "without ANTHROPIC_API_KEY" do
+        before do
+          allow(ENV).to receive(:[]).and_call_original
+          allow(ENV).to receive(:[]).with("ANTHROPIC_API_KEY").and_return(nil)
+        end
+
+        it "raises AuthMismatchError" do
+          expect { provider.send_message(prompt: "prompt", mode: :text) }
+            .to raise_error(AgentHarness::AuthMismatchError, /ANTHROPIC_API_KEY/) do |error|
+              expect(error.provider).to eq(:claude)
+            end
+        end
+
+        it "includes guidance about billing in the error message" do
+          expect { provider.send_message(prompt: "prompt", mode: :text) }
+            .to raise_error(AgentHarness::AuthMismatchError, /billing/)
+        end
+      end
+
+      context "with empty ANTHROPIC_API_KEY" do
+        before do
+          allow(ENV).to receive(:[]).and_call_original
+          allow(ENV).to receive(:[]).with("ANTHROPIC_API_KEY").and_return("   ")
+        end
+
+        it "raises AuthMismatchError" do
+          expect { provider.send_message(prompt: "prompt", mode: :text) }
+            .to raise_error(AgentHarness::AuthMismatchError)
+        end
+      end
+    end
+
     describe "#execution_semantics" do
       it "returns the full provider contract" do
         semantics = provider.execution_semantics

--- a/spec/agent_harness/text_mode_fallback_spec.rb
+++ b/spec/agent_harness/text_mode_fallback_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+RSpec.describe "Text mode CLI fallback" do
+  let(:mock_executor) { instance_double(AgentHarness::CommandExecutor) }
+  let(:config) { AgentHarness::ProviderConfig.new(:claude) }
+
+  let(:success_result) do
+    AgentHarness::CommandExecutor::Result.new(
+      stdout: '{"result":"response","usage":{"input_tokens":10,"output_tokens":5}}',
+      stderr: "",
+      exit_code: 0,
+      duration: 1.0
+    )
+  end
+
+  describe "provider that does not support text mode" do
+    # Use Anthropic but test via Base's fallback path by creating a provider
+    # that does NOT override supports_text_mode? (it defaults to false).
+    let(:provider_class) do
+      Class.new(AgentHarness::Providers::Base) do
+        class << self
+          def provider_name
+            :test_provider
+          end
+
+          def binary_name
+            "test-cli"
+          end
+
+          def available?
+            true
+          end
+        end
+
+        def supports_tool_control?
+          true
+        end
+
+        protected
+
+        def build_command(prompt, options)
+          cmd = ["test-cli", "--print"]
+          if options[:tools] == :none
+            cmd += ["--no-tools"]
+          end
+          cmd << prompt
+          cmd
+        end
+      end
+    end
+
+    let(:provider) do
+      provider_class.new(config: config, executor: mock_executor)
+    end
+
+    it "does not support text mode" do
+      expect(provider.supports_text_mode?).to be false
+    end
+
+    it "falls back to CLI with tools: :none when mode: :text is requested" do
+      expect(mock_executor).to receive(:execute) do |cmd, **_opts|
+        expect(cmd).to include("--no-tools")
+        success_result
+      end
+
+      provider.send_message(prompt: "Summarize", mode: :text)
+    end
+
+    it "strips the mode option before forwarding to the CLI path" do
+      expect(mock_executor).to receive(:execute) do |cmd, **_opts|
+        # The mode option should not appear in the command
+        expect(cmd).not_to include("--mode")
+        expect(cmd).not_to include(":text")
+        success_result
+      end
+
+      provider.send_message(prompt: "Summarize", mode: :text)
+    end
+
+    it "returns a valid Response" do
+      allow(mock_executor).to receive(:execute).and_return(success_result)
+
+      response = provider.send_message(prompt: "Summarize", mode: :text)
+
+      expect(response).to be_a(AgentHarness::Response)
+      expect(response.success?).to be true
+    end
+  end
+
+  describe "Anthropic provider with text mode" do
+    let(:anthropic_config) do
+      AgentHarness::ProviderConfig.new(:claude).tap do |c|
+        c.model = "claude-3-5-sonnet"
+      end
+    end
+
+    let(:anthropic_provider) do
+      AgentHarness::Providers::Anthropic.new(config: anthropic_config, executor: mock_executor)
+    end
+
+    it "supports text mode" do
+      expect(anthropic_provider.supports_text_mode?).to be true
+    end
+
+    it "routes to HTTP transport (not CLI) when mode: :text and API key is set" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("ANTHROPIC_API_KEY").and_return("sk-ant-test")
+
+      http_response = instance_double(Net::HTTPOK,
+        code: "200",
+        body: JSON.generate({
+          "content" => [{"type" => "text", "text" => "HTTP response"}],
+          "usage" => {"input_tokens" => 10, "output_tokens" => 5}
+        }))
+
+      http = instance_double(Net::HTTP)
+      allow(Net::HTTP).to receive(:new).and_return(http)
+      allow(http).to receive(:use_ssl=)
+      allow(http).to receive(:open_timeout=)
+      allow(http).to receive(:read_timeout=)
+      allow(http).to receive(:request).and_return(http_response)
+
+      # CLI executor should NOT be called
+      expect(mock_executor).not_to receive(:execute)
+
+      response = anthropic_provider.send_message(prompt: "Summarize", mode: :text)
+      expect(response.output).to eq("HTTP response")
+      expect(response.metadata[:transport]).to eq(:http)
+    end
+
+    it "uses CLI normally when mode is not :text" do
+      allow(mock_executor).to receive(:execute).and_return(success_result)
+
+      # Should use CLI, not HTTP
+      expect(mock_executor).to receive(:execute).with(
+        array_including("claude", "--print"),
+        anything
+      )
+
+      anthropic_provider.send_message(prompt: "Hello")
+    end
+  end
+end

--- a/spec/agent_harness/text_transport_spec.rb
+++ b/spec/agent_harness/text_transport_spec.rb
@@ -1,0 +1,335 @@
+# frozen_string_literal: true
+
+require "logger"
+require "net/http"
+
+RSpec.describe AgentHarness::TextTransport do
+  let(:api_key) { "sk-ant-test-key-123" }
+  let(:logger) { instance_double(Logger, debug: nil, error: nil, warn: nil) }
+  let(:transport) { described_class.new(api_key: api_key, logger: logger) }
+
+  def stub_api_response(status:, body:)
+    http_response = instance_double(Net::HTTPOK,
+      code: status.to_s,
+      body: JSON.generate(body))
+    http = instance_double(Net::HTTP)
+    allow(Net::HTTP).to receive(:new).and_return(http)
+    allow(http).to receive(:use_ssl=)
+    allow(http).to receive(:open_timeout=)
+    allow(http).to receive(:read_timeout=)
+    allow(http).to receive(:request).and_return(http_response)
+    http
+  end
+
+  def stub_raw_api_response(status:, body_string:)
+    http_response = instance_double(Net::HTTPOK,
+      code: status.to_s,
+      body: body_string)
+    http = instance_double(Net::HTTP)
+    allow(Net::HTTP).to receive(:new).and_return(http)
+    allow(http).to receive(:use_ssl=)
+    allow(http).to receive(:open_timeout=)
+    allow(http).to receive(:read_timeout=)
+    allow(http).to receive(:request).and_return(http_response)
+    http
+  end
+
+  describe "#send_message" do
+    context "successful response" do
+      it "returns a Response with extracted text content" do
+        stub_api_response(status: 200, body: {
+          "id" => "msg_123",
+          "type" => "message",
+          "role" => "assistant",
+          "model" => "claude-sonnet-4-20250514",
+          "content" => [
+            {"type" => "text", "text" => "Hello, world!"}
+          ],
+          "usage" => {
+            "input_tokens" => 10,
+            "output_tokens" => 5
+          }
+        })
+
+        response = transport.send_message("Say hello")
+
+        expect(response).to be_a(AgentHarness::Response)
+        expect(response.output).to eq("Hello, world!")
+        expect(response.success?).to be true
+        expect(response.exit_code).to eq(0)
+        expect(response.provider).to eq(:claude)
+        expect(response.model).to eq("claude-sonnet-4-20250514")
+        expect(response.metadata[:transport]).to eq(:http)
+      end
+
+      it "extracts token usage" do
+        stub_api_response(status: 200, body: {
+          "content" => [{"type" => "text", "text" => "response"}],
+          "usage" => {"input_tokens" => 100, "output_tokens" => 50}
+        })
+
+        response = transport.send_message("prompt")
+
+        expect(response.tokens).to eq({input: 100, output: 50, total: 150})
+        expect(response.input_tokens).to eq(100)
+        expect(response.output_tokens).to eq(50)
+        expect(response.total_tokens).to eq(150)
+      end
+
+      it "handles multiple text content blocks" do
+        stub_api_response(status: 200, body: {
+          "content" => [
+            {"type" => "text", "text" => "Part 1. "},
+            {"type" => "text", "text" => "Part 2."}
+          ],
+          "usage" => {"input_tokens" => 10, "output_tokens" => 10}
+        })
+
+        response = transport.send_message("prompt")
+
+        expect(response.output).to eq("Part 1. Part 2.")
+      end
+
+      it "handles empty content array" do
+        stub_api_response(status: 200, body: {
+          "content" => [],
+          "usage" => {"input_tokens" => 10, "output_tokens" => 0}
+        })
+
+        response = transport.send_message("prompt")
+
+        expect(response.output).to eq("")
+      end
+
+      it "handles missing usage data" do
+        stub_api_response(status: 200, body: {
+          "content" => [{"type" => "text", "text" => "response"}]
+        })
+
+        response = transport.send_message("prompt")
+
+        expect(response.tokens).to be_nil
+      end
+
+      it "sends the correct headers" do
+        http = stub_api_response(status: 200, body: {
+          "content" => [{"type" => "text", "text" => "ok"}],
+          "usage" => {"input_tokens" => 1, "output_tokens" => 1}
+        })
+
+        expect(http).to receive(:request) do |req|
+          expect(req["Content-Type"]).to eq("application/json")
+          expect(req["x-api-key"]).to eq(api_key)
+          expect(req["anthropic-version"]).to eq("2023-06-01")
+
+          body = JSON.parse(req.body)
+          expect(body["messages"]).to eq([{"role" => "user", "content" => "test prompt"}])
+          expect(body["model"]).to eq("claude-sonnet-4-20250514")
+          expect(body["max_tokens"]).to eq(4096)
+
+          instance_double(Net::HTTPOK,
+            code: "200",
+            body: JSON.generate({
+              "content" => [{"type" => "text", "text" => "ok"}],
+              "usage" => {"input_tokens" => 1, "output_tokens" => 1}
+            }))
+        end
+
+        transport.send_message("test prompt")
+      end
+
+      it "uses custom model and max_tokens when provided" do
+        http = stub_api_response(status: 200, body: {
+          "content" => [{"type" => "text", "text" => "ok"}],
+          "usage" => {"input_tokens" => 1, "output_tokens" => 1}
+        })
+
+        expect(http).to receive(:request) do |req|
+          body = JSON.parse(req.body)
+          expect(body["model"]).to eq("claude-3-opus-20240229")
+          expect(body["max_tokens"]).to eq(8192)
+
+          instance_double(Net::HTTPOK,
+            code: "200",
+            body: JSON.generate({
+              "content" => [{"type" => "text", "text" => "ok"}],
+              "model" => "claude-3-opus-20240229",
+              "usage" => {"input_tokens" => 1, "output_tokens" => 1}
+            }))
+        end
+
+        transport.send_message("prompt", model: "claude-3-opus-20240229", max_tokens: 8192)
+      end
+
+      it "records duration" do
+        stub_api_response(status: 200, body: {
+          "content" => [{"type" => "text", "text" => "ok"}],
+          "usage" => {"input_tokens" => 1, "output_tokens" => 1}
+        })
+
+        response = transport.send_message("prompt")
+
+        expect(response.duration).to be_a(Float)
+        expect(response.duration).to be >= 0
+      end
+    end
+
+    context "error responses" do
+      it "raises AuthenticationError on 401" do
+        stub_api_response(status: 401, body: {
+          "error" => {"type" => "authentication_error", "message" => "invalid x-api-key"}
+        })
+
+        expect { transport.send_message("prompt") }
+          .to raise_error(AgentHarness::AuthenticationError, /invalid x-api-key/) do |error|
+            expect(error.provider).to eq(:claude)
+          end
+      end
+
+      it "raises AuthenticationError on 403" do
+        stub_api_response(status: 403, body: {
+          "error" => {"type" => "forbidden", "message" => "access denied"}
+        })
+
+        expect { transport.send_message("prompt") }
+          .to raise_error(AgentHarness::AuthenticationError, /access denied/)
+      end
+
+      it "raises RateLimitError on 429" do
+        stub_api_response(status: 429, body: {
+          "error" => {"type" => "rate_limit_error", "message" => "too many requests"}
+        })
+
+        expect { transport.send_message("prompt") }
+          .to raise_error(AgentHarness::RateLimitError, /too many requests/)
+      end
+
+      it "raises ProviderError on 400" do
+        stub_api_response(status: 400, body: {
+          "error" => {"type" => "invalid_request_error", "message" => "invalid model"}
+        })
+
+        expect { transport.send_message("prompt") }
+          .to raise_error(AgentHarness::ProviderError, /invalid model/)
+      end
+
+      it "raises ProviderError on 500" do
+        stub_api_response(status: 500, body: {
+          "error" => {"type" => "api_error", "message" => "internal error"}
+        })
+
+        expect { transport.send_message("prompt") }
+          .to raise_error(AgentHarness::ProviderError, /internal error/)
+      end
+
+      it "raises ProviderError on 529 (overloaded)" do
+        stub_api_response(status: 529, body: {
+          "error" => {"type" => "overloaded_error", "message" => "API is overloaded"}
+        })
+
+        expect { transport.send_message("prompt") }
+          .to raise_error(AgentHarness::ProviderError, /overloaded/)
+      end
+
+      it "handles non-JSON error responses" do
+        stub_raw_api_response(status: 502, body_string: "Bad Gateway")
+
+        expect { transport.send_message("prompt") }
+          .to raise_error(AgentHarness::ProviderError, /Bad Gateway/)
+      end
+
+      it "raises ProviderError for unexpected status codes" do
+        stub_api_response(status: 418, body: {
+          "error" => {"message" => "I'm a teapot"}
+        })
+
+        expect { transport.send_message("prompt") }
+          .to raise_error(AgentHarness::ProviderError, /418/)
+      end
+    end
+
+    context "network errors" do
+      it "raises TimeoutError on open timeout" do
+        http = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:new).and_return(http)
+        allow(http).to receive(:use_ssl=)
+        allow(http).to receive(:open_timeout=)
+        allow(http).to receive(:read_timeout=)
+        allow(http).to receive(:request).and_raise(Net::OpenTimeout.new("connection timed out"))
+
+        expect { transport.send_message("prompt") }
+          .to raise_error(AgentHarness::TimeoutError, /connection timed out/)
+      end
+
+      it "raises TimeoutError on read timeout" do
+        http = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:new).and_return(http)
+        allow(http).to receive(:use_ssl=)
+        allow(http).to receive(:open_timeout=)
+        allow(http).to receive(:read_timeout=)
+        allow(http).to receive(:request).and_raise(Net::ReadTimeout.new("read timed out"))
+
+        expect { transport.send_message("prompt") }
+          .to raise_error(AgentHarness::TimeoutError, /read timed out/)
+      end
+
+      it "raises ProviderError on connection refused" do
+        http = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:new).and_return(http)
+        allow(http).to receive(:use_ssl=)
+        allow(http).to receive(:open_timeout=)
+        allow(http).to receive(:read_timeout=)
+        allow(http).to receive(:request).and_raise(Errno::ECONNREFUSED)
+
+        expect { transport.send_message("prompt") }
+          .to raise_error(AgentHarness::ProviderError, /connection error/i)
+      end
+
+      it "raises ProviderError on socket error" do
+        http = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:new).and_return(http)
+        allow(http).to receive(:use_ssl=)
+        allow(http).to receive(:open_timeout=)
+        allow(http).to receive(:read_timeout=)
+        allow(http).to receive(:request).and_raise(SocketError.new("getaddrinfo: Name or service not known"))
+
+        expect { transport.send_message("prompt") }
+          .to raise_error(AgentHarness::ProviderError, /connection error/i)
+      end
+    end
+
+    context "timeout configuration" do
+      it "sets open_timeout to minimum of timeout and 30" do
+        http = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:new).and_return(http)
+        allow(http).to receive(:use_ssl=)
+        allow(http).to receive(:read_timeout=)
+        allow(http).to receive(:request).and_return(
+          instance_double(Net::HTTPOK,
+            code: "200",
+            body: JSON.generate({"content" => [], "usage" => {"input_tokens" => 0, "output_tokens" => 0}}))
+        )
+
+        expect(http).to receive(:open_timeout=).with(30)
+
+        transport.send_message("prompt", timeout: 120)
+      end
+
+      it "uses timeout value for open_timeout when less than 30" do
+        http = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:new).and_return(http)
+        allow(http).to receive(:use_ssl=)
+        allow(http).to receive(:read_timeout=)
+        allow(http).to receive(:request).and_return(
+          instance_double(Net::HTTPOK,
+            code: "200",
+            body: JSON.generate({"content" => [], "usage" => {"input_tokens" => 0, "output_tokens" => 0}}))
+        )
+
+        expect(http).to receive(:open_timeout=).with(10)
+
+        transport.send_message("prompt", timeout: 10)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add a lightweight text-only transport that calls the Anthropic Messages API directly over HTTP, bypassing the CLI subprocess for pure prompt-in/text-out use cases like PR description generation and issue summarization. This eliminates the overhead and safety risks of spawning a CLI process (context file loading, tool execution, git state leakage) while preserving token tracking, error classification, and fallback semantics through the existing `AgentHarness.send_message` interface.

## Changes

**New transport layer**
- `TextTransport` class wraps `net/http` calls to the Anthropic Messages API, handling request construction, text content extraction, token usage parsing, and error classification (401→AuthenticationError, 429→RateLimitError, timeouts→TimeoutError)

**Provider interface**
- Added `supports_text_mode?` to the adapter interface (default `false`) so each provider declares whether it has an HTTP backend
- Anthropic provider overrides `supports_text_mode?` → `true` and intercepts `mode: :text` to route through `TextTransport`
- Providers without HTTP support fall back to CLI with `tools: :none` set implicitly (builds on #113)

**Auth safety**
- New `AuthMismatchError` (subclass of `AuthenticationError`) raised when `mode: :text` is requested but no `ANTHROPIC_API_KEY` is available — prevents silent billing shift from subscription-based CLI pricing to API-metered usage

**Error model**
- HTTP error codes mapped to the same error hierarchy used by CLI execution, so callers get consistent retry/circuit-breaker/fallback behavior regardless of transport

**Tests**
- 22 specs for `TextTransport` (happy path, error codes, network errors, timeout config)
- 7 specs for CLI fallback when provider lacks HTTP transport
- 10 specs on Anthropic provider for text mode routing, token tracking, model selection, and auth mismatch

## Design Decisions

- **`net/http` over `ruby-llm` or other clients** — avoids adding a dependency that would need vetting against agent-harness's error model and token extraction conventions. The transport is intentionally thin (~single file) and can be swapped later.
- **Auth-mismatch fails loudly** — rather than silently falling back to CLI when an API key is missing, the transport raises `AuthMismatchError`. This protects teams on subscription-based CLI billing from unexpected API-metered charges.
- **Anthropic-only initially** — the `supports_text_mode?` interface makes it straightforward to add HTTP transports for other providers incrementally without changing the caller-facing API.
- **Implicit `tools: :none` on fallback** — when a provider lacks HTTP transport, the CLI fallback automatically disables tools, ensuring text-mode callers never trigger unintended tool execution regardless of provider.

---

Closes #114