### PR TITLE
feat(providers): add config_file_content and auth_lock_config to provider classes

### DIFF
--- a/lib/agent_harness/providers/adapter.rb
+++ b/lib/agent_harness/providers/adapter.rb
@@ -1020,6 +1020,35 @@ module AgentHarness
         nil
       end
 
+      # Generate provider-specific config file content.
+      #
+      # Providers that require a config file written before CLI execution
+      # (e.g. Codex TOML, Kilocode JSON) should override this method.
+      #
+      # @param options [Hash] provider-specific options for config generation
+      # @return [String, nil] config file content, or nil when no config is needed
+      def config_file_content(options = {})
+        nil
+      end
+
+      # Generate provider-specific notification hook content.
+      #
+      # Providers that support notification hooks appended to their config
+      # file should override this method.
+      #
+      # @return [String, nil] notify hook content, or nil when not applicable
+      def notify_hook_content
+        nil
+      end
+
+      # Auth lock configuration for providers that need file-based lock
+      # serialization (e.g. OAuth refresh token coordination).
+      #
+      # @return [Hash, nil] lock config with :path and :timeout keys, or nil
+      def auth_lock_config
+        nil
+      end
+
       private
 
       def classify_smoke_test_message(message)

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -272,6 +272,28 @@ module AgentHarness
         {valid: errors.empty?, errors: errors}
       end
 
+      def config_file_content(options = {})
+        <<~TOML
+          [chatgpt]
+          model_provider = "#{options[:model_provider]}"
+          base_url = "#{options[:base_url]}"
+          env_key = "#{options[:env_key]}"
+          wire_api = "#{options[:wire_api]}"
+        TOML
+      end
+
+      def notify_hook_content
+        <<~TOML
+
+          [notify]
+          # Paid notification hook
+        TOML
+      end
+
+      def auth_lock_config
+        {path: "/tmp/codex-auth.lock", timeout: 30}
+      end
+
       protected
 
       def parse_response(result, duration:)

--- a/lib/agent_harness/providers/kilocode.rb
+++ b/lib/agent_harness/providers/kilocode.rb
@@ -125,6 +125,13 @@ module AgentHarness
         }
       end
 
+      def config_file_content(options = {})
+        {
+          provider: options[:api_provider],
+          model: options[:model_id]
+        }.to_json
+      end
+
       def error_patterns
         COMMON_ERROR_PATTERNS
       end

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -5616,4 +5616,53 @@ RSpec.describe AgentHarness::Providers::Codex do
       end
     end
   end
+
+  describe "#config_file_content" do
+    let(:executor) { instance_double(AgentHarness::CommandExecutor, which: "/usr/bin/codex") }
+    let(:provider) { described_class.new(executor: executor) }
+
+    it "returns TOML config with provided options" do
+      content = provider.config_file_content(
+        model_provider: "openai",
+        base_url: "https://api.openai.com",
+        env_key: "OPENAI_API_KEY",
+        wire_api: "openai"
+      )
+
+      expect(content).to include("[chatgpt]")
+      expect(content).to include('model_provider = "openai"')
+      expect(content).to include('base_url = "https://api.openai.com"')
+      expect(content).to include('env_key = "OPENAI_API_KEY"')
+      expect(content).to include('wire_api = "openai"')
+    end
+
+    it "returns TOML string with empty options" do
+      content = provider.config_file_content
+      expect(content).to include("[chatgpt]")
+      expect(content).to include('model_provider = ""')
+    end
+  end
+
+  describe "#notify_hook_content" do
+    let(:executor) { instance_double(AgentHarness::CommandExecutor, which: "/usr/bin/codex") }
+    let(:provider) { described_class.new(executor: executor) }
+
+    it "returns TOML notify hook section" do
+      content = provider.notify_hook_content
+
+      expect(content).to include("[notify]")
+      expect(content).to include("# Paid notification hook")
+    end
+  end
+
+  describe "#auth_lock_config" do
+    let(:executor) { instance_double(AgentHarness::CommandExecutor, which: "/usr/bin/codex") }
+    let(:provider) { described_class.new(executor: executor) }
+
+    it "returns lock config with path and timeout" do
+      config = provider.auth_lock_config
+
+      expect(config).to eq({path: "/tmp/codex-auth.lock", timeout: 30})
+    end
+  end
 end

--- a/spec/agent_harness/providers/kilocode_spec.rb
+++ b/spec/agent_harness/providers/kilocode_spec.rb
@@ -3577,4 +3577,47 @@ RSpec.describe AgentHarness::Providers::Kilocode do
       end
     end
   end
+
+  describe "#config_file_content" do
+    let(:executor) { instance_double(AgentHarness::CommandExecutor, which: "/usr/bin/kilo") }
+    let(:provider) { described_class.new(executor: executor) }
+
+    it "returns JSON config with provided options" do
+      content = provider.config_file_content(
+        api_provider: "anthropic",
+        model_id: "claude-sonnet-4-6"
+      )
+      parsed = JSON.parse(content)
+
+      expect(parsed["provider"]).to eq("anthropic")
+      expect(parsed["model"]).to eq("claude-sonnet-4-6")
+    end
+
+    it "returns valid JSON with empty options" do
+      content = provider.config_file_content
+      parsed = JSON.parse(content)
+
+      expect(parsed).to be_a(Hash)
+      expect(parsed["provider"]).to be_nil
+      expect(parsed["model"]).to be_nil
+    end
+  end
+
+  describe "#notify_hook_content" do
+    let(:executor) { instance_double(AgentHarness::CommandExecutor, which: "/usr/bin/kilo") }
+    let(:provider) { described_class.new(executor: executor) }
+
+    it "returns nil (not supported)" do
+      expect(provider.notify_hook_content).to be_nil
+    end
+  end
+
+  describe "#auth_lock_config" do
+    let(:executor) { instance_double(AgentHarness::CommandExecutor, which: "/usr/bin/kilo") }
+    let(:provider) { described_class.new(executor: executor) }
+
+    it "returns nil (not supported)" do
+      expect(provider.auth_lock_config).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Summary

feat(providers): add config_file_content and auth_lock_config to provider classes

See #127 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #127