### PR TITLE
feat: add structured streaming response observer for chat

### DIFF
--- a/lib/agent_harness/openai_compatible_transport.rb
+++ b/lib/agent_harness/openai_compatible_transport.rb
@@ -54,7 +54,27 @@ module AgentHarness
     # @raise [RateLimitError] on 429 responses
     # @raise [TimeoutError] on network timeouts
     # @raise [ProviderError] on other HTTP errors
-    def chat(messages:, tools: nil, stream: false, max_tokens: nil, temperature: nil, &on_chunk)
+    # Send a chat completion request.
+    #
+    # Streaming chunks can be received via block, +on_chat_chunk+ proc,
+    # or an observer that responds to +on_chat_chunk+. When multiple
+    # receivers are provided, all receive every event.
+    #
+    # @param messages [Array<Hash>] conversation messages
+    # @param tools [Array<Hash>, nil] tool/function definitions
+    # @param stream [Boolean] whether to stream the response
+    # @param max_tokens [Integer, nil] maximum tokens in the response
+    # @param temperature [Float, nil] sampling temperature
+    # @param on_chat_chunk [Proc, nil] callback for structured streaming events
+    # @param observer [#on_chat_chunk, nil] observer receiving streaming events
+    # @yield [Hash] streaming chunks when stream: true
+    # @return [Response] the response
+    # @raise [AuthenticationError] on 401/403 responses
+    # @raise [RateLimitError] on 429 responses
+    # @raise [TimeoutError] on network timeouts
+    # @raise [ProviderError] on other HTTP errors
+    def chat(messages:, tools: nil, stream: false, max_tokens: nil, temperature: nil,
+      on_chat_chunk: nil, observer: nil, &on_chunk)
       max_tokens ||= DEFAULT_MAX_TOKENS
       uri = URI("#{@base_url}/chat/completions")
 
@@ -65,8 +85,11 @@ module AgentHarness
 
       start_time = Time.now
 
-      if stream && on_chunk
-        result = make_streaming_request(uri, body, &on_chunk)
+      has_stream_receiver = on_chunk || on_chat_chunk || observer_responds_to?(observer, :on_chat_chunk)
+
+      if stream && has_stream_receiver
+        combined = build_chat_chunk_callback(on_chunk, on_chat_chunk, observer)
+        result = make_streaming_request(uri, body, &combined)
         duration = Time.now - start_time
         build_streaming_response(result, duration: duration)
       else
@@ -159,7 +182,8 @@ module AgentHarness
       if event["usage"]
         usage = extract_usage(event)
         accumulated[:usage] = usage
-        on_chunk.call({type: :done, usage: usage})
+        on_chunk.call({type: :usage, input_tokens: usage[:input], output_tokens: usage[:output]})
+        on_chunk.call({type: :done})
         return
       end
 
@@ -174,6 +198,8 @@ module AgentHarness
       end
 
       process_tool_call_delta(delta, accumulated, &on_chunk)
+
+      emit_tool_call_completions(choice, accumulated, &on_chunk)
     end
 
     def process_tool_call_delta(delta, accumulated, &on_chunk)
@@ -199,19 +225,32 @@ module AgentHarness
 
         if tc_delta["id"]
           on_chunk.call({
-            type: :tool_call,
+            type: :tool_call_start,
             id: tc_delta["id"],
-            name: tc_delta.dig("function", "name") || "",
-            arguments: ""
+            name: tc_delta.dig("function", "name") || ""
           })
         elsif tc_delta.dig("function", "arguments")
           on_chunk.call({
-            type: :tool_call,
+            type: :tool_call_delta,
             id: tc[:id],
-            name: tc[:name],
             arguments: tc_delta.dig("function", "arguments")
           })
         end
+      end
+    end
+
+    def emit_tool_call_completions(choice, accumulated, &on_chunk)
+      return unless choice["finish_reason"] == "tool_calls"
+
+      accumulated[:tool_calls].each do |tc|
+        next unless tc
+
+        on_chunk.call({
+          type: :tool_call_complete,
+          id: tc[:id],
+          name: tc[:name],
+          arguments: tc[:arguments]
+        })
       end
     end
 
@@ -307,6 +346,18 @@ module AgentHarness
           arguments: tc.dig("function", "arguments")
         }
       end
+    end
+
+    def build_chat_chunk_callback(on_chunk, on_chat_chunk, observer)
+      proc do |chunk|
+        on_chunk&.call(chunk)
+        on_chat_chunk&.call(chunk)
+        observer.on_chat_chunk(chunk) if observer_responds_to?(observer, :on_chat_chunk)
+      end
+    end
+
+    def observer_responds_to?(observer, method_name)
+      observer&.respond_to?(method_name)
     end
 
     def handle_error_response(http_response, status_code)

--- a/lib/agent_harness/openai_compatible_transport.rb
+++ b/lib/agent_harness/openai_compatible_transport.rb
@@ -22,7 +22,8 @@ module AgentHarness
   #   transport.chat(messages: msgs, stream: true) do |chunk|
   #     case chunk[:type]
   #     when :text    then print chunk[:content]
-  #     when :done    then puts "\nTokens: #{chunk[:usage]}"
+  #     when :usage   then puts "\nTokens: #{chunk[:input_tokens]}+#{chunk[:output_tokens]}"
+  #     when :done    then puts "Stream complete"
   #     end
   #   end
   class OpenAICompatibleTransport
@@ -41,19 +42,6 @@ module AgentHarness
       @logger = logger
     end
 
-    # Send a chat completion request.
-    #
-    # @param messages [Array<Hash>] conversation messages
-    # @param tools [Array<Hash>, nil] tool/function definitions
-    # @param stream [Boolean] whether to stream the response
-    # @param max_tokens [Integer, nil] maximum tokens in the response
-    # @param temperature [Float, nil] sampling temperature
-    # @yield [Hash] streaming chunks when stream: true
-    # @return [Response] the response
-    # @raise [AuthenticationError] on 401/403 responses
-    # @raise [RateLimitError] on 429 responses
-    # @raise [TimeoutError] on network timeouts
-    # @raise [ProviderError] on other HTTP errors
     # Send a chat completion request.
     #
     # Streaming chunks can be received via block, +on_chat_chunk+ proc,

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -181,6 +181,30 @@ module AgentHarness
         handle_error(e, prompt: prompt, options: options)
       end
 
+      # Send a multi-turn chat message via an HTTP transport.
+      #
+      # Providers that support OpenAI-compatible chat should override this
+      # to wire up their transport. The default raises NotImplementedError.
+      #
+      # Structured streaming events are delivered through three channels:
+      # - +on_chat_chunk+ proc (keyword argument)
+      # - +observer+ object responding to +on_chat_chunk+
+      # - block (yield)
+      #
+      # When multiple receivers are provided, all receive every event.
+      #
+      # @param messages [Array<Hash>] conversation messages
+      # @param stream [Boolean] whether to stream the response
+      # @param on_chat_chunk [Proc, nil] callback for structured streaming events
+      # @param observer [#on_chat_chunk, nil] observer receiving streaming events
+      # @param options [Hash] additional options forwarded to the transport
+      # @return [Response] the response
+      def send_chat_message(messages:, stream: false, on_chat_chunk: nil, observer: nil, **options, &on_chunk)
+        raise NotImplementedError,
+          "#{self.class.provider_name} does not support chat messages. " \
+          "Override send_chat_message or configure an OpenAI-compatible transport."
+      end
+
       # Provider name for display
       #
       # @return [String] display name

--- a/spec/agent_harness/openai_compatible_transport_spec.rb
+++ b/spec/agent_harness/openai_compatible_transport_spec.rb
@@ -272,9 +272,13 @@ RSpec.describe AgentHarness::OpenAICompatibleTransport do
         text_chunks = received_chunks.select { |c| c[:type] == :text }
         expect(text_chunks.map { |c| c[:content] }).to eq(["Hello", ", world!"])
 
+        usage_chunks = received_chunks.select { |c| c[:type] == :usage }
+        expect(usage_chunks.length).to eq(1)
+        expect(usage_chunks[0]).to eq({type: :usage, input_tokens: 10, output_tokens: 5})
+
         done_chunks = received_chunks.select { |c| c[:type] == :done }
         expect(done_chunks.length).to eq(1)
-        expect(done_chunks[0][:usage]).to eq({input: 10, output: 5, total: 15})
+        expect(done_chunks[0]).to eq({type: :done})
 
         expect(response.output).to eq("Hello, world!")
         expect(response.success?).to be true
@@ -282,7 +286,7 @@ RSpec.describe AgentHarness::OpenAICompatibleTransport do
         expect(response.tokens).to eq({input: 10, output: 5, total: 15})
       end
 
-      it "handles streamed tool calls" do
+      it "handles streamed tool calls with structured chunk types" do
         chunks = [
           "data: #{JSON.generate({
             "choices" => [{"delta" => {"role" => "assistant", "tool_calls" => [{"index" => 0, "id" => "call_abc", "function" => {"name" => "get_weather", "arguments" => ""}}]}}]
@@ -292,6 +296,9 @@ RSpec.describe AgentHarness::OpenAICompatibleTransport do
           })}\n\n",
           "data: #{JSON.generate({
             "choices" => [{"delta" => {"tool_calls" => [{"index" => 0, "function" => {"arguments" => 'ation":"NYC"}'}}]}}]
+          })}\n\n",
+          "data: #{JSON.generate({
+            "choices" => [{"delta" => {}, "finish_reason" => "tool_calls"}]
           })}\n\n",
           "data: #{JSON.generate({"usage" => {"prompt_tokens" => 15, "completion_tokens" => 10}})}\n\n",
           "data: [DONE]\n\n"
@@ -305,10 +312,21 @@ RSpec.describe AgentHarness::OpenAICompatibleTransport do
           stream: true
         ) { |chunk| received_chunks << chunk }
 
-        tool_chunks = received_chunks.select { |c| c[:type] == :tool_call }
-        expect(tool_chunks.length).to eq(3)
-        expect(tool_chunks[0][:id]).to eq("call_abc")
-        expect(tool_chunks[0][:name]).to eq("get_weather")
+        start_chunks = received_chunks.select { |c| c[:type] == :tool_call_start }
+        expect(start_chunks.length).to eq(1)
+        expect(start_chunks[0]).to eq({type: :tool_call_start, id: "call_abc", name: "get_weather"})
+
+        delta_chunks = received_chunks.select { |c| c[:type] == :tool_call_delta }
+        expect(delta_chunks.length).to eq(2)
+        expect(delta_chunks[0]).to eq({type: :tool_call_delta, id: "call_abc", arguments: '{"loc'})
+        expect(delta_chunks[1]).to eq({type: :tool_call_delta, id: "call_abc", arguments: 'ation":"NYC"}'})
+
+        complete_chunks = received_chunks.select { |c| c[:type] == :tool_call_complete }
+        expect(complete_chunks.length).to eq(1)
+        expect(complete_chunks[0]).to eq({
+          type: :tool_call_complete, id: "call_abc",
+          name: "get_weather", arguments: '{"location":"NYC"}'
+        })
 
         expect(response.metadata[:tool_calls]).to eq([
           {id: "call_abc", name: "get_weather", arguments: '{"location":"NYC"}'}
@@ -340,6 +358,79 @@ RSpec.describe AgentHarness::OpenAICompatibleTransport do
           messages: [{role: "user", content: "prompt"}],
           stream: true
         ) { |_chunk| }
+      end
+
+      it "delivers events to on_chat_chunk proc" do
+        chunks = [
+          "data: #{JSON.generate({"choices" => [{"delta" => {"content" => "Hi"}}]})}\n\n",
+          "data: #{JSON.generate({"usage" => {"prompt_tokens" => 5, "completion_tokens" => 2}})}\n\n",
+          "data: [DONE]\n\n"
+        ]
+
+        stub_streaming_response(status: 200, chunks: chunks)
+
+        received = []
+        transport.chat(
+          messages: [{role: "user", content: "prompt"}],
+          stream: true,
+          on_chat_chunk: proc { |chunk| received << chunk }
+        )
+
+        expect(received.map { |c| c[:type] }).to eq([:text, :usage, :done])
+        expect(received[0][:content]).to eq("Hi")
+      end
+
+      it "delivers events to observer responding to on_chat_chunk" do
+        chunks = [
+          "data: #{JSON.generate({"choices" => [{"delta" => {"content" => "Hi"}}]})}\n\n",
+          "data: #{JSON.generate({"usage" => {"prompt_tokens" => 5, "completion_tokens" => 2}})}\n\n",
+          "data: [DONE]\n\n"
+        ]
+
+        stub_streaming_response(status: 200, chunks: chunks)
+
+        observer = double("observer")
+        allow(observer).to receive(:respond_to?).and_return(false)
+        allow(observer).to receive(:respond_to?).with(:on_chat_chunk).and_return(true)
+        allow(observer).to receive(:on_chat_chunk)
+
+        transport.chat(
+          messages: [{role: "user", content: "prompt"}],
+          stream: true,
+          observer: observer
+        )
+
+        expect(observer).to have_received(:on_chat_chunk).with({type: :text, content: "Hi"})
+        expect(observer).to have_received(:on_chat_chunk).with({type: :usage, input_tokens: 5, output_tokens: 2})
+        expect(observer).to have_received(:on_chat_chunk).with({type: :done})
+      end
+
+      it "delivers events to block, on_chat_chunk, and observer simultaneously" do
+        chunks = [
+          "data: #{JSON.generate({"choices" => [{"delta" => {"content" => "Hi"}}]})}\n\n",
+          "data: #{JSON.generate({"usage" => {"prompt_tokens" => 5, "completion_tokens" => 2}})}\n\n",
+          "data: [DONE]\n\n"
+        ]
+
+        stub_streaming_response(status: 200, chunks: chunks)
+
+        block_received = []
+        proc_received = []
+        observer = double("observer")
+        allow(observer).to receive(:respond_to?).and_return(false)
+        allow(observer).to receive(:respond_to?).with(:on_chat_chunk).and_return(true)
+        allow(observer).to receive(:on_chat_chunk)
+
+        transport.chat(
+          messages: [{role: "user", content: "prompt"}],
+          stream: true,
+          on_chat_chunk: proc { |chunk| proc_received << chunk },
+          observer: observer
+        ) { |chunk| block_received << chunk }
+
+        expect(block_received.length).to eq(3)
+        expect(proc_received.length).to eq(3)
+        expect(observer).to have_received(:on_chat_chunk).exactly(3).times
       end
     end
 

--- a/spec/agent_harness/providers/base_send_chat_message_spec.rb
+++ b/spec/agent_harness/providers/base_send_chat_message_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe AgentHarness::Providers::Base, "#send_chat_message" do
+  let(:mock_executor) do
+    instance_double(AgentHarness::CommandExecutor).tap do |executor|
+      allow(executor).to receive(:execute).and_return(
+        AgentHarness::CommandExecutor::Result.new(
+          stdout: "", stderr: "", exit_code: 0, duration: 1.0
+        )
+      )
+    end
+  end
+
+  let(:test_provider_class) do
+    Class.new(described_class) do
+      class << self
+        def provider_name
+          :test_provider
+        end
+
+        def binary_name
+          "test-cli"
+        end
+
+        def available?
+          true
+        end
+      end
+
+      protected
+
+      def build_command(prompt, options)
+        [self.class.binary_name, "--prompt", prompt]
+      end
+
+      def default_timeout
+        60
+      end
+    end
+  end
+
+  let(:config) do
+    AgentHarness::ProviderConfig.new(:test_provider).tap do |c|
+      c.model = "test-model"
+    end
+  end
+
+  subject(:provider) { test_provider_class.new(config: config, executor: mock_executor) }
+
+  it "raises NotImplementedError by default" do
+    expect {
+      provider.send_chat_message(messages: [{role: "user", content: "Hello"}])
+    }.to raise_error(NotImplementedError, /test_provider does not support chat messages/)
+  end
+end


### PR DESCRIPTION
## Summary

feat: add structured streaming response observer for chat

See #151 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #151