### PR TITLE
feat(providers): add test_command_overrides and parse_test_error to provider classes

### DIFF
--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -205,6 +205,28 @@ module AgentHarness
         @executor.is_a?(DockerCommandExecutor)
       end
 
+      # Additional CLI flags for health-check/test invocations
+      #
+      # Providers override this to supply flags that should be appended
+      # when the CLI is invoked in a test or smoke-test context.
+      #
+      # @return [Array<String>] extra CLI flags (empty by default)
+      def test_command_overrides
+        []
+      end
+
+      # Parse provider-specific error information from test output
+      #
+      # Providers override this to extract structured error details from
+      # CLI output or sidecar files produced during a test invocation.
+      #
+      # @param output [String] the CLI stdout/stderr output
+      # @param files [Hash] mapping of logical names to file paths
+      # @return [Hash, nil] structured error hash or nil if no error detected
+      def parse_test_error(output:, files: {})
+        nil
+      end
+
       protected
 
       # Build CLI command - override in subclasses

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -167,6 +167,10 @@ module AgentHarness
         }
       end
 
+      def test_command_overrides
+        ["--skip-git-repo-check", "--output-last-message"]
+      end
+
       def dangerous_mode_flags
         ["--full-auto"]
       end

--- a/lib/agent_harness/providers/gemini.rb
+++ b/lib/agent_harness/providers/gemini.rb
@@ -163,6 +163,20 @@ module AgentHarness
         }
       end
 
+      def parse_test_error(output:, files: {})
+        error_file = files.values.find { |path| path.match?(/gemini-client-error-.*\.json/) }
+        return nil unless error_file
+
+        error_data = begin
+          JSON.parse(File.read(error_file))
+        rescue JSON::ParserError, Errno::ENOENT
+          nil
+        end
+        return nil unless error_data
+
+        {message: error_data.dig("error", "message") || output, type: :configuration}
+      end
+
       def auth_type
         :oauth
       end

--- a/lib/agent_harness/providers/kilocode.rb
+++ b/lib/agent_harness/providers/kilocode.rb
@@ -113,6 +113,10 @@ module AgentHarness
         "Kilocode CLI"
       end
 
+      def test_command_overrides
+        ["--auto", "--print-logs"]
+      end
+
       def capabilities
         {
           streaming: false,

--- a/spec/agent_harness/providers/base_spec.rb
+++ b/spec/agent_harness/providers/base_spec.rb
@@ -183,4 +183,20 @@ RSpec.describe AgentHarness::Providers::Base do
       expect(docker_provider.sandboxed_environment?).to be true
     end
   end
+
+  describe "#test_command_overrides" do
+    it "returns an empty array by default" do
+      expect(provider.test_command_overrides).to eq([])
+    end
+  end
+
+  describe "#parse_test_error" do
+    it "returns nil by default" do
+      expect(provider.parse_test_error(output: "some output")).to be_nil
+    end
+
+    it "accepts a files keyword argument" do
+      expect(provider.parse_test_error(output: "err", files: {"log" => "/tmp/log.txt"})).to be_nil
+    end
+  end
 end

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -5616,4 +5616,11 @@ RSpec.describe AgentHarness::Providers::Codex do
       end
     end
   end
+
+  describe "#test_command_overrides" do
+    it "returns codex-specific test flags" do
+      provider = described_class.new
+      expect(provider.test_command_overrides).to eq(["--skip-git-repo-check", "--output-last-message"])
+    end
+  end
 end

--- a/spec/agent_harness/providers/gemini_spec.rb
+++ b/spec/agent_harness/providers/gemini_spec.rb
@@ -659,4 +659,58 @@ RSpec.describe AgentHarness::Providers::Gemini do
       end
     end
   end
+
+  describe "#parse_test_error" do
+    let(:provider) { described_class.new }
+
+    it "returns nil when no matching error file is present" do
+      expect(provider.parse_test_error(output: "some output", files: {})).to be_nil
+    end
+
+    it "returns nil when error file does not match gemini pattern" do
+      files = {"log" => "/tmp/other-error.json"}
+      expect(provider.parse_test_error(output: "err", files: files)).to be_nil
+    end
+
+    it "parses a gemini client error JSON file" do
+      error_json = {"error" => {"message" => "Invalid API key"}}.to_json
+      error_path = File.join(Dir.tmpdir, "gemini-client-error-#{SecureRandom.hex(4)}.json")
+      File.write(error_path, error_json)
+
+      files = {"error" => error_path}
+      result = provider.parse_test_error(output: "failed", files: files)
+
+      expect(result).to eq({message: "Invalid API key", type: :configuration})
+    ensure
+      FileUtils.rm_f(error_path)
+    end
+
+    it "falls back to output when error message key is missing" do
+      error_json = {"error" => {}}.to_json
+      error_path = File.join(Dir.tmpdir, "gemini-client-error-#{SecureRandom.hex(4)}.json")
+      File.write(error_path, error_json)
+
+      files = {"error" => error_path}
+      result = provider.parse_test_error(output: "raw output", files: files)
+
+      expect(result).to eq({message: "raw output", type: :configuration})
+    ensure
+      FileUtils.rm_f(error_path)
+    end
+
+    it "returns nil when the error file contains invalid JSON" do
+      error_path = File.join(Dir.tmpdir, "gemini-client-error-#{SecureRandom.hex(4)}.json")
+      File.write(error_path, "not json")
+
+      files = {"error" => error_path}
+      expect(provider.parse_test_error(output: "err", files: files)).to be_nil
+    ensure
+      FileUtils.rm_f(error_path)
+    end
+
+    it "returns nil when the error file does not exist" do
+      files = {"error" => "/tmp/gemini-client-error-nonexistent.json"}
+      expect(provider.parse_test_error(output: "err", files: files)).to be_nil
+    end
+  end
 end

--- a/spec/agent_harness/providers/kilocode_spec.rb
+++ b/spec/agent_harness/providers/kilocode_spec.rb
@@ -3577,4 +3577,11 @@ RSpec.describe AgentHarness::Providers::Kilocode do
       end
     end
   end
+
+  describe "#test_command_overrides" do
+    it "returns kilocode-specific test flags" do
+      provider = described_class.new
+      expect(provider.test_command_overrides).to eq(["--auto", "--print-logs"])
+    end
+  end
 end


### PR DESCRIPTION
## Summary

feat(providers): add test_command_overrides and parse_test_error to provider classes

See #125 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #125