### PR TITLE
feat(providers): add env var name mappings to provider classes

### DIFF
--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -170,6 +170,10 @@ module AgentHarness
         }
       end
 
+      def api_key_env_var_names = ["ANTHROPIC_API_KEY"]
+
+      def api_key_unset_vars = ["ANTHROPIC_BASE_URL", "ANTHROPIC_HEADER_X_AGENT_RUN_ID", "ANTHROPIC_HEADER_X_PROXY_TOKEN"]
+
       def error_patterns
         COMMON_ERROR_PATTERNS.merge(
           auth_expired: COMMON_ERROR_PATTERNS[:auth_expired] + [/incorrect.*api.*key/i],

--- a/lib/agent_harness/providers/anthropic.rb
+++ b/lib/agent_harness/providers/anthropic.rb
@@ -379,6 +379,12 @@ module AgentHarness
         cleanup_mcp_tempfiles!
       end
 
+      def api_key_env_var_names = ["ANTHROPIC_API_KEY"]
+
+      def api_key_unset_vars = ["ANTHROPIC_BASE_URL", "ANTHROPIC_HEADER_X_AGENT_RUN_ID", "ANTHROPIC_HEADER_X_PROXY_TOKEN"]
+
+      def subscription_unset_vars = ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"] + api_key_unset_vars
+
       def supports_mcp?
         true
       end

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -205,6 +205,29 @@ module AgentHarness
         @executor.is_a?(DockerCommandExecutor)
       end
 
+      # Environment variable names that the provider's CLI reads for API key authentication.
+      #
+      # @return [Array<String>] env var names (empty by default)
+      def api_key_env_var_names = []
+
+      # Environment variable names to unset when the caller supplies its own API key,
+      # preventing the CLI from reading stale or conflicting proxy/header variables.
+      #
+      # @return [Array<String>] env var names (empty by default)
+      def api_key_unset_vars = []
+
+      # Environment variable names to unset when the caller uses subscription-based auth,
+      # ensuring the CLI does not pick up API-key or proxy variables that would conflict.
+      #
+      # @return [Array<String>] env var names (empty by default)
+      def subscription_unset_vars = []
+
+      # Provider-specific environment variable overrides that the caller should set
+      # when invoking the CLI (e.g. feature flags or sandbox controls).
+      #
+      # @return [Hash{String => String}] env var name => value (empty by default)
+      def cli_env_overrides = {}
+
       # Additional CLI flags for health-check/test invocations
       #
       # Providers override this to supply flags that should be appended

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -167,6 +167,14 @@ module AgentHarness
         }
       end
 
+      def api_key_env_var_names = ["OPENAI_API_KEY"]
+
+      def api_key_unset_vars = ["OPENAI_BASE_URL", "OPENAI_HEADER_X_AGENT_RUN_ID", "OPENAI_HEADER_X_PROXY_TOKEN"]
+
+      def subscription_unset_vars = ["OPENAI_API_KEY", "OPENAI_BASE_URL"] + api_key_unset_vars
+
+      def cli_env_overrides = {"PAID_CODEX_SUBSCRIPTION_AUTH" => "1"}
+
       def test_command_overrides
         ["--skip-git-repo-check", "--output-last-message"]
       end

--- a/lib/agent_harness/providers/cursor.rb
+++ b/lib/agent_harness/providers/cursor.rb
@@ -206,6 +206,10 @@ module AgentHarness
         fetch_mcp_servers_cli || fetch_mcp_servers_config
       end
 
+      def api_key_env_var_names = ["ANTHROPIC_API_KEY"]
+
+      def api_key_unset_vars = ["ANTHROPIC_BASE_URL", "ANTHROPIC_HEADER_X_AGENT_RUN_ID", "ANTHROPIC_HEADER_X_PROXY_TOKEN"]
+
       def auth_type
         :oauth
       end

--- a/lib/agent_harness/providers/gemini.rb
+++ b/lib/agent_harness/providers/gemini.rb
@@ -177,6 +177,19 @@ module AgentHarness
         {message: error_data.dig("error", "message") || output, type: :configuration}
       end
 
+      def api_key_env_var_names = ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
+
+      def api_key_unset_vars = ["GOOGLE_GEMINI_BASE_URL", "GOOGLE_GENAI_BASE_URL", "GEMINI_CLI_CUSTOM_HEADERS"]
+
+      def subscription_unset_vars = ["GEMINI_API_KEY", "GOOGLE_GEMINI_BASE_URL", "GOOGLE_GENAI_BASE_URL", "GEMINI_CLI_CUSTOM_HEADERS"]
+
+      def cli_env_overrides
+        {
+          "GEMINI_SANDBOX" => "false",
+          "GEMINI_CLI_DISABLE_RETRIES" => "true"
+        }
+      end
+
       def auth_type
         :oauth
       end


### PR DESCRIPTION
## Summary

feat(providers): add env var name mappings to provider classes

See #122 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #122