### PR TITLE
Fix #119: Claude provider leaks raw --output-format json envelope as response.output

### DIFF
--- a/lib/agent_harness/providers/anthropic.rb
+++ b/lib/agent_harness/providers/anthropic.rb
@@ -161,6 +161,40 @@ module AgentHarness
           Base::DEFAULT_SMOKE_TEST_CONTRACT
         end
 
+        # Parse a raw Claude CLI --output-format=json envelope into its components.
+        #
+        # Downstream callers that capture Claude CLI stdout directly (e.g. container
+        # execution plans) can use this to extract the assistant text, error state,
+        # token usage, and structured metadata without re-implementing the parsing.
+        #
+        # @param json_string [String] raw JSON envelope from Claude CLI stdout
+        # @return [Hash, nil] parsed components or nil if not a valid envelope
+        #   - :output [String] the assistant's final text (the "result" field)
+        #   - :error [String, nil] error message if is_error was true
+        #   - :tokens [Hash, nil] {input:, output:, total:} token counts
+        #   - :metadata [Hash] structured metadata (cost_usd, session_id, etc.)
+        def parse_cli_json_envelope(json_string)
+          return nil if json_string.nil? || json_string.empty?
+
+          parsed = JSON.parse(json_string)
+          return nil unless parsed.is_a?(Hash) && parsed.key?("result")
+
+          instance = allocate
+          output = parsed["result"]
+          error = nil
+
+          if parsed["is_error"]
+            error = instance.send(:classify_error_message, output || "Unknown Claude CLI error")
+          end
+
+          tokens = instance.send(:extract_tokens, parsed)
+          metadata = instance.send(:extract_envelope_metadata, parsed)
+
+          {output: output, error: error, tokens: tokens, metadata: metadata}
+        rescue JSON::ParserError
+          nil
+        end
+
         private
 
         def validate_version!(version)
@@ -473,17 +507,24 @@ module AgentHarness
         output = result.stdout
         error = nil
         tokens = nil
+        metadata = {}
 
         if result.failed?
           combined = [result.stdout, result.stderr].compact.join("\n")
           error = classify_error_message(combined)
         end
 
-        # Parse JSON output to extract result text and token usage
+        # Parse JSON output to extract result text, token usage, and metadata
         parsed = parse_json_output(output)
         if parsed
+          # Handle is_error envelopes as provider errors
+          if parsed["is_error"]
+            error ||= classify_error_message(parsed["result"] || "Unknown Claude CLI error")
+          end
+
           output = parsed["result"] || output
           tokens = extract_tokens(parsed)
+          metadata = extract_envelope_metadata(parsed)
         end
 
         Response.new(
@@ -493,6 +534,7 @@ module AgentHarness
           provider: self.class.provider_name,
           model: @config.model,
           tokens: tokens,
+          metadata: metadata,
           error: error
         )
       end
@@ -570,6 +612,18 @@ module AgentHarness
         JSON.parse(output)
       rescue JSON::ParserError
         nil
+      end
+
+      def extract_envelope_metadata(parsed)
+        meta = {}
+        meta[:cost_usd] = parsed["total_cost_usd"] if parsed.key?("total_cost_usd")
+        meta[:session_id] = parsed["session_id"] if parsed.key?("session_id")
+        meta[:stop_reason] = parsed["stop_reason"] if parsed.key?("stop_reason")
+        meta[:terminal_reason] = parsed["terminal_reason"] if parsed.key?("terminal_reason")
+        meta[:num_turns] = parsed["num_turns"] if parsed.key?("num_turns")
+        meta[:duration_ms] = parsed["duration_ms"] if parsed.key?("duration_ms")
+        meta[:duration_api_ms] = parsed["duration_api_ms"] if parsed.key?("duration_api_ms")
+        meta
       end
 
       def extract_tokens(parsed)

--- a/lib/agent_harness/providers/anthropic.rb
+++ b/lib/agent_harness/providers/anthropic.rb
@@ -179,16 +179,15 @@ module AgentHarness
           parsed = JSON.parse(json_string)
           return nil unless parsed.is_a?(Hash) && parsed.key?("result")
 
-          instance = allocate
           output = parsed["result"]
           error = nil
 
           if parsed["is_error"]
-            error = instance.send(:classify_error_message, output || "Unknown Claude CLI error")
+            error = classify_error_message(output || "Unknown Claude CLI error")
           end
 
-          tokens = instance.send(:extract_tokens, parsed)
-          metadata = instance.send(:extract_envelope_metadata, parsed)
+          tokens = extract_tokens(parsed)
+          metadata = extract_envelope_metadata(parsed)
 
           {output: output, error: error, tokens: tokens, metadata: metadata}
         rescue JSON::ParserError
@@ -196,6 +195,46 @@ module AgentHarness
         end
 
         private
+
+        def classify_error_message(message)
+          msg_lower = message.downcase
+
+          if msg_lower.include?("rate limit") || msg_lower.include?("session limit")
+            "Rate limit exceeded"
+          elsif msg_lower.include?("deprecat") || msg_lower.include?("end-of-life")
+            "Model deprecated"
+          elsif msg_lower.include?("oauth token") || msg_lower.include?("authentication")
+            "Authentication error"
+          else
+            message
+          end
+        end
+
+        def extract_tokens(parsed)
+          usage = parsed["usage"]
+          return nil unless usage
+
+          input = usage["input_tokens"]
+          output = usage["output_tokens"]
+          return nil unless input || output
+
+          input ||= 0
+          output ||= 0
+
+          {input: input, output: output, total: input + output}
+        end
+
+        def extract_envelope_metadata(parsed)
+          meta = {}
+          meta[:cost_usd] = parsed["total_cost_usd"] if parsed.key?("total_cost_usd")
+          meta[:session_id] = parsed["session_id"] if parsed.key?("session_id")
+          meta[:stop_reason] = parsed["stop_reason"] if parsed.key?("stop_reason")
+          meta[:terminal_reason] = parsed["terminal_reason"] if parsed.key?("terminal_reason")
+          meta[:num_turns] = parsed["num_turns"] if parsed.key?("num_turns")
+          meta[:duration_ms] = parsed["duration_ms"] if parsed.key?("duration_ms")
+          meta[:duration_api_ms] = parsed["duration_api_ms"] if parsed.key?("duration_api_ms")
+          meta
+        end
 
         def validate_version!(version)
           unless version.is_a?(String) && !version.strip.empty?
@@ -614,44 +653,18 @@ module AgentHarness
         nil
       end
 
+      # Delegate to class-level implementations so both instance and class
+      # methods share a single definition.
       def extract_envelope_metadata(parsed)
-        meta = {}
-        meta[:cost_usd] = parsed["total_cost_usd"] if parsed.key?("total_cost_usd")
-        meta[:session_id] = parsed["session_id"] if parsed.key?("session_id")
-        meta[:stop_reason] = parsed["stop_reason"] if parsed.key?("stop_reason")
-        meta[:terminal_reason] = parsed["terminal_reason"] if parsed.key?("terminal_reason")
-        meta[:num_turns] = parsed["num_turns"] if parsed.key?("num_turns")
-        meta[:duration_ms] = parsed["duration_ms"] if parsed.key?("duration_ms")
-        meta[:duration_api_ms] = parsed["duration_api_ms"] if parsed.key?("duration_api_ms")
-        meta
+        self.class.send(:extract_envelope_metadata, parsed)
       end
 
       def extract_tokens(parsed)
-        usage = parsed["usage"]
-        return nil unless usage
-
-        input = usage["input_tokens"]
-        output = usage["output_tokens"]
-        return nil unless input || output
-
-        input ||= 0
-        output ||= 0
-
-        {input: input, output: output, total: input + output}
+        self.class.send(:extract_tokens, parsed)
       end
 
       def classify_error_message(message)
-        msg_lower = message.downcase
-
-        if msg_lower.include?("rate limit") || msg_lower.include?("session limit")
-          "Rate limit exceeded"
-        elsif msg_lower.include?("deprecat") || msg_lower.include?("end-of-life")
-          "Model deprecated"
-        elsif msg_lower.include?("oauth token") || msg_lower.include?("authentication")
-          "Authentication error"
-        else
-          message
-        end
+        self.class.send(:classify_error_message, message)
       end
 
       def parse_claude_mcp_output(output)

--- a/spec/agent_harness/providers/anthropic_spec.rb
+++ b/spec/agent_harness/providers/anthropic_spec.rb
@@ -13,6 +13,67 @@ RSpec.describe AgentHarness::Providers::Anthropic do
     end
   end
 
+  describe ".parse_cli_json_envelope" do
+    it "extracts output, tokens, and metadata from a success envelope" do
+      envelope = JSON.generate({
+        "type" => "result",
+        "subtype" => "success",
+        "is_error" => false,
+        "duration_ms" => 3588,
+        "duration_api_ms" => 388_349,
+        "num_turns" => 1,
+        "result" => "Hello! How can I help?",
+        "stop_reason" => "end_turn",
+        "session_id" => "sess-abc-123",
+        "total_cost_usd" => 2.28,
+        "terminal_reason" => "completed",
+        "usage" => {"input_tokens" => 100, "output_tokens" => 50}
+      })
+
+      parsed = described_class.parse_cli_json_envelope(envelope)
+
+      expect(parsed[:output]).to eq("Hello! How can I help?")
+      expect(parsed[:error]).to be_nil
+      expect(parsed[:tokens]).to eq({input: 100, output: 50, total: 150})
+      expect(parsed[:metadata][:cost_usd]).to eq(2.28)
+      expect(parsed[:metadata][:session_id]).to eq("sess-abc-123")
+      expect(parsed[:metadata][:stop_reason]).to eq("end_turn")
+      expect(parsed[:metadata][:terminal_reason]).to eq("completed")
+      expect(parsed[:metadata][:num_turns]).to eq(1)
+      expect(parsed[:metadata][:duration_ms]).to eq(3588)
+      expect(parsed[:metadata][:duration_api_ms]).to eq(388_349)
+    end
+
+    it "surfaces is_error envelopes as errors" do
+      envelope = JSON.generate({
+        "type" => "result",
+        "is_error" => true,
+        "result" => "Rate limit exceeded for this model"
+      })
+
+      parsed = described_class.parse_cli_json_envelope(envelope)
+
+      expect(parsed[:output]).to eq("Rate limit exceeded for this model")
+      expect(parsed[:error]).to eq("Rate limit exceeded")
+    end
+
+    it "returns nil for non-JSON input" do
+      expect(described_class.parse_cli_json_envelope("not json")).to be_nil
+    end
+
+    it "returns nil for nil input" do
+      expect(described_class.parse_cli_json_envelope(nil)).to be_nil
+    end
+
+    it "returns nil for empty input" do
+      expect(described_class.parse_cli_json_envelope("")).to be_nil
+    end
+
+    it "returns nil for JSON without a result field" do
+      expect(described_class.parse_cli_json_envelope('{"foo":"bar"}')).to be_nil
+    end
+  end
+
   describe ".install_contract" do
     it "exposes the official install contract" do
       contract = described_class.install_contract
@@ -839,6 +900,130 @@ RSpec.describe AgentHarness::Providers::Anthropic do
           expect(summary[:total_input_tokens]).to eq(50)
           expect(summary[:total_output_tokens]).to eq(25)
           expect(summary[:total_tokens]).to eq(75)
+        end
+      end
+
+      context "with is_error envelope" do
+        it "surfaces is_error as a provider error" do
+          json_output = JSON.generate({
+            "type" => "result",
+            "subtype" => "error",
+            "is_error" => true,
+            "result" => "Rate limit exceeded for this model",
+            "usage" => {"input_tokens" => 10, "output_tokens" => 0}
+          })
+
+          allow(mock_executor).to receive(:execute).and_return(
+            AgentHarness::CommandExecutor::Result.new(
+              stdout: json_output,
+              stderr: "",
+              exit_code: 0,
+              duration: 1.0
+            )
+          )
+
+          response = provider.send_message(prompt: "Hello")
+          expect(response.error).to eq("Rate limit exceeded")
+          expect(response.output).to eq("Rate limit exceeded for this model")
+        end
+
+        it "classifies authentication errors from is_error envelope" do
+          json_output = JSON.generate({
+            "type" => "result",
+            "is_error" => true,
+            "result" => "Authentication failed: oauth token expired"
+          })
+
+          allow(mock_executor).to receive(:execute).and_return(
+            AgentHarness::CommandExecutor::Result.new(
+              stdout: json_output,
+              stderr: "",
+              exit_code: 0,
+              duration: 1.0
+            )
+          )
+
+          response = provider.send_message(prompt: "Hello")
+          expect(response.error).to eq("Authentication error")
+        end
+
+        it "uses generic error for unclassified is_error envelopes" do
+          json_output = JSON.generate({
+            "type" => "result",
+            "is_error" => true,
+            "result" => "Something unexpected happened"
+          })
+
+          allow(mock_executor).to receive(:execute).and_return(
+            AgentHarness::CommandExecutor::Result.new(
+              stdout: json_output,
+              stderr: "",
+              exit_code: 0,
+              duration: 1.0
+            )
+          )
+
+          response = provider.send_message(prompt: "Hello")
+          expect(response.error).to eq("Something unexpected happened")
+        end
+      end
+
+      context "with envelope metadata extraction" do
+        it "extracts structured metadata from the JSON envelope" do
+          json_output = JSON.generate({
+            "type" => "result",
+            "subtype" => "success",
+            "is_error" => false,
+            "duration_ms" => 3588,
+            "duration_api_ms" => 388_349,
+            "num_turns" => 1,
+            "result" => "Hello! How can I help?",
+            "stop_reason" => "end_turn",
+            "session_id" => "abc-123",
+            "total_cost_usd" => 2.28,
+            "terminal_reason" => "completed",
+            "usage" => {"input_tokens" => 100, "output_tokens" => 50}
+          })
+
+          allow(mock_executor).to receive(:execute).and_return(
+            AgentHarness::CommandExecutor::Result.new(
+              stdout: json_output,
+              stderr: "",
+              exit_code: 0,
+              duration: 3.5
+            )
+          )
+
+          response = provider.send_message(prompt: "Hello")
+          expect(response.output).to eq("Hello! How can I help?")
+          expect(response.metadata[:cost_usd]).to eq(2.28)
+          expect(response.metadata[:session_id]).to eq("abc-123")
+          expect(response.metadata[:stop_reason]).to eq("end_turn")
+          expect(response.metadata[:terminal_reason]).to eq("completed")
+          expect(response.metadata[:num_turns]).to eq(1)
+          expect(response.metadata[:duration_ms]).to eq(3588)
+          expect(response.metadata[:duration_api_ms]).to eq(388_349)
+        end
+
+        it "handles envelopes with partial metadata" do
+          json_output = JSON.generate({
+            "result" => "Hello!",
+            "session_id" => "xyz-456"
+          })
+
+          allow(mock_executor).to receive(:execute).and_return(
+            AgentHarness::CommandExecutor::Result.new(
+              stdout: json_output,
+              stderr: "",
+              exit_code: 0,
+              duration: 1.0
+            )
+          )
+
+          response = provider.send_message(prompt: "Hello")
+          expect(response.output).to eq("Hello!")
+          expect(response.metadata[:session_id]).to eq("xyz-456")
+          expect(response.metadata[:cost_usd]).to be_nil
         end
       end
     end


### PR DESCRIPTION
## Summary

Claude provider leaks raw --output-format json envelope as response.output

See #119 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #119