### PR TITLE
feat(installers): make Github Copilot CLI installation/version support a first-class provider contract

### DIFF
--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -8,6 +8,10 @@ module AgentHarness
     class GithubCopilot < Base
       include TokenUsageParsing
 
+      PACKAGE_NAME = "@githubnext/github-copilot-cli"
+      SUPPORTED_CLI_VERSION = "0.1.36"
+      SUPPORTED_CLI_REQUIREMENT = Gem::Requirement.new(">= #{SUPPORTED_CLI_VERSION}", "< 0.2.0").freeze
+
       MODEL_PATTERN = /^gpt-[\d.o-]+(?:-turbo)?(?:-mini)?$/i
       JSON_OUTPUT_MIN_VERSION = Gem::Version.new("0.0.422").freeze
 
@@ -31,6 +35,40 @@ module AgentHarness
         def available?
           executor = AgentHarness.configuration.command_executor
           !!executor.which(binary_name)
+        end
+
+        def installation_contract(version: SUPPORTED_CLI_VERSION)
+          version = version.strip if version.respond_to?(:strip)
+          validate_install_version!(version)
+          package_spec = "#{PACKAGE_NAME}@#{version}".freeze
+          install_command_prefix = ["npm", "install", "-g", "--ignore-scripts"].freeze
+          install_command = (install_command_prefix + [package_spec]).freeze
+          version_requirement = SUPPORTED_CLI_REQUIREMENT.requirements
+            .map { |op, ver| "#{op} #{ver}".freeze }
+            .freeze
+
+          contract = {
+            source: {
+              type: :npm,
+              package: PACKAGE_NAME
+            },
+            install_command_prefix: install_command_prefix,
+            install_command: install_command,
+            binary_name: binary_name,
+            default_version: SUPPORTED_CLI_VERSION,
+            version: version,
+            version_requirement: version_requirement,
+            supported_version_requirement: SUPPORTED_CLI_REQUIREMENT.to_s
+          }
+
+          contract.each_value do |value|
+            value.freeze if value.is_a?(String)
+          end
+          contract.freeze
+        end
+
+        def install_command(version: SUPPORTED_CLI_VERSION)
+          installation_contract(version: version)[:install_command]
         end
 
         def provider_metadata_overrides
@@ -92,6 +130,30 @@ module AgentHarness
 
         def supports_model_family?(family_name)
           MODEL_PATTERN.match?(family_name)
+        end
+
+        private
+
+        def validate_install_version!(version)
+          unless version.is_a?(String) && !version.strip.empty?
+            raise ArgumentError,
+              "Unsupported GitHub Copilot CLI version #{version.inspect}; " \
+              "supported versions must satisfy #{SUPPORTED_CLI_REQUIREMENT}"
+          end
+
+          parsed_version = begin
+            Gem::Version.new(version)
+          rescue ArgumentError
+            raise ArgumentError,
+              "Unsupported GitHub Copilot CLI version #{version.inspect}; " \
+              "supported versions must satisfy #{SUPPORTED_CLI_REQUIREMENT}"
+          end
+
+          return if SUPPORTED_CLI_REQUIREMENT.satisfied_by?(parsed_version)
+
+          raise ArgumentError,
+            "Unsupported GitHub Copilot CLI version #{version.inspect}; " \
+            "supported versions must satisfy #{SUPPORTED_CLI_REQUIREMENT}"
         end
       end
 

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -51,7 +51,7 @@ module AgentHarness
             source: {
               type: :npm,
               package: PACKAGE_NAME
-            },
+            }.freeze,
             install_command_prefix: install_command_prefix,
             install_command: install_command,
             binary_name: binary_name,

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -13,6 +13,90 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
     end
   end
 
+  describe ".installation_contract" do
+    it "returns the upstream install contract" do
+      contract = described_class.installation_contract
+
+      expect(contract[:source]).to eq({
+        type: :npm,
+        package: "@githubnext/github-copilot-cli"
+      })
+      expect(contract[:binary_name]).to eq("github-copilot-cli")
+      expect(contract[:default_version]).to eq("0.1.36")
+      expect(contract[:install_command]).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "@githubnext/github-copilot-cli@0.1.36"]
+      )
+    end
+
+    it "keeps the runtime binary aligned with the install contract" do
+      contract = described_class.installation_contract
+
+      expect(contract[:binary_name]).to eq(described_class.binary_name)
+    end
+
+    it "can render an install command for an explicitly supported target" do
+      contract = described_class.installation_contract(version: "0.1.36")
+
+      expect(contract[:install_command]).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "@githubnext/github-copilot-cli@0.1.36"]
+      )
+    end
+
+    it "deep-freezes the contract" do
+      contract = described_class.installation_contract
+
+      expect(contract).to be_frozen
+      expect { contract[:install_command] << "extra" }.to raise_error(FrozenError)
+      expect { contract[:install_command_prefix] << "extra" }.to raise_error(FrozenError)
+    end
+
+    it "rejects unsupported versions" do
+      expect {
+        described_class.installation_contract(version: "0.0.1")
+      }.to raise_error(ArgumentError, /Unsupported GitHub Copilot CLI version/)
+    end
+
+    it "rejects malformed version strings with a provider-specific message" do
+      expect {
+        described_class.installation_contract(version: "not-a-version")
+      }.to raise_error(ArgumentError, /Unsupported GitHub Copilot CLI version/)
+    end
+
+    it "rejects nil version" do
+      expect {
+        described_class.installation_contract(version: nil)
+      }.to raise_error(ArgumentError, /Unsupported GitHub Copilot CLI version/)
+    end
+
+    it "rejects empty version" do
+      expect {
+        described_class.installation_contract(version: "")
+      }.to raise_error(ArgumentError, /Unsupported GitHub Copilot CLI version/)
+    end
+
+    it "preserves non-String version in error message" do
+      expect {
+        described_class.installation_contract(version: 42)
+      }.to raise_error(ArgumentError, /Unsupported GitHub Copilot CLI version 42/)
+    end
+
+    it "normalizes padded version strings in the install command" do
+      contract = described_class.installation_contract(version: " 0.1.36 ")
+
+      expect(contract[:install_command]).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "@githubnext/github-copilot-cli@0.1.36"]
+      )
+    end
+  end
+
+  describe ".install_command" do
+    it "returns the install command array" do
+      expect(described_class.install_command).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "@githubnext/github-copilot-cli@0.1.36"]
+      )
+    end
+  end
+
   describe ".firewall_requirements" do
     it "returns required domains" do
       requirements = described_class.firewall_requirements


### PR DESCRIPTION
## Summary

feat(installers): make Github Copilot CLI installation/version support a first-class provider contract

See #69 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #69