### PR TITLE
Fix #144: Use a harness-specific error for unsupported auth flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ AgentHarness.auth_url(:claude)
 # => "https://claude.ai/oauth/authorize"
 ```
 
-This raises `NotImplementedError` for `:api_key` providers.
+This raises `AgentHarness::UnsupportedAuthFlowError` for `:api_key` providers or providers whose OAuth URL flow is not implemented. The exception inherits from `AgentHarness::Error` and `StandardError`, so host applications can rescue it with their normal app-level error handling.
 
 ### Credential Refresh
 
@@ -537,7 +537,9 @@ AgentHarness.refresh_auth(:claude, token: "new-oauth-token")
 
 Any existing expiry metadata in the credentials file is cleared on refresh so that `auth_valid?` returns `true` immediately after a successful refresh.
 
-This raises `NotImplementedError` for `:api_key` providers. Credential file paths respect the `CLAUDE_CONFIG_DIR` environment variable.
+This raises `AgentHarness::UnsupportedAuthFlowError` for `:api_key` providers or providers whose credential refresh flow is not implemented. Credential file paths respect the `CLAUDE_CONFIG_DIR` environment variable.
+
+If you currently rescue `NotImplementedError` for unsupported auth URL generation or credential refresh, update that code to rescue `AgentHarness::UnsupportedAuthFlowError` or the broader `AgentHarness::Error` instead.
 
 ## Provider Health Checks
 

--- a/lib/agent_harness.rb
+++ b/lib/agent_harness.rb
@@ -187,7 +187,7 @@ module AgentHarness
     # Generate an OAuth URL for a provider
     # @param provider_name [Symbol] the provider name
     # @return [String] the OAuth authorization URL
-    # @raise [NotImplementedError] if provider doesn't support OAuth
+    # @raise [UnsupportedAuthFlowError] if provider doesn't support OAuth
     def auth_url(provider_name)
       Authentication.auth_url(provider_name)
     end
@@ -196,7 +196,7 @@ module AgentHarness
     # @param provider_name [Symbol] the provider name
     # @param token [String, nil] OAuth token to store
     # @return [Hash] result with :success key
-    # @raise [NotImplementedError] if provider doesn't support credential refresh
+    # @raise [UnsupportedAuthFlowError] if provider doesn't support credential refresh
     def refresh_auth(provider_name, token: nil)
       Authentication.refresh_auth(provider_name, token: token)
     end

--- a/lib/agent_harness/authentication.rb
+++ b/lib/agent_harness/authentication.rb
@@ -41,13 +41,13 @@ module AgentHarness
       #
       # @param provider_name [Symbol] the provider name
       # @return [String] the OAuth authorization URL
-      # @raise [NotImplementedError] if provider doesn't support OAuth
+      # @raise [UnsupportedAuthFlowError] if provider doesn't support OAuth
       def auth_url(provider_name)
         provider_name = provider_name.to_sym
         provider = resolve_provider(provider_name)
 
         unless provider.auth_type == :oauth
-          raise NotImplementedError,
+          raise UnsupportedAuthFlowError,
             "Provider #{provider_name} uses #{provider.auth_type} auth and does not support OAuth URL generation"
         end
 
@@ -55,7 +55,7 @@ module AgentHarness
         when :claude, :anthropic
           claude_auth_url
         else
-          raise NotImplementedError,
+          raise UnsupportedAuthFlowError,
             "OAuth URL generation is not yet implemented for provider #{provider_name}"
         end
       end
@@ -66,18 +66,18 @@ module AgentHarness
       # This method accepts a token (not an authorization code) because
       # the OAuth code-exchange flow is provider-specific and should be
       # handled by the caller or a CLI login command before calling this.
-      # For API key providers, raises NotImplementedError.
+      # For API key providers, raises UnsupportedAuthFlowError.
       #
       # @param provider_name [Symbol] the provider name
       # @param token [String] OAuth token to store (must be non-blank)
       # @return [Hash] result with :success key
-      # @raise [NotImplementedError] if provider doesn't support credential refresh
+      # @raise [UnsupportedAuthFlowError] if provider doesn't support credential refresh
       def refresh_auth(provider_name, token: nil)
         provider_name = provider_name.to_sym
         provider = resolve_provider(provider_name)
 
         unless provider.auth_type == :oauth
-          raise NotImplementedError,
+          raise UnsupportedAuthFlowError,
             "Provider #{provider_name} uses #{provider.auth_type} auth and does not support credential refresh"
         end
 
@@ -85,7 +85,7 @@ module AgentHarness
         when :claude, :anthropic
           refresh_claude_auth(token: token)
         else
-          raise NotImplementedError,
+          raise UnsupportedAuthFlowError,
             "Credential refresh is not yet implemented for provider #{provider_name}"
         end
       end

--- a/lib/agent_harness/errors.rb
+++ b/lib/agent_harness/errors.rb
@@ -66,6 +66,9 @@ module AgentHarness
   # subscription to API-metered usage.
   class AuthMismatchError < AuthenticationError; end
 
+  # Raised when a provider does not support the requested authentication flow.
+  class UnsupportedAuthFlowError < Error; end
+
   # Configuration errors
   class ConfigurationError < Error; end
 

--- a/spec/agent_harness/authentication_spec.rb
+++ b/spec/agent_harness/authentication_spec.rb
@@ -465,8 +465,20 @@ RSpec.describe AgentHarness::Authentication do
     end
 
     context "for API key provider" do
-      it "raises NotImplementedError" do
-        expect { described_class.auth_url(:aider) }.to raise_error(NotImplementedError, /api_key/)
+      it "raises UnsupportedAuthFlowError with provider auth details" do
+        expect { described_class.auth_url(:aider) }
+          .to raise_error(AgentHarness::UnsupportedAuthFlowError, /Provider aider uses api_key auth/)
+      end
+
+      it "raises an AgentHarness::Error subclass" do
+        expect { described_class.auth_url(:aider) }.to raise_error(AgentHarness::Error)
+      end
+    end
+
+    context "for OAuth provider without URL generation support" do
+      it "raises UnsupportedAuthFlowError with implementation details" do
+        expect { described_class.auth_url(:cursor) }
+          .to raise_error(AgentHarness::UnsupportedAuthFlowError, /OAuth URL generation is not yet implemented/)
       end
     end
   end
@@ -551,8 +563,20 @@ RSpec.describe AgentHarness::Authentication do
     end
 
     context "for API key provider" do
-      it "raises NotImplementedError" do
-        expect { described_class.refresh_auth(:aider, token: "key") }.to raise_error(NotImplementedError, /api_key/)
+      it "raises UnsupportedAuthFlowError with provider auth details" do
+        expect { described_class.refresh_auth(:aider, token: "key") }
+          .to raise_error(AgentHarness::UnsupportedAuthFlowError, /Provider aider uses api_key auth/)
+      end
+
+      it "raises an AgentHarness::Error subclass" do
+        expect { described_class.refresh_auth(:aider, token: "key") }.to raise_error(AgentHarness::Error)
+      end
+    end
+
+    context "for OAuth provider without credential refresh support" do
+      it "raises UnsupportedAuthFlowError with implementation details" do
+        expect { described_class.refresh_auth(:cursor, token: "key") }
+          .to raise_error(AgentHarness::UnsupportedAuthFlowError, /Credential refresh is not yet implemented/)
       end
     end
   end

--- a/spec/agent_harness/errors_spec.rb
+++ b/spec/agent_harness/errors_spec.rb
@@ -94,6 +94,16 @@ RSpec.describe AgentHarness do
       end
     end
 
+    describe AgentHarness::UnsupportedAuthFlowError do
+      it "inherits from Error" do
+        expect(described_class.new).to be_a(AgentHarness::Error)
+      end
+
+      it "is rescuable as StandardError" do
+        expect(described_class.new).to be_a(StandardError)
+      end
+    end
+
     describe AgentHarness::ConfigurationError do
       it "inherits from Error" do
         expect(described_class.new).to be_a(AgentHarness::Error)


### PR DESCRIPTION
## Summary

Use a harness-specific error for unsupported auth flows

See #144 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #144