### PR TITLE
feat(providers): add error_classification_patterns, noisy_error_patterns, and translate_error to provider classes

### DIFF
--- a/lib/agent_harness/providers/adapter.rb
+++ b/lib/agent_harness/providers/adapter.rb
@@ -781,6 +781,50 @@ module AgentHarness
         {}
       end
 
+      # Error classification patterns for downstream consumers
+      #
+      # Returns patterns grouped by classification category. These patterns
+      # encode provider-specific knowledge about how each CLI reports errors
+      # and are intended for use by callers outside agent-harness.
+      #
+      # @return [Hash<Symbol, Array<Regexp>>] patterns by category
+      #   (:auth_expired, :abort, :authentication, :quota)
+      def error_classification_patterns
+        {
+          auth_expired: [],
+          abort: [],
+          authentication: [],
+          quota: [
+            /requires more credits/i,
+            /insufficient credits/i,
+            /credit.*exceeded/i,
+            /spend limit.*reached/i,
+            /billing.*limit/i
+          ]
+        }
+      end
+
+      # Patterns matching noisy/non-actionable error output
+      #
+      # Downstream consumers can use these to filter out log noise
+      # from provider stderr/stdout that is not meaningful for users.
+      #
+      # @return [Array<Regexp>] noisy error patterns
+      def noisy_error_patterns
+        []
+      end
+
+      # Translate a raw error message into a user-friendly string
+      #
+      # Providers override this to map CLI-specific error output
+      # into concise, actionable messages.
+      #
+      # @param message [String] raw error message
+      # @return [String] translated message (or the original if no match)
+      def translate_error(message)
+        message
+      end
+
       # Authentication type for this provider
       #
       # @return [Symbol] :oauth for token-based auth that can expire,

--- a/lib/agent_harness/providers/anthropic.rb
+++ b/lib/agent_harness/providers/anthropic.rb
@@ -474,6 +474,15 @@ module AgentHarness
         }
       end
 
+      def error_classification_patterns
+        super.merge(
+          abort: [
+            /free tier limit reached/i,
+            /please upgrade to a paid plan/i
+          ]
+        )
+      end
+
       def fetch_mcp_servers
         return [] unless self.class.available?
 

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -216,6 +216,31 @@ module AgentHarness
         }
       end
 
+      def error_classification_patterns
+        super.merge(
+          auth_expired: [
+            /refresh_token_reused/i,
+            /refresh token has already been used/i,
+            /Please log out and sign in again/i,
+            /authentication_error/i,
+            /invalid_grant/i,
+            /Token is expired or invalid/i
+          ],
+          abort: [
+            /free tier limit reached/i,
+            /please upgrade to a paid plan/i
+          ]
+        )
+      end
+
+      def translate_error(message)
+        case message
+        when /refresh_token_reused/i then "Codex authentication expired. Please re-authenticate."
+        when /free tier limit/i then "Codex free tier limit reached."
+        else message
+        end
+      end
+
       def auth_status
         api_key = ENV["OPENAI_API_KEY"]
         if api_key && !api_key.strip.empty?

--- a/lib/agent_harness/providers/gemini.rb
+++ b/lib/agent_harness/providers/gemini.rb
@@ -204,6 +204,35 @@ module AgentHarness
         }
       end
 
+      def error_classification_patterns
+        super.merge(
+          authentication: [
+            /GEMINI_API_KEY/i,
+            /GOOGLE_GENAI_USE_VERTEXAI/i,
+            /GOOGLE_GENAI_USE_GCA/i,
+            /ValidationRequiredError/i,
+            /API key not configured for google/i,
+            /API key not valid/i
+          ]
+        )
+      end
+
+      def noisy_error_patterns
+        [
+          /Error when talking to Gemini API/i,
+          /service=.*status/i,
+          /loading\.\.\./i,
+          /subscribing/i
+        ]
+      end
+
+      def translate_error(message)
+        case message
+        when /API key not configured/i then "Gemini API key not set. Run: export GEMINI_API_KEY=..."
+        else message
+        end
+      end
+
       def auth_status
         api_key = [ENV["GEMINI_API_KEY"], ENV["GOOGLE_API_KEY"]].find { |key| key && !key.strip.empty? }
         if api_key

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -191,6 +191,13 @@ module AgentHarness
         }
       end
 
+      def translate_error(message)
+        case message
+        when /github-copilot-cli.*not found/i then "GitHub Copilot CLI not installed."
+        else message
+        end
+      end
+
       def supports_token_counting?
         supports_json_output_format?
       end

--- a/spec/agent_harness/providers/adapter_spec.rb
+++ b/spec/agent_harness/providers/adapter_spec.rb
@@ -1983,6 +1983,31 @@ RSpec.describe AgentHarness::Providers::Adapter do
       end
     end
 
+    describe "#error_classification_patterns" do
+      it "returns a hash with default categories" do
+        patterns = adapter.error_classification_patterns
+        expect(patterns).to be_a(Hash)
+        expect(patterns.keys).to contain_exactly(:auth_expired, :abort, :authentication, :quota)
+      end
+
+      it "includes shared quota patterns" do
+        patterns = adapter.error_classification_patterns
+        expect(patterns[:quota]).not_to be_empty
+      end
+    end
+
+    describe "#noisy_error_patterns" do
+      it "returns an empty array by default" do
+        expect(adapter.noisy_error_patterns).to eq([])
+      end
+    end
+
+    describe "#translate_error" do
+      it "returns the message unchanged by default" do
+        expect(adapter.translate_error("some error")).to eq("some error")
+      end
+    end
+
     describe "#auth_type" do
       it "returns :api_key by default" do
         expect(adapter.auth_type).to eq(:api_key)

--- a/spec/agent_harness/providers/anthropic_spec.rb
+++ b/spec/agent_harness/providers/anthropic_spec.rb
@@ -510,7 +510,29 @@ RSpec.describe AgentHarness::Providers::Anthropic do
         patterns = provider.error_patterns
         expect(patterns[:permanent]).not_to be_empty
       end
+    end
 
+    describe "#error_classification_patterns" do
+      it "includes abort patterns for free tier" do
+        patterns = provider.error_classification_patterns
+        expect(patterns[:abort]).not_to be_empty
+        expect(patterns[:abort].any? { |p| "free tier limit reached" =~ p }).to be true
+        expect(patterns[:abort].any? { |p| "please upgrade to a paid plan" =~ p }).to be true
+      end
+
+      it "inherits shared quota patterns from base" do
+        patterns = provider.error_classification_patterns
+        expect(patterns[:quota]).not_to be_empty
+      end
+
+      it "has empty auth_expired and authentication arrays" do
+        patterns = provider.error_classification_patterns
+        expect(patterns[:auth_expired]).to eq([])
+        expect(patterns[:authentication]).to eq([])
+      end
+    end
+
+    describe "#error_patterns (continued)" do
       it "does not misclassify embedded numeric substrings as HTTP status codes" do
         patterns = provider.error_patterns
         expect(

--- a/spec/agent_harness/providers/anthropic_spec.rb
+++ b/spec/agent_harness/providers/anthropic_spec.rb
@@ -510,29 +510,7 @@ RSpec.describe AgentHarness::Providers::Anthropic do
         patterns = provider.error_patterns
         expect(patterns[:permanent]).not_to be_empty
       end
-    end
 
-    describe "#error_classification_patterns" do
-      it "includes abort patterns for free tier" do
-        patterns = provider.error_classification_patterns
-        expect(patterns[:abort]).not_to be_empty
-        expect(patterns[:abort].any? { |p| "free tier limit reached" =~ p }).to be true
-        expect(patterns[:abort].any? { |p| "please upgrade to a paid plan" =~ p }).to be true
-      end
-
-      it "inherits shared quota patterns from base" do
-        patterns = provider.error_classification_patterns
-        expect(patterns[:quota]).not_to be_empty
-      end
-
-      it "has empty auth_expired and authentication arrays" do
-        patterns = provider.error_classification_patterns
-        expect(patterns[:auth_expired]).to eq([])
-        expect(patterns[:authentication]).to eq([])
-      end
-    end
-
-    describe "#error_patterns (continued)" do
       it "does not misclassify embedded numeric substrings as HTTP status codes" do
         patterns = provider.error_patterns
         expect(
@@ -569,6 +547,26 @@ RSpec.describe AgentHarness::Providers::Anthropic do
             patterns
           )
         ).to eq(:unknown)
+      end
+    end
+
+    describe "#error_classification_patterns" do
+      it "includes abort patterns for free tier" do
+        patterns = provider.error_classification_patterns
+        expect(patterns[:abort]).not_to be_empty
+        expect(patterns[:abort].any? { |p| "free tier limit reached" =~ p }).to be true
+        expect(patterns[:abort].any? { |p| "please upgrade to a paid plan" =~ p }).to be true
+      end
+
+      it "inherits shared quota patterns from base" do
+        patterns = provider.error_classification_patterns
+        expect(patterns[:quota]).not_to be_empty
+      end
+
+      it "has empty auth_expired and authentication arrays" do
+        patterns = provider.error_classification_patterns
+        expect(patterns[:auth_expired]).to eq([])
+        expect(patterns[:authentication]).to eq([])
       end
     end
 

--- a/spec/agent_harness/providers/base_spec.rb
+++ b/spec/agent_harness/providers/base_spec.rb
@@ -88,6 +88,41 @@ RSpec.describe AgentHarness::Providers::Base do
     end
   end
 
+  describe "#error_classification_patterns" do
+    it "returns a hash with default categories" do
+      patterns = provider.error_classification_patterns
+      expect(patterns).to be_a(Hash)
+      expect(patterns.keys).to contain_exactly(:auth_expired, :abort, :authentication, :quota)
+    end
+
+    it "has empty arrays for auth_expired, abort, and authentication" do
+      patterns = provider.error_classification_patterns
+      expect(patterns[:auth_expired]).to eq([])
+      expect(patterns[:abort]).to eq([])
+      expect(patterns[:authentication]).to eq([])
+    end
+
+    it "includes shared quota patterns" do
+      patterns = provider.error_classification_patterns
+      expect(patterns[:quota]).not_to be_empty
+      expect(patterns[:quota].any? { |p| "insufficient credits" =~ p }).to be true
+      expect(patterns[:quota].any? { |p| "spend limit reached" =~ p }).to be true
+      expect(patterns[:quota].any? { |p| "billing limit" =~ p }).to be true
+    end
+  end
+
+  describe "#noisy_error_patterns" do
+    it "returns an empty array by default" do
+      expect(provider.noisy_error_patterns).to eq([])
+    end
+  end
+
+  describe "#translate_error" do
+    it "returns the message unchanged by default" do
+      expect(provider.translate_error("some error")).to eq("some error")
+    end
+  end
+
   describe "COMMON_ERROR_PATTERNS" do
     it "is defined on the Base class" do
       expect(described_class::COMMON_ERROR_PATTERNS).to be_a(Hash)

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -4966,6 +4966,45 @@ RSpec.describe AgentHarness::Providers::Codex do
       end
     end
 
+    describe "#error_classification_patterns" do
+      it "includes auth_expired patterns for OAuth refresh failures" do
+        patterns = provider.error_classification_patterns
+        expect(patterns[:auth_expired]).not_to be_empty
+        expect(patterns[:auth_expired].any? { |p| "refresh_token_reused" =~ p }).to be true
+        expect(patterns[:auth_expired].any? { |p| "Please log out and sign in again" =~ p }).to be true
+        expect(patterns[:auth_expired].any? { |p| "authentication_error" =~ p }).to be true
+        expect(patterns[:auth_expired].any? { |p| "invalid_grant" =~ p }).to be true
+        expect(patterns[:auth_expired].any? { |p| "Token is expired or invalid" =~ p }).to be true
+      end
+
+      it "includes abort patterns for free tier" do
+        patterns = provider.error_classification_patterns
+        expect(patterns[:abort]).not_to be_empty
+        expect(patterns[:abort].any? { |p| "free tier limit reached" =~ p }).to be true
+        expect(patterns[:abort].any? { |p| "please upgrade to a paid plan" =~ p }).to be true
+      end
+
+      it "inherits shared quota patterns from base" do
+        patterns = provider.error_classification_patterns
+        expect(patterns[:quota]).not_to be_empty
+        expect(patterns[:quota].any? { |p| "insufficient credits" =~ p }).to be true
+      end
+    end
+
+    describe "#translate_error" do
+      it "translates refresh_token_reused" do
+        expect(provider.translate_error("refresh_token_reused error")).to eq("Codex authentication expired. Please re-authenticate.")
+      end
+
+      it "translates free tier limit" do
+        expect(provider.translate_error("free tier limit reached")).to eq("Codex free tier limit reached.")
+      end
+
+      it "returns unknown messages unchanged" do
+        expect(provider.translate_error("something else")).to eq("something else")
+      end
+    end
+
     describe "#smoke_test" do
       let(:mock_executor) { instance_double(AgentHarness::CommandExecutor) }
       subject(:provider) { described_class.new(executor: mock_executor) }

--- a/spec/agent_harness/providers/gemini_spec.rb
+++ b/spec/agent_harness/providers/gemini_spec.rb
@@ -266,6 +266,41 @@ RSpec.describe AgentHarness::Providers::Gemini do
       end
     end
 
+    describe "#error_classification_patterns" do
+      it "includes authentication patterns for Gemini-specific errors" do
+        patterns = provider.error_classification_patterns
+        expect(patterns[:authentication]).not_to be_empty
+        expect(patterns[:authentication].any? { |p| "GEMINI_API_KEY" =~ p }).to be true
+        expect(patterns[:authentication].any? { |p| "ValidationRequiredError" =~ p }).to be true
+        expect(patterns[:authentication].any? { |p| "API key not configured for google" =~ p }).to be true
+        expect(patterns[:authentication].any? { |p| "API key not valid" =~ p }).to be true
+      end
+
+      it "inherits shared quota patterns from base" do
+        patterns = provider.error_classification_patterns
+        expect(patterns[:quota]).not_to be_empty
+      end
+    end
+
+    describe "#noisy_error_patterns" do
+      it "returns Gemini-specific noisy patterns" do
+        patterns = provider.noisy_error_patterns
+        expect(patterns).not_to be_empty
+        expect(patterns.any? { |p| "Error when talking to Gemini API" =~ p }).to be true
+        expect(patterns.any? { |p| "loading..." =~ p }).to be true
+      end
+    end
+
+    describe "#translate_error" do
+      it "translates API key not configured" do
+        expect(provider.translate_error("API key not configured for google")).to eq("Gemini API key not set. Run: export GEMINI_API_KEY=...")
+      end
+
+      it "returns unknown messages unchanged" do
+        expect(provider.translate_error("something else")).to eq("something else")
+      end
+    end
+
     describe "#send_message" do
       it "includes model when configured" do
         allow(mock_executor).to receive(:execute).and_return(

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -404,6 +404,16 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
       end
     end
 
+    describe "#translate_error" do
+      it "translates CLI not found" do
+        expect(provider.translate_error("github-copilot-cli was not found")).to eq("GitHub Copilot CLI not installed.")
+      end
+
+      it "returns unknown messages unchanged" do
+        expect(provider.translate_error("something else")).to eq("something else")
+      end
+    end
+
     describe "#execution_semantics" do
       it "returns the full provider contract" do
         semantics = provider.execution_semantics


### PR DESCRIPTION
## Summary

feat(providers): add error_classification_patterns, noisy_error_patterns, and translate_error to provider classes

See #123 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #123