### PR TITLE
Fix #143: Expose auth flow capability predicates for providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,29 @@ AgentHarness.auth_status(:claude)
 
 For providers without a built-in auth check (including `:api_key` providers), `auth_valid?` returns `false` and `auth_status` returns an error indicating the check is not implemented. Custom providers can implement an `auth_status` instance method to provide their own check.
 
+### Auth Flow Capabilities
+
+Before rendering provider-specific auth controls, check whether the flow is supported:
+
+```ruby
+AgentHarness.auth_url_supported?(:claude)
+# => true
+
+AgentHarness.auth_url_supported?(:codex)
+# => false
+
+AgentHarness.refresh_auth_supported?(:claude)
+# => true
+
+AgentHarness.refresh_auth_supported?(:codex)
+# => false
+
+AgentHarness.auth_capabilities(:codex)
+# => { auth_type: :api_key, auth_url: false, refresh: false }
+```
+
+Provider aliases are resolved the same way as other auth APIs, so `:anthropic` reports the same capabilities as `:claude`. Unknown providers raise `AgentHarness::ProviderNotFoundError`, matching `auth_url` and `refresh_auth` provider lookup behavior.
+
 ### Auth Error Detection
 
 When a CLI agent fails due to expired or invalid authentication, `send_message` raises `AuthenticationError` with the provider name. Authentication errors are always surfaced directly to the caller (never auto-switched to another provider) so your application can trigger the appropriate re-auth flow:
@@ -509,9 +532,15 @@ When a CLI agent fails due to expired or invalid authentication, `send_message` 
 begin
   AgentHarness.send_message("Hello", provider: :claude)
 rescue AgentHarness::AuthenticationError => e
-  puts e.provider  # => :claude
-  puts e.message   # => "oauth token expired"
-  # Trigger re-authentication flow for the specific provider
+  provider = e.provider
+
+  if AgentHarness.auth_url_supported?(provider)
+    redirect_to AgentHarness.auth_url(provider)
+  elsif AgentHarness.refresh_auth_supported?(provider)
+    render :reauth_token_form, locals: { provider: provider }
+  else
+    render :auth_expired_without_refresh, locals: { provider: provider, message: e.message }
+  end
 end
 ```
 

--- a/lib/agent_harness.rb
+++ b/lib/agent_harness.rb
@@ -184,12 +184,36 @@ module AgentHarness
       Authentication.auth_status(provider_name)
     end
 
+    # Get authentication flow capabilities for a provider
+    # @param provider_name [Symbol] the provider name
+    # @return [Hash] capabilities with :auth_type, :auth_url, :refresh keys
+    # @raise [ProviderNotFoundError] if provider is unknown
+    def auth_capabilities(provider_name)
+      Authentication.auth_capabilities(provider_name)
+    end
+
+    # Check whether OAuth URL generation is supported for a provider
+    # @param provider_name [Symbol] the provider name
+    # @return [Boolean] true if auth_url can be called for the provider
+    # @raise [ProviderNotFoundError] if provider is unknown
+    def auth_url_supported?(provider_name)
+      Authentication.auth_url_supported?(provider_name)
+    end
+
     # Generate an OAuth URL for a provider
     # @param provider_name [Symbol] the provider name
     # @return [String] the OAuth authorization URL
     # @raise [NotImplementedError] if provider doesn't support OAuth
     def auth_url(provider_name)
       Authentication.auth_url(provider_name)
+    end
+
+    # Check whether credential refresh is supported for a provider
+    # @param provider_name [Symbol] the provider name
+    # @return [Boolean] true if refresh_auth can be called for the provider
+    # @raise [ProviderNotFoundError] if provider is unknown
+    def refresh_auth_supported?(provider_name)
+      Authentication.refresh_auth_supported?(provider_name)
     end
 
     # Refresh authentication credentials for a provider

--- a/lib/agent_harness/authentication.rb
+++ b/lib/agent_harness/authentication.rb
@@ -35,6 +35,33 @@ module AgentHarness
         end
       end
 
+      # Get authentication flow capabilities for a provider.
+      #
+      # @param provider_name [Symbol] the provider name
+      # @return [Hash] capabilities with :auth_type, :auth_url, :refresh keys
+      # @raise [ProviderNotFoundError] if provider is unknown
+      def auth_capabilities(provider_name)
+        provider_name = provider_name.to_sym
+        provider = resolve_provider(provider_name)
+        canonical_name = Providers::Registry.instance.canonical_name(provider_name)
+        flow_supported = claude_oauth_flow_provider?(provider_name, canonical_name)
+
+        {
+          auth_type: provider.auth_type,
+          auth_url: flow_supported,
+          refresh: flow_supported
+        }
+      end
+
+      # Check whether OAuth URL generation is supported for a provider.
+      #
+      # @param provider_name [Symbol] the provider name
+      # @return [Boolean] true if auth_url can be called for the provider
+      # @raise [ProviderNotFoundError] if provider is unknown
+      def auth_url_supported?(provider_name)
+        auth_capabilities(provider_name)[:auth_url]
+      end
+
       # Generate an OAuth URL for a provider
       #
       # Only supported for :oauth auth type providers.
@@ -58,6 +85,15 @@ module AgentHarness
           raise NotImplementedError,
             "OAuth URL generation is not yet implemented for provider #{provider_name}"
         end
+      end
+
+      # Check whether credential refresh is supported for a provider.
+      #
+      # @param provider_name [Symbol] the provider name
+      # @return [Boolean] true if refresh_auth can be called for the provider
+      # @raise [ProviderNotFoundError] if provider is unknown
+      def refresh_auth_supported?(provider_name)
+        auth_capabilities(provider_name)[:refresh]
       end
 
       # Refresh authentication credentials for a provider
@@ -91,6 +127,10 @@ module AgentHarness
       end
 
       private
+
+      def claude_oauth_flow_provider?(requested_name, canonical_name)
+        [:claude, :anthropic].include?(requested_name) || canonical_name == :claude
+      end
 
       def resolve_provider(provider_name)
         klass = Providers::Registry.instance.get(provider_name)

--- a/spec/agent_harness/authentication_spec.rb
+++ b/spec/agent_harness/authentication_spec.rb
@@ -471,6 +471,95 @@ RSpec.describe AgentHarness::Authentication do
     end
   end
 
+  describe ".auth_capabilities" do
+    it "returns supported OAuth flows for Claude" do
+      expect(described_class.auth_capabilities(:claude)).to eq(
+        auth_type: :oauth,
+        auth_url: true,
+        refresh: true
+      )
+    end
+
+    it "returns supported OAuth flows for the Anthropic alias" do
+      expect(described_class.auth_capabilities(:anthropic)).to eq(
+        auth_type: :oauth,
+        auth_url: true,
+        refresh: true
+      )
+    end
+
+    it "returns unsupported OAuth flows for API key providers" do
+      expect(described_class.auth_capabilities(:codex)).to eq(
+        auth_type: :api_key,
+        auth_url: false,
+        refresh: false
+      )
+    end
+
+    it "returns unsupported OAuth flows for OAuth providers without flow implementations" do
+      expect(described_class.auth_capabilities(:cursor)).to eq(
+        auth_type: :oauth,
+        auth_url: false,
+        refresh: false
+      )
+    end
+
+    it "raises ProviderNotFoundError for unknown providers" do
+      expect { described_class.auth_capabilities(:unknown_provider) }
+        .to raise_error(AgentHarness::ProviderNotFoundError, "Unknown provider: unknown_provider")
+    end
+  end
+
+  describe ".auth_url_supported?" do
+    it "returns true for Claude without invoking auth_url" do
+      expect(described_class).not_to receive(:auth_url)
+
+      expect(described_class.auth_url_supported?(:claude)).to be true
+    end
+
+    it "returns true for the Anthropic alias" do
+      expect(described_class.auth_url_supported?(:anthropic)).to be true
+    end
+
+    it "returns false for API key providers" do
+      expect(described_class.auth_url_supported?(:codex)).to be false
+    end
+
+    it "returns false for OAuth providers without URL generation implementations" do
+      expect(described_class.auth_url_supported?(:cursor)).to be false
+    end
+
+    it "raises ProviderNotFoundError for unknown providers" do
+      expect { described_class.auth_url_supported?(:unknown_provider) }
+        .to raise_error(AgentHarness::ProviderNotFoundError, "Unknown provider: unknown_provider")
+    end
+  end
+
+  describe ".refresh_auth_supported?" do
+    it "returns true for Claude without invoking refresh_auth" do
+      expect(described_class).not_to receive(:refresh_auth)
+
+      expect(described_class.refresh_auth_supported?(:claude)).to be true
+    end
+
+    it "returns true for the Anthropic alias" do
+      expect(described_class.refresh_auth_supported?(:anthropic)).to be true
+    end
+
+    it "returns false for API key providers" do
+      expect(described_class.refresh_auth_supported?(:codex)).to be false
+    end
+
+    it "returns false for OAuth providers without refresh implementations" do
+      expect(described_class.refresh_auth_supported?(:cursor)).to be false
+    end
+
+    it "raises ProviderNotFoundError for unknown providers" do
+      expect { described_class.refresh_auth_supported?(:unknown_provider) }
+        .to raise_error(AgentHarness::ProviderNotFoundError, "Unknown provider: unknown_provider")
+    end
+  end
+
   describe ".refresh_auth" do
     context "for Claude provider" do
       it "stores a token in credentials" do

--- a/spec/agent_harness_spec.rb
+++ b/spec/agent_harness_spec.rb
@@ -267,10 +267,32 @@ RSpec.describe AgentHarness do
     end
   end
 
+  describe ".auth_capabilities" do
+    it "delegates to Authentication module" do
+      capabilities = {auth_type: :oauth, auth_url: true, refresh: true}
+      expect(AgentHarness::Authentication).to receive(:auth_capabilities).with(:claude).and_return(capabilities)
+      expect(AgentHarness.auth_capabilities(:claude)).to eq(capabilities)
+    end
+  end
+
+  describe ".auth_url_supported?" do
+    it "delegates to Authentication module" do
+      expect(AgentHarness::Authentication).to receive(:auth_url_supported?).with(:claude).and_return(true)
+      expect(AgentHarness.auth_url_supported?(:claude)).to be true
+    end
+  end
+
   describe ".auth_url" do
     it "delegates to Authentication module" do
       expect(AgentHarness::Authentication).to receive(:auth_url).with(:claude).and_return("https://example.com")
       expect(AgentHarness.auth_url(:claude)).to eq("https://example.com")
+    end
+  end
+
+  describe ".refresh_auth_supported?" do
+    it "delegates to Authentication module" do
+      expect(AgentHarness::Authentication).to receive(:refresh_auth_supported?).with(:claude).and_return(true)
+      expect(AgentHarness.refresh_auth_supported?(:claude)).to be true
     end
   end
 


### PR DESCRIPTION
## Summary

Expose auth flow capability predicates for providers

See #143 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #143