### PR TITLE
feat: add MCP HTTP transport support for servers

### DIFF
--- a/lib/agent_harness/mcp_server.rb
+++ b/lib/agent_harness/mcp_server.rb
@@ -75,6 +75,25 @@ module AgentHarness
       %w[http sse].include?(@transport)
     end
 
+    # Check if the MCP server is reachable based on its transport type.
+    #
+    # For stdio servers, checks that a command is present.
+    # For HTTP/SSE servers, checks that a URL is present and the server
+    # responds to an HTTP HEAD request.
+    #
+    # @param timeout [Integer] HTTP request timeout in seconds (default: 5)
+    # @return [Boolean]
+    def reachable?(timeout: 5)
+      case transport
+      when "stdio"
+        !command.nil? && !command.empty?
+      when "http", "sse"
+        !url.nil? && !url.to_s.strip.empty? && http_ping_ok?(timeout: timeout)
+      else
+        false
+      end
+    end
+
     def to_h
       h = {name: @name, transport: @transport}
       if stdio?
@@ -152,6 +171,19 @@ module AgentHarness
 
       raise McpConfigurationError,
         "MCP server '#{@name}' with #{@transport} transport should not have args (args are only valid for stdio)"
+    end
+
+    def http_ping_ok?(timeout: 5)
+      require "net/http"
+      uri = URI.parse(@url)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = (uri.scheme == "https")
+      http.open_timeout = timeout
+      http.read_timeout = timeout
+      response = http.head(uri.request_uri)
+      response.is_a?(Net::HTTPSuccess) || response.is_a?(Net::HTTPRedirection)
+    rescue
+      false
     end
   end
 end

--- a/lib/agent_harness/providers/adapter.rb
+++ b/lib/agent_harness/providers/adapter.rb
@@ -599,7 +599,7 @@ module AgentHarness
         end
 
         def default_supported_mcp_transports
-          []
+          %w[stdio]
         end
 
         def default_supports_sessions
@@ -849,9 +849,12 @@ module AgentHarness
 
       # Supported MCP transport types for this provider
       #
+      # Defaults to ["stdio"]. Providers that support HTTP/SSE transports
+      # should override this to include those transports.
+      #
       # @return [Array<String>] supported transports (e.g. ["stdio", "http"])
       def supported_mcp_transports
-        []
+        %w[stdio]
       end
 
       # Build provider-specific MCP flags/arguments for CLI invocation

--- a/spec/agent_harness/mcp_server_spec.rb
+++ b/spec/agent_harness/mcp_server_spec.rb
@@ -250,4 +250,86 @@ RSpec.describe AgentHarness::McpServer do
       expect(h).not_to have_key(:args)
     end
   end
+
+  describe "#reachable?" do
+    context "with stdio transport" do
+      it "returns true when command is present" do
+        server = described_class.new(
+          name: "fs",
+          transport: "stdio",
+          command: ["npx", "server"]
+        )
+        expect(server.reachable?).to be true
+      end
+    end
+
+    context "with http transport" do
+      it "returns true when url is present and server responds" do
+        server = described_class.new(
+          name: "web",
+          transport: "http",
+          url: "http://localhost:9999/mcp"
+        )
+
+        http_double = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:new).and_return(http_double)
+        allow(http_double).to receive(:use_ssl=)
+        allow(http_double).to receive(:open_timeout=)
+        allow(http_double).to receive(:read_timeout=)
+        allow(http_double).to receive(:head).and_return(Net::HTTPOK.new("1.1", "200", "OK"))
+
+        expect(server.reachable?).to be true
+      end
+
+      it "returns false when HTTP request fails" do
+        server = described_class.new(
+          name: "web",
+          transport: "http",
+          url: "http://localhost:9999/mcp"
+        )
+
+        allow(Net::HTTP).to receive(:new).and_raise(Errno::ECONNREFUSED)
+
+        expect(server.reachable?).to be false
+      end
+
+      it "returns false when server returns error status" do
+        server = described_class.new(
+          name: "web",
+          transport: "http",
+          url: "http://localhost:9999/mcp"
+        )
+
+        http_double = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:new).and_return(http_double)
+        allow(http_double).to receive(:use_ssl=)
+        allow(http_double).to receive(:open_timeout=)
+        allow(http_double).to receive(:read_timeout=)
+        allow(http_double).to receive(:head).and_return(
+          Net::HTTPInternalServerError.new("1.1", "500", "Internal Server Error")
+        )
+
+        expect(server.reachable?).to be false
+      end
+    end
+
+    context "with sse transport" do
+      it "returns true when url is present and server responds" do
+        server = described_class.new(
+          name: "events",
+          transport: "sse",
+          url: "http://localhost:8080/sse"
+        )
+
+        http_double = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:new).and_return(http_double)
+        allow(http_double).to receive(:use_ssl=)
+        allow(http_double).to receive(:open_timeout=)
+        allow(http_double).to receive(:read_timeout=)
+        allow(http_double).to receive(:head).and_return(Net::HTTPOK.new("1.1", "200", "OK"))
+
+        expect(server.reachable?).to be true
+      end
+    end
+  end
 end

--- a/spec/agent_harness/providers/adapter_spec.rb
+++ b/spec/agent_harness/providers/adapter_spec.rb
@@ -857,7 +857,7 @@ RSpec.describe AgentHarness::Providers::Adapter do
           supports_sessions: false,
           supports_dangerous_mode: false
         )
-        expect(metadata[:runtime][:supported_mcp_transports]).to eq([])
+        expect(metadata[:runtime][:supported_mcp_transports]).to eq(%w[stdio])
         expect(metadata[:configuration]).to include(
           fields: [],
           auth_modes: [:api_key],


### PR DESCRIPTION
## Summary

feat: add MCP HTTP transport support for servers

See #153 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #153