### PR TITLE
feat(codex): expose JSONL transcript parser

### DIFF
--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -141,6 +141,8 @@ module AgentHarness
         end
 
         def parse_cli_jsonl_transcript(raw_output, max_events: nil)
+          return new.send(:parse_jsonl_output, "") if max_events && max_events <= 0
+
           output = max_events ? tail_nonempty_lines(raw_output, limit: max_events).join("\n") : raw_output
 
           new.send(:parse_jsonl_output, output)
@@ -149,6 +151,8 @@ module AgentHarness
         private
 
         def tail_nonempty_lines(text, limit:)
+          return [] if limit <= 0
+
           text.to_s.each_line.each_with_object([]) do |line, lines|
             stripped = line.strip
             next if stripped.empty?

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -139,6 +139,24 @@ module AgentHarness
         def smoke_test_contract
           Base::DEFAULT_SMOKE_TEST_CONTRACT
         end
+
+        def parse_cli_jsonl_transcript(raw_output, max_events: nil)
+          output = max_events ? tail_nonempty_lines(raw_output, limit: max_events).join("\n") : raw_output
+
+          new.send(:parse_jsonl_output, output)
+        end
+
+        private
+
+        def tail_nonempty_lines(text, limit:)
+          text.to_s.each_line.each_with_object([]) do |line, lines|
+            stripped = line.strip
+            next if stripped.empty?
+
+            lines.shift if lines.size >= limit
+            lines << stripped
+          end
+        end
       end
 
       def name
@@ -603,10 +621,11 @@ module AgentHarness
           when "turn.completed"
             turn_usage = build_token_usage(event["usage"])
             result = event["result"]
+            result_parts = result.is_a?(String) ? [result] : extract_task_complete_parts(event)
             wrapped_completion_without_new_output =
               pending_turn_usage_source == :wrapped &&
               pending_turn_usage &&
-              !result.is_a?(String) &&
+              result_parts.nil? &&
               (turn_usage.nil? || current_turn_parts.empty? || current_turn_parts.equal?(pending_wrapped_output_parts))
 
             if wrapped_completion_without_new_output
@@ -663,8 +682,8 @@ module AgentHarness
               pending_wrapped_same_turn_finalization = false
             end
 
-            if result.is_a?(String)
-              current_turn_parts = [result]
+            if result_parts
+              current_turn_parts = result_parts
               saw_assistant_output = true
               current_turn_finalized_output = true
             end

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -110,6 +110,54 @@ RSpec.describe AgentHarness::Providers::Codex do
     end
   end
 
+  describe ".parse_cli_jsonl_transcript" do
+    it "extracts final assistant text from a single JSONL event" do
+      output = JSON.generate({
+        "type" => "turn.completed",
+        "result" => "Final answer from Codex"
+      })
+
+      parsed = described_class.parse_cli_jsonl_transcript(output)
+
+      expect(parsed[:text]).to eq("Final answer from Codex")
+    end
+
+    it "extracts final assistant text from turn.completed last_agent_message" do
+      output = JSON.generate({
+        "type" => "turn.completed",
+        "last_agent_message" => "Final answer from last_agent_message"
+      })
+
+      parsed = described_class.parse_cli_jsonl_transcript(output)
+
+      expect(parsed[:text]).to eq("Final answer from last_agent_message")
+    end
+
+    it "applies max_events before parsing JSONL events" do
+      stale_line = JSON.generate({
+        "type" => "agent_message",
+        "role" => "assistant",
+        "text" => "Stale output"
+      })
+      output = [
+        stale_line,
+        *500.times.map { |i| JSON.generate({"type" => "message.delta", "delta" => {"index" => i}}) }
+      ].join("\n")
+
+      parsed_inputs = []
+      original_parse = JSON.method(:parse)
+      allow(JSON).to receive(:parse) do |input, *args|
+        parsed_inputs << input
+        original_parse.call(input, *args)
+      end
+
+      parsed = described_class.parse_cli_jsonl_transcript(output, max_events: 500)
+
+      expect(parsed[:text]).to be_nil
+      expect(parsed_inputs).not_to include(stale_line)
+    end
+  end
+
   describe ".firewall_requirements" do
     it "returns required domains" do
       requirements = described_class.firewall_requirements

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -156,6 +156,32 @@ RSpec.describe AgentHarness::Providers::Codex do
       expect(parsed[:text]).to be_nil
       expect(parsed_inputs).not_to include(stale_line)
     end
+
+    it "does not parse JSONL events when max_events is zero" do
+      output = JSON.generate({
+        "type" => "turn.completed",
+        "result" => "Ignored output"
+      })
+
+      expect(JSON).not_to receive(:parse)
+
+      parsed = described_class.parse_cli_jsonl_transcript(output, max_events: 0)
+
+      expect(parsed).to be_nil
+    end
+
+    it "does not parse JSONL events when max_events is negative" do
+      output = JSON.generate({
+        "type" => "turn.completed",
+        "result" => "Ignored output"
+      })
+
+      expect(JSON).not_to receive(:parse)
+
+      parsed = described_class.parse_cli_jsonl_transcript(output, max_events: -1)
+
+      expect(parsed).to be_nil
+    end
   end
 
   describe ".firewall_requirements" do


### PR DESCRIPTION
## Summary

- Exposes `AgentHarness::Providers::Codex.parse_cli_jsonl_transcript` as a public API for consumers that capture raw Codex CLI JSONL stdout outside normal response parsing.
- Adds optional `max_events:` support so callers can bound JSON parsing to the most recent transcript events.
- Covers single-event transcript parsing and pre-parse event capping.

Fixes #147

## Test plan

- [x] `bundle exec rspec spec/agent_harness/providers/codex_spec.rb`
- [x] `bundle exec standardrb lib/agent_harness/providers/codex.rb spec/agent_harness/providers/codex_spec.rb`