### PR TITLE
fix(copilot): github-copilot-cli does not support the -p flag used by build_command

### DIFF
--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -14,6 +14,7 @@ module AgentHarness
 
       MODEL_PATTERN = /^gpt-[\d.o-]+(?:-turbo)?(?:-mini)?$/i
       JSON_OUTPUT_MIN_VERSION = Gem::Version.new("0.0.422").freeze
+      SUBCOMMAND_CLI_MIN_VERSION = Gem::Version.new("0.1.0").freeze
 
       SMOKE_TEST_CONTRACT = {
         prompt: "Reply with exactly OK.",
@@ -195,17 +196,21 @@ module AgentHarness
       end
 
       def dangerous_mode_flags(probe_timeout: nil, env: {})
-        return [] unless supports_json_output_format?(probe_timeout: probe_timeout, env: env)
+        version = copilot_cli_version(probe_timeout: probe_timeout, env: env)
+        return [] if subcommand_cli_version?(version)
+        return [] unless supports_json_output_format?(version: version)
 
         ["--allow-all"]
       end
 
       def supports_sessions?
-        true
+        false
       end
 
       def session_flags(session_id)
+        return [] unless legacy_prompt_cli?
         return [] unless session_id && !session_id.empty?
+
         ["--resume", session_id]
       end
 
@@ -220,8 +225,8 @@ module AgentHarness
           # must not claim JSON-only output even though newer versions support it.
           output_format: :text,
           sandbox_aware: false,
-          uses_subcommand: false,
-          non_interactive_flag: "-p",
+          uses_subcommand: true,
+          non_interactive_flag: nil,
           legitimate_exit_codes: [0],
           stderr_is_diagnostic: true,
           parses_rate_limit_reset: false
@@ -324,11 +329,17 @@ module AgentHarness
       protected
 
       def build_command(prompt, options)
-        cmd = [self.class.binary_name, "-p", prompt]
         env = options.fetch(:_command_env) { build_env(options) }
         runtime = options[:provider_runtime]
+        version = copilot_cli_version(probe_timeout: options[:_version_probe_timeout], env: env)
 
-        if supports_json_output_format?(probe_timeout: options[:_version_probe_timeout], env: env)
+        if subcommand_cli_version?(version) || version.nil?
+          return [self.class.binary_name, "what-the-shell", prompt]
+        end
+
+        cmd = [self.class.binary_name, "-p", prompt]
+
+        if supports_json_output_format?(version: version)
           cmd += ["--output-format", "json"]
         else
           # Silent mode suppresses the model/stats decoration older CLIs print in
@@ -385,9 +396,18 @@ module AgentHarness
         ["--allow-all-tools"]
       end
 
-      def supports_json_output_format?(probe_timeout: nil, env: {})
-        version = copilot_cli_version(probe_timeout: probe_timeout, env: env)
-        !version.nil? && version >= JSON_OUTPUT_MIN_VERSION
+      def supports_json_output_format?(probe_timeout: nil, env: {}, version: nil)
+        version ||= copilot_cli_version(probe_timeout: probe_timeout, env: env)
+        !version.nil? && !subcommand_cli_version?(version) && version >= JSON_OUTPUT_MIN_VERSION
+      end
+
+      def legacy_prompt_cli?
+        version = copilot_cli_version
+        !version.nil? && !subcommand_cli_version?(version)
+      end
+
+      def subcommand_cli_version?(version)
+        !version.nil? && version >= SUBCOMMAND_CLI_MIN_VERSION
       end
 
       def copilot_cli_version(probe_timeout: nil, env: {})

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -183,8 +183,8 @@ module AgentHarness
         ["--allow-all"]
       end
 
-      def supports_sessions?
-        false
+      def supports_sessions?(probe_timeout: nil, env: {}, version: nil)
+        legacy_prompt_cli?(version: version, probe_timeout: probe_timeout, env: env)
       end
 
       def session_flags(session_id, version: nil, probe_timeout: nil, env: {})

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -149,8 +149,8 @@ module AgentHarness
         }
       end
 
-      def dangerous_mode_flags(probe_timeout: nil, env: {})
-        version = copilot_cli_version(probe_timeout: probe_timeout, env: env)
+      def dangerous_mode_flags(probe_timeout: nil, env: {}, version: nil)
+        version ||= copilot_cli_version(probe_timeout: probe_timeout, env: env)
         return [] if subcommand_cli_version?(version)
         return [] unless supports_json_output_format?(version: version)
 
@@ -161,9 +161,9 @@ module AgentHarness
         false
       end
 
-      def session_flags(session_id)
-        return [] unless legacy_prompt_cli?
+      def session_flags(session_id, version: nil, probe_timeout: nil, env: {})
         return [] unless session_id && !session_id.empty?
+        return [] unless legacy_prompt_cli?(version: version, probe_timeout: probe_timeout, env: env)
 
         ["--resume", session_id]
       end
@@ -303,11 +303,11 @@ module AgentHarness
         cmd += ["--model", model] if model
         if options[:dangerous_mode] && supports_dangerous_mode?
           cmd += programmatic_tool_approval_flags
-          cmd += dangerous_mode_flags(probe_timeout: options[:_version_probe_timeout], env: env)
+          cmd += dangerous_mode_flags(version: version)
         end
 
         if options[:session] && !options[:session].empty?
-          cmd += session_flags(options[:session])
+          cmd += session_flags(options[:session], version: version)
         end
 
         cmd
@@ -353,8 +353,8 @@ module AgentHarness
         !version.nil? && !subcommand_cli_version?(version) && version >= JSON_OUTPUT_MIN_VERSION
       end
 
-      def legacy_prompt_cli?
-        version = copilot_cli_version
+      def legacy_prompt_cli?(probe_timeout: nil, env: {}, version: nil)
+        version ||= copilot_cli_version(probe_timeout: probe_timeout, env: env)
         !version.nil? && !subcommand_cli_version?(version)
       end
 

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -229,7 +229,7 @@ module AgentHarness
           output_format: :text,
           sandbox_aware: false,
           uses_subcommand: false,
-          non_interactive_flag: "-p",
+          non_interactive_flag: nil,
           legitimate_exit_codes: [0],
           stderr_is_diagnostic: true,
           parses_rate_limit_reset: false

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -8,10 +8,6 @@ module AgentHarness
     class GithubCopilot < Base
       include TokenUsageParsing
 
-      PACKAGE_NAME = "@githubnext/github-copilot-cli"
-      SUPPORTED_CLI_VERSION = "0.1.36"
-      SUPPORTED_CLI_REQUIREMENT = Gem::Requirement.new(">= #{SUPPORTED_CLI_VERSION}", "< 0.2.0").freeze
-
       MODEL_PATTERN = /^gpt-[\d.o-]+(?:-turbo)?(?:-mini)?$/i
       JSON_OUTPUT_MIN_VERSION = Gem::Version.new("0.0.422").freeze
       SUBCOMMAND_CLI_MIN_VERSION = Gem::Version.new("0.1.0").freeze
@@ -41,38 +37,15 @@ module AgentHarness
           !!executor.which(binary_name)
         end
 
-        def installation_contract(version: SUPPORTED_CLI_VERSION)
-          version = version.strip if version.respond_to?(:strip)
-          validate_install_version!(version)
-          package_spec = "#{PACKAGE_NAME}@#{version}".freeze
-          install_command_prefix = ["npm", "install", "-g", "--ignore-scripts"].freeze
-          install_command = (install_command_prefix + [package_spec]).freeze
-          version_requirement = SUPPORTED_CLI_REQUIREMENT.requirements
-            .map { |op, ver| "#{op} #{ver}".freeze }
-            .freeze
-
-          contract = {
-            source: {
-              type: :npm,
-              package: PACKAGE_NAME
-            }.freeze,
-            install_command_prefix: install_command_prefix,
-            install_command: install_command,
-            binary_name: binary_name,
-            default_version: SUPPORTED_CLI_VERSION,
-            version: version,
-            version_requirement: version_requirement,
-            supported_version_requirement: SUPPORTED_CLI_REQUIREMENT.to_s
-          }
-
-          contract.each_value do |value|
-            value.freeze if value.is_a?(String)
-          end
-          contract.freeze
+        def installation_contract(version: nil)
+          # The published @githubnext/github-copilot-cli package only has
+          # 0.1.x releases, and those expose an interactive subcommand instead
+          # of the non-interactive -p prompt path AgentHarness uses.
+          nil
         end
 
-        def install_command(version: SUPPORTED_CLI_VERSION)
-          installation_contract(version: version)[:install_command]
+        def install_command(version: nil)
+          installation_contract(version: version)&.fetch(:install_command)
         end
 
         def provider_metadata_overrides
@@ -137,28 +110,6 @@ module AgentHarness
         end
 
         private
-
-        def validate_install_version!(version)
-          unless version.is_a?(String) && !version.strip.empty?
-            raise ArgumentError,
-              "Unsupported GitHub Copilot CLI version #{version.inspect}; " \
-              "supported versions must satisfy #{SUPPORTED_CLI_REQUIREMENT}"
-          end
-
-          parsed_version = begin
-            Gem::Version.new(version)
-          rescue ArgumentError
-            raise ArgumentError,
-              "Unsupported GitHub Copilot CLI version #{version.inspect}; " \
-              "supported versions must satisfy #{SUPPORTED_CLI_REQUIREMENT}"
-          end
-
-          return if SUPPORTED_CLI_REQUIREMENT.satisfied_by?(parsed_version)
-
-          raise ArgumentError,
-            "Unsupported GitHub Copilot CLI version #{version.inspect}; " \
-            "supported versions must satisfy #{SUPPORTED_CLI_REQUIREMENT}"
-        end
       end
 
       def name

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -15,6 +15,9 @@ module AgentHarness
       MODEL_PATTERN = /^gpt-[\d.o-]+(?:-turbo)?(?:-mini)?$/i
       JSON_OUTPUT_MIN_VERSION = Gem::Version.new("0.0.422").freeze
       SUBCOMMAND_CLI_MIN_VERSION = Gem::Version.new("0.1.0").freeze
+      UNSUPPORTED_SUBCOMMAND_CLI_MESSAGE =
+        "github-copilot-cli 0.1.x does not expose a non-interactive send interface; " \
+        "the what-the-shell subcommand is interactive and cannot be used by AgentHarness."
 
       SMOKE_TEST_CONTRACT = {
         prompt: "Reply with exactly OK.",
@@ -225,8 +228,8 @@ module AgentHarness
           # must not claim JSON-only output even though newer versions support it.
           output_format: :text,
           sandbox_aware: false,
-          uses_subcommand: true,
-          non_interactive_flag: nil,
+          uses_subcommand: false,
+          non_interactive_flag: "-p",
           legitimate_exit_codes: [0],
           stderr_is_diagnostic: true,
           parses_rate_limit_reset: false
@@ -333,9 +336,7 @@ module AgentHarness
         runtime = options[:provider_runtime]
         version = copilot_cli_version(probe_timeout: options[:_version_probe_timeout], env: env)
 
-        if subcommand_cli_version?(version) || version.nil?
-          return [self.class.binary_name, "what-the-shell", prompt]
-        end
+        raise unsupported_subcommand_cli_error if subcommand_cli_version?(version)
 
         cmd = [self.class.binary_name, "-p", prompt]
 
@@ -408,6 +409,10 @@ module AgentHarness
 
       def subcommand_cli_version?(version)
         !version.nil? && version >= SUBCOMMAND_CLI_MIN_VERSION
+      end
+
+      def unsupported_subcommand_cli_error
+        ProviderError.new(UNSUPPORTED_SUBCOMMAND_CLI_MESSAGE)
       end
 
       def copilot_cli_version(probe_timeout: nil, env: {})

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -34,7 +34,11 @@ module AgentHarness
 
         def available?
           executor = AgentHarness.configuration.command_executor
-          !!executor.which(binary_name)
+          return false unless executor.which(binary_name)
+
+          !subcommand_cli_version?(copilot_cli_version(executor: executor))
+        rescue
+          false
         end
 
         def installation_contract(version: nil)
@@ -110,6 +114,28 @@ module AgentHarness
         end
 
         private
+
+        def copilot_cli_version(executor:)
+          result = executor.execute([binary_name, "--version"], timeout: 5, env: {})
+          extract_version(result)
+        rescue
+          nil
+        end
+
+        def subcommand_cli_version?(version)
+          !version.nil? && version >= SUBCOMMAND_CLI_MIN_VERSION
+        end
+
+        def extract_version(result)
+          return nil unless result.success?
+
+          version_string = [result.stdout, result.stderr].compact.join("\n")[/\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?/]
+          return nil if version_string.nil? || version_string.empty?
+
+          Gem::Version.new(version_string)
+        rescue ArgumentError
+          nil
+        end
       end
 
       def name
@@ -359,7 +385,7 @@ module AgentHarness
       end
 
       def subcommand_cli_version?(version)
-        !version.nil? && version >= SUBCOMMAND_CLI_MIN_VERSION
+        self.class.send(:subcommand_cli_version?, version)
       end
 
       def unsupported_subcommand_cli_error
@@ -419,14 +445,7 @@ module AgentHarness
       end
 
       def extract_version(result)
-        return nil unless result.success?
-
-        version_string = [result.stdout, result.stderr].compact.join("\n")[/\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?/]
-        return nil if version_string.nil? || version_string.empty?
-
-        Gem::Version.new(version_string)
-      rescue ArgumentError
-        nil
+        self.class.send(:extract_version, result)
       end
 
       def parse_jsonl_output(output)

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -322,7 +322,7 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
     end
 
     describe "#supports_sessions?" do
-      it "returns false for the supported subcommand CLI" do
+      it "returns false for the pinned 0.1.x CLI" do
         expect(provider.supports_sessions?).to be false
       end
     end
@@ -333,7 +333,7 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         expect(flags).to eq(["--resume", "session-123"])
       end
 
-      it "returns empty flags for the supported subcommand CLI" do
+      it "returns empty flags for the pinned 0.1.x CLI" do
         allow(mock_executor).to receive(:execute).with(
           ["github-copilot-cli", "--version"],
           timeout: 5,
@@ -521,8 +521,8 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         expect(semantics[:prompt_delivery]).to eq(:arg)
         expect(semantics[:output_format]).to eq(:text)
         expect(semantics[:sandbox_aware]).to be false
-        expect(semantics[:uses_subcommand]).to be true
-        expect(semantics[:non_interactive_flag]).to be_nil
+        expect(semantics[:uses_subcommand]).to be false
+        expect(semantics[:non_interactive_flag]).to eq("-p")
         expect(semantics[:legitimate_exit_codes]).to eq([0])
         expect(semantics[:stderr_is_diagnostic]).to be true
         expect(semantics[:parses_rate_limit_reset]).to be false
@@ -540,20 +540,22 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         first_command = provider.send(:build_command, "Hello", {})
         expect(first_command).to eq([
           "github-copilot-cli",
-          "what-the-shell",
-          "Hello"
+          "-p",
+          "Hello",
+          "-s"
         ])
 
         # Second call should use cached nil without retrying the probe
         second_command = provider.send(:build_command, "Hello", {})
         expect(second_command).to eq([
           "github-copilot-cli",
-          "what-the-shell",
-          "Hello"
+          "-p",
+          "Hello",
+          "-s"
         ])
       end
 
-      it "uses the supported subcommand interface for the pinned CLI" do
+      it "fails fast for the pinned CLI because its available send flow is interactive" do
         allow(mock_executor).to receive(:execute).with(
           ["github-copilot-cli", "--version"],
           timeout: 5,
@@ -567,13 +569,9 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
           )
         )
 
-        command = provider.send(:build_command, "Hello", {dangerous_mode: true, session: "session-123"})
-
-        expect(command).to eq([
-          "github-copilot-cli",
-          "what-the-shell",
-          "Hello"
-        ])
+        expect do
+          provider.send(:build_command, "Hello", {dangerous_mode: true, session: "session-123"})
+        end.to raise_error(AgentHarness::ProviderError, /does not expose a non-interactive send interface/)
       end
 
       it "includes --output-format json for legacy JSON-capable CLIs" do
@@ -664,7 +662,7 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         ])
       end
 
-      it "falls back to the supported subcommand interface without probing when the CLI is unavailable" do
+      it "falls back to prompt mode without probing when the CLI is unavailable" do
         allow(mock_executor).to receive(:which).with("github-copilot-cli").and_return(nil)
         expect(mock_executor).not_to receive(:execute).with(["github-copilot-cli", "--version"], any_args)
 
@@ -672,8 +670,9 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
 
         expect(command).to eq([
           "github-copilot-cli",
-          "what-the-shell",
-          "Hello"
+          "-p",
+          "Hello",
+          "-s"
         ])
       end
 
@@ -918,8 +917,9 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
 
         fallback_command = [
           "github-copilot-cli",
-          "what-the-shell",
-          "Hello"
+          "-p",
+          "Hello",
+          "-s"
         ]
         expect(first_command).to eq(fallback_command)
         expect(second_command).to eq(fallback_command)
@@ -1259,7 +1259,7 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         expect(mock_executor).not_to receive(:execute).with(["github-copilot-cli", "--version"], any_args)
 
         allow(mock_executor).to receive(:execute).with(
-          ["github-copilot-cli", "what-the-shell", "Hello"],
+          ["github-copilot-cli", "-p", "Hello", "-s"],
           anything
         ).and_return(
           AgentHarness::CommandExecutor::Result.new(
@@ -1273,6 +1273,30 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         response = provider.send_message(prompt: "Hello")
         expect(response.output).to eq("plain text response")
         expect(response.tokens).to be_nil
+      end
+
+      it "fails fast for 0.1.x instead of invoking the interactive what-the-shell flow" do
+        allow(mock_executor).to receive(:execute).with(
+          ["github-copilot-cli", "--version"],
+          timeout: 5,
+          env: {}
+        ).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "github-copilot-cli 0.1.36",
+            stderr: "",
+            exit_code: 0,
+            duration: 0.1
+          )
+        )
+
+        expect(mock_executor).not_to receive(:execute).with(
+          ["github-copilot-cli", "what-the-shell", "Hello"],
+          anything
+        )
+
+        expect do
+          provider.send_message(prompt: "Hello")
+        end.to raise_error(AgentHarness::ProviderError, /what-the-shell subcommand is interactive/)
       end
 
       it "does not decode plain-text fallback output that happens to be valid JSON" do

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -14,86 +14,16 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
   end
 
   describe ".installation_contract" do
-    it "returns the upstream install contract" do
-      contract = described_class.installation_contract
-
-      expect(contract[:source]).to eq({
-        type: :npm,
-        package: "@githubnext/github-copilot-cli"
-      })
-      expect(contract[:binary_name]).to eq("github-copilot-cli")
-      expect(contract[:default_version]).to eq("0.1.36")
-      expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@githubnext/github-copilot-cli@0.1.36"]
-      )
-    end
-
-    it "keeps the runtime binary aligned with the install contract" do
-      contract = described_class.installation_contract
-
-      expect(contract[:binary_name]).to eq(described_class.binary_name)
-    end
-
-    it "can render an install command for an explicitly supported target" do
-      contract = described_class.installation_contract(version: "0.1.36")
-
-      expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@githubnext/github-copilot-cli@0.1.36"]
-      )
-    end
-
-    it "deep-freezes the contract" do
-      contract = described_class.installation_contract
-
-      expect(contract).to be_frozen
-      expect { contract[:install_command] << "extra" }.to raise_error(FrozenError)
-      expect { contract[:install_command_prefix] << "extra" }.to raise_error(FrozenError)
-    end
-
-    it "rejects unsupported versions" do
-      expect {
-        described_class.installation_contract(version: "0.0.1")
-      }.to raise_error(ArgumentError, /Unsupported GitHub Copilot CLI version/)
-    end
-
-    it "rejects malformed version strings with a provider-specific message" do
-      expect {
-        described_class.installation_contract(version: "not-a-version")
-      }.to raise_error(ArgumentError, /Unsupported GitHub Copilot CLI version/)
-    end
-
-    it "rejects nil version" do
-      expect {
-        described_class.installation_contract(version: nil)
-      }.to raise_error(ArgumentError, /Unsupported GitHub Copilot CLI version/)
-    end
-
-    it "rejects empty version" do
-      expect {
-        described_class.installation_contract(version: "")
-      }.to raise_error(ArgumentError, /Unsupported GitHub Copilot CLI version/)
-    end
-
-    it "preserves non-String version in error message" do
-      expect {
-        described_class.installation_contract(version: 42)
-      }.to raise_error(ArgumentError, /Unsupported GitHub Copilot CLI version 42/)
-    end
-
-    it "normalizes padded version strings in the install command" do
-      contract = described_class.installation_contract(version: " 0.1.36 ")
-
-      expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@githubnext/github-copilot-cli@0.1.36"]
-      )
+    it "does not advertise an install contract for the interactive-only npm CLI" do
+      expect(described_class.installation_contract).to be_nil
+      expect(described_class.installation_contract(version: "0.1.36")).to be_nil
     end
   end
 
   describe ".install_command" do
-    it "returns the install command array" do
-      expect(described_class.install_command).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@githubnext/github-copilot-cli@0.1.36"]
-      )
+    it "returns nil when no non-interactive install target is available" do
+      expect(described_class.install_command).to be_nil
+      expect(described_class.install_command(version: "0.1.36")).to be_nil
     end
   end
 
@@ -149,6 +79,8 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
       metadata = described_class.provider_metadata
 
       expect(metadata[:runtime]).to include(
+        installable: false,
+        installation: nil,
         output_format: :text,
         supports_token_counting: true,
         supports_dangerous_mode: true
@@ -168,6 +100,8 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
 
       expect(metadata[:runtime]).to include(
         available: false,
+        installable: false,
+        installation: nil,
         output_format: :text,
         supports_token_counting: false,
         supports_dangerous_mode: true
@@ -197,6 +131,8 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
 
       expect(metadata[:runtime]).to include(
         available: true,
+        installable: false,
+        installation: nil,
         output_format: :text,
         supports_token_counting: false,
         supports_dangerous_mode: true

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -322,15 +322,32 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
     end
 
     describe "#supports_sessions?" do
-      it "returns true" do
-        expect(provider.supports_sessions?).to be true
+      it "returns false for the supported subcommand CLI" do
+        expect(provider.supports_sessions?).to be false
       end
     end
 
     describe "#session_flags" do
-      it "returns resume flags when session provided" do
+      it "returns legacy resume flags when the prompt-mode CLI is installed" do
         flags = provider.session_flags("session-123")
         expect(flags).to eq(["--resume", "session-123"])
+      end
+
+      it "returns empty flags for the supported subcommand CLI" do
+        allow(mock_executor).to receive(:execute).with(
+          ["github-copilot-cli", "--version"],
+          timeout: 5,
+          env: {}
+        ).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "github-copilot-cli 0.1.36",
+            stderr: "",
+            exit_code: 0,
+            duration: 0.1
+          )
+        )
+
+        expect(provider.session_flags("session-123")).to eq([])
       end
 
       it "returns empty when no session" do
@@ -504,8 +521,8 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         expect(semantics[:prompt_delivery]).to eq(:arg)
         expect(semantics[:output_format]).to eq(:text)
         expect(semantics[:sandbox_aware]).to be false
-        expect(semantics[:uses_subcommand]).to be false
-        expect(semantics[:non_interactive_flag]).to eq("-p")
+        expect(semantics[:uses_subcommand]).to be true
+        expect(semantics[:non_interactive_flag]).to be_nil
         expect(semantics[:legitimate_exit_codes]).to eq([0])
         expect(semantics[:stderr_is_diagnostic]).to be true
         expect(semantics[:parses_rate_limit_reset]).to be false
@@ -523,22 +540,43 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         first_command = provider.send(:build_command, "Hello", {})
         expect(first_command).to eq([
           "github-copilot-cli",
-          "-p",
-          "Hello",
-          "-s"
+          "what-the-shell",
+          "Hello"
         ])
 
         # Second call should use cached nil without retrying the probe
         second_command = provider.send(:build_command, "Hello", {})
         expect(second_command).to eq([
           "github-copilot-cli",
-          "-p",
-          "Hello",
-          "-s"
+          "what-the-shell",
+          "Hello"
         ])
       end
 
-      it "includes --output-format json by default" do
+      it "uses the supported subcommand interface for the pinned CLI" do
+        allow(mock_executor).to receive(:execute).with(
+          ["github-copilot-cli", "--version"],
+          timeout: 5,
+          env: {}
+        ).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "github-copilot-cli 0.1.36",
+            stderr: "",
+            exit_code: 0,
+            duration: 0.1
+          )
+        )
+
+        command = provider.send(:build_command, "Hello", {dangerous_mode: true, session: "session-123"})
+
+        expect(command).to eq([
+          "github-copilot-cli",
+          "what-the-shell",
+          "Hello"
+        ])
+      end
+
+      it "includes --output-format json for legacy JSON-capable CLIs" do
         command = provider.send(:build_command, "Hello", {})
 
         expect(command).to eq([
@@ -626,7 +664,7 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         ])
       end
 
-      it "falls back to silent prompt mode without probing when the CLI is unavailable" do
+      it "falls back to the supported subcommand interface without probing when the CLI is unavailable" do
         allow(mock_executor).to receive(:which).with("github-copilot-cli").and_return(nil)
         expect(mock_executor).not_to receive(:execute).with(["github-copilot-cli", "--version"], any_args)
 
@@ -634,9 +672,8 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
 
         expect(command).to eq([
           "github-copilot-cli",
-          "-p",
-          "Hello",
-          "-s"
+          "what-the-shell",
+          "Hello"
         ])
       end
 
@@ -881,9 +918,8 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
 
         fallback_command = [
           "github-copilot-cli",
-          "-p",
-          "Hello",
-          "-s"
+          "what-the-shell",
+          "Hello"
         ]
         expect(first_command).to eq(fallback_command)
         expect(second_command).to eq(fallback_command)
@@ -1223,7 +1259,7 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         expect(mock_executor).not_to receive(:execute).with(["github-copilot-cli", "--version"], any_args)
 
         allow(mock_executor).to receive(:execute).with(
-          ["github-copilot-cli", "-p", "Hello", "-s"],
+          ["github-copilot-cli", "what-the-shell", "Hello"],
           anything
         ).and_return(
           AgentHarness::CommandExecutor::Result.new(

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         supports_token_counting: true,
         supports_dangerous_mode: true
       )
+      expect(metadata[:runtime]).not_to have_key(:non_interactive_flag)
       expect(metadata[:capabilities]).to include(
         tool_use: true,
         dangerous_mode: true
@@ -171,6 +172,7 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         supports_token_counting: false,
         supports_dangerous_mode: true
       )
+      expect(metadata[:runtime]).not_to have_key(:non_interactive_flag)
       expect(metadata[:capabilities]).to include(
         tool_use: true,
         dangerous_mode: true
@@ -199,6 +201,7 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         supports_token_counting: false,
         supports_dangerous_mode: true
       )
+      expect(metadata[:runtime]).not_to have_key(:non_interactive_flag)
       expect(metadata[:capabilities]).to include(
         tool_use: true,
         dangerous_mode: true
@@ -522,7 +525,7 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         expect(semantics[:output_format]).to eq(:text)
         expect(semantics[:sandbox_aware]).to be false
         expect(semantics[:uses_subcommand]).to be false
-        expect(semantics[:non_interactive_flag]).to eq("-p")
+        expect(semantics[:non_interactive_flag]).to be_nil
         expect(semantics[:legitimate_exit_codes]).to eq([0])
         expect(semantics[:stderr_is_diagnostic]).to be true
         expect(semantics[:parses_rate_limit_reset]).to be false

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -137,6 +137,7 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         installation: nil,
         output_format: :text,
         supports_token_counting: true,
+        supports_sessions: true,
         supports_dangerous_mode: true
       )
       expect(metadata[:runtime]).not_to have_key(:non_interactive_flag)
@@ -158,6 +159,7 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         installation: nil,
         output_format: :text,
         supports_token_counting: false,
+        supports_sessions: false,
         supports_dangerous_mode: true
       )
       expect(metadata[:runtime]).not_to have_key(:non_interactive_flag)
@@ -189,6 +191,7 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         installation: nil,
         output_format: :text,
         supports_token_counting: false,
+        supports_sessions: true,
         supports_dangerous_mode: true
       )
       expect(metadata[:runtime]).not_to have_key(:non_interactive_flag)
@@ -369,7 +372,24 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
     end
 
     describe "#supports_sessions?" do
-      it "returns false for the pinned 0.1.x CLI" do
+      it "returns true for legacy prompt-mode CLIs" do
+        expect(provider.supports_sessions?).to be true
+      end
+
+      it "returns false for the interactive-only 0.1.x CLI" do
+        allow(mock_executor).to receive(:execute).with(
+          ["github-copilot-cli", "--version"],
+          timeout: 5,
+          env: {}
+        ).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "github-copilot-cli 0.1.36",
+            stderr: "",
+            exit_code: 0,
+            duration: 0.1
+          )
+        )
+
         expect(provider.supports_sessions?).to be false
       end
     end

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -757,6 +757,39 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         ])
       end
 
+      it "decides session support from the already-probed runtime CLI version" do
+        runtime = AgentHarness::ProviderRuntime.new(env: {"PATH" => "/legacy/copilot/bin"})
+
+        allow(mock_executor).to receive(:execute).with(
+          ["github-copilot-cli", "--version"],
+          timeout: 5,
+          env: {"PATH" => "/legacy/copilot/bin"}
+        ).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "github-copilot-cli 0.0.421",
+            stderr: "",
+            exit_code: 0,
+            duration: 0.1
+          )
+        )
+        expect(mock_executor).not_to receive(:execute).with(
+          ["github-copilot-cli", "--version"],
+          timeout: 5,
+          env: {}
+        )
+
+        command = provider.send(:build_command, "Hello", {provider_runtime: runtime, session: "session-123"})
+
+        expect(command).to eq([
+          "github-copilot-cli",
+          "-p",
+          "Hello",
+          "-s",
+          "--resume",
+          "session-123"
+        ])
+      end
+
       it "caches CLI versions per effective runtime env" do
         legacy_runtime = AgentHarness::ProviderRuntime.new(env: {"PATH" => "/legacy/copilot/bin"})
         json_runtime = AgentHarness::ProviderRuntime.new(env: {"PATH" => "/json/copilot/bin"})

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -13,6 +13,60 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
     end
   end
 
+  describe ".available?" do
+    let(:availability_executor) do
+      instance_double(
+        AgentHarness::CommandExecutor,
+        which: "/usr/bin/github-copilot-cli"
+      )
+    end
+
+    before do
+      allow(AgentHarness.configuration).to receive(:command_executor).and_return(availability_executor)
+    end
+
+    it "returns true for legacy prompt-mode CLIs" do
+      allow(availability_executor).to receive(:execute).with(
+        ["github-copilot-cli", "--version"],
+        timeout: 5,
+        env: {}
+      ).and_return(
+        AgentHarness::CommandExecutor::Result.new(
+          stdout: "github-copilot-cli 0.0.422",
+          stderr: "",
+          exit_code: 0,
+          duration: 0.1
+        )
+      )
+
+      expect(described_class.available?).to be true
+    end
+
+    it "returns false when the CLI is missing" do
+      allow(availability_executor).to receive(:which).with("github-copilot-cli").and_return(nil)
+      expect(availability_executor).not_to receive(:execute)
+
+      expect(described_class.available?).to be false
+    end
+
+    it "returns false for the interactive-only 0.1.x CLI" do
+      allow(availability_executor).to receive(:execute).with(
+        ["github-copilot-cli", "--version"],
+        timeout: 5,
+        env: {}
+      ).and_return(
+        AgentHarness::CommandExecutor::Result.new(
+          stdout: "github-copilot-cli 0.1.36",
+          stderr: "",
+          exit_code: 0,
+          duration: 0.1
+        )
+      )
+
+      expect(described_class.available?).to be false
+    end
+  end
+
   describe ".installation_contract" do
     it "does not advertise an install contract for the interactive-only npm CLI" do
       expect(described_class.installation_contract).to be_nil
@@ -142,6 +196,60 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         tool_use: true,
         dangerous_mode: true
       )
+    end
+
+    it "reports the interactive-only 0.1.x CLI as unavailable for sends" do
+      allow(metadata_executor).to receive(:execute).with(
+        ["github-copilot-cli", "--version"],
+        timeout: 5,
+        env: {}
+      ).and_return(
+        AgentHarness::CommandExecutor::Result.new(
+          stdout: "github-copilot-cli 0.1.36",
+          stderr: "",
+          exit_code: 0,
+          duration: 0.1
+        )
+      )
+
+      metadata = described_class.provider_metadata(refresh: true)
+
+      expect(metadata[:runtime]).to include(
+        available: false,
+        installable: false,
+        installation: nil,
+        supports_token_counting: false,
+        supports_sessions: false
+      )
+    end
+  end
+
+  describe ".discover_models" do
+    let(:discovery_executor) do
+      instance_double(
+        AgentHarness::CommandExecutor,
+        which: "/usr/bin/github-copilot-cli"
+      )
+    end
+
+    before do
+      allow(AgentHarness.configuration).to receive(:command_executor).and_return(discovery_executor)
+      allow(discovery_executor).to receive(:execute).with(
+        ["github-copilot-cli", "--version"],
+        timeout: 5,
+        env: {}
+      ).and_return(
+        AgentHarness::CommandExecutor::Result.new(
+          stdout: "github-copilot-cli 0.1.36",
+          stderr: "",
+          exit_code: 0,
+          duration: 0.1
+        )
+      )
+    end
+
+    it "does not discover models for the interactive-only 0.1.x CLI" do
+      expect(described_class.discover_models).to eq([])
     end
   end
 


### PR DESCRIPTION
## Summary

fix(copilot): github-copilot-cli does not support the -p flag used by build_command

See #140 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #140