### PR TITLE
feat: add conversation manager for multi-turn chat

### DIFF
--- a/lib/agent_harness.rb
+++ b/lib/agent_harness.rb
@@ -271,6 +271,7 @@ require_relative "agent_harness/token_tracker"
 require_relative "agent_harness/error_taxonomy"
 require_relative "agent_harness/text_transport"
 require_relative "agent_harness/openai_compatible_transport"
+require_relative "agent_harness/conversation"
 require_relative "agent_harness/authentication"
 require_relative "agent_harness/provider_health_check"
 

--- a/lib/agent_harness/conversation.rb
+++ b/lib/agent_harness/conversation.rb
@@ -113,7 +113,11 @@ module AgentHarness
 
     # Remove oldest non-system messages to free context window.
     #
-    # @param keep_recent [Integer, nil] minimum number of recent messages to preserve
+    # keep_recent counts conversational turns, not individual messages. A turn is
+    # anchored by a user message and includes any following assistant/tool
+    # messages up to the next user message.
+    #
+    # @param keep_recent [Integer, nil] minimum number of recent turns to preserve
     # @param keep_system_prompt [Boolean] whether to preserve the system prompt
     # @return [Integer] number of messages removed
     def truncate(keep_recent: nil, keep_system_prompt: true)
@@ -121,8 +125,8 @@ module AgentHarness
       system_messages = keep_system_prompt ? @messages.select { |m| m[:role] == :system } : []
       non_system = @messages.reject { |m| m[:role] == :system }
 
-      kept = if keep_recent && keep_recent < non_system.size
-        non_system.last(keep_recent)
+      kept = if keep_recent
+        recent_turns(non_system, keep_recent).flatten
       else
         non_system
       end
@@ -145,13 +149,13 @@ module AgentHarness
     #
     # @return [Hash] :system [String, nil] and :messages [Array<Hash>]
     def to_anthropic_messages
-      system_text = nil
+      system_messages = []
       result_messages = []
 
       @messages.each do |msg|
         case msg[:role]
         when :system
-          system_text = msg[:content]
+          system_messages << msg[:content]
         when :user
           result_messages << {
             role: "user",
@@ -200,7 +204,7 @@ module AgentHarness
         end
       end
 
-      {system: system_text, messages: result_messages}
+      {system: system_messages.empty? ? nil : system_messages.join("\n\n"), messages: result_messages}
     end
 
     # Returns the most recent assistant message, or nil.
@@ -221,6 +225,18 @@ module AgentHarness
     end
 
     private
+
+    def recent_turns(non_system_messages, keep_recent)
+      turns = non_system_messages.each_with_object([]) do |msg, grouped_turns|
+        if msg[:role] == :user || grouped_turns.empty?
+          grouped_turns << [msg]
+        else
+          grouped_turns.last << msg
+        end
+      end
+
+      (keep_recent < turns.size) ? turns.last(keep_recent) : turns
+    end
 
     def openai_format(msg)
       case msg[:role]

--- a/lib/agent_harness/conversation.rb
+++ b/lib/agent_harness/conversation.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "json"
+
 module AgentHarness
   # Manages multi-turn conversation history with token tracking and
   # transport-specific message formatting.
@@ -180,14 +182,20 @@ module AgentHarness
 
           result_messages << {role: "assistant", content: content_blocks}
         when :tool
-          result_messages << {
-            role: "user",
-            content: [{
-              type: "tool_result",
-              tool_use_id: msg[:tool_call_id],
-              content: msg[:content]
-            }]
+          tool_result_block = {
+            type: "tool_result",
+            tool_use_id: msg[:tool_call_id],
+            content: msg[:content]
           }
+          prev = result_messages.last
+          if prev && prev[:role] == "user" && prev[:content]&.first&.dig(:type) == "tool_result"
+            prev[:content] << tool_result_block
+          else
+            result_messages << {
+              role: "user",
+              content: [tool_result_block]
+            }
+          end
         end
       end
 

--- a/lib/agent_harness/conversation.rb
+++ b/lib/agent_harness/conversation.rb
@@ -117,17 +117,18 @@ module AgentHarness
     # @param keep_system_prompt [Boolean] whether to preserve the system prompt
     # @return [Integer] number of messages removed
     def truncate(keep_recent: nil, keep_system_prompt: true)
+      original_size = @messages.size
       system_messages = keep_system_prompt ? @messages.select { |m| m[:role] == :system } : []
       non_system = @messages.reject { |m| m[:role] == :system }
 
-      if keep_recent && keep_recent < non_system.size
-        kept = non_system.last(keep_recent)
-        removed_count = non_system.size - kept.size
-        @messages = system_messages + kept
-        removed_count
+      kept = if keep_recent && keep_recent < non_system.size
+        non_system.last(keep_recent)
       else
-        0
+        non_system
       end
+
+      @messages = system_messages + kept
+      original_size - @messages.size
     end
 
     # Format messages for OpenAI-compatible chat completions APIs.

--- a/lib/agent_harness/conversation.rb
+++ b/lib/agent_harness/conversation.rb
@@ -49,6 +49,9 @@ module AgentHarness
       unless VALID_ROLES.include?(role)
         raise ArgumentError, "Invalid role: #{role}. Must be one of #{VALID_ROLES.join(", ")}"
       end
+      if role == :system && !@messages.empty?
+        raise ArgumentError, "System messages are only allowed as the first message"
+      end
 
       message = {
         role: role,
@@ -122,8 +125,9 @@ module AgentHarness
     # @return [Integer] number of messages removed
     def truncate(keep_recent: nil, keep_system_prompt: true)
       original_size = @messages.size
-      system_messages = keep_system_prompt ? @messages.select { |m| m[:role] == :system } : []
-      non_system = @messages.reject { |m| m[:role] == :system }
+      system_message = initial_system_message
+      system_messages = (keep_system_prompt && system_message) ? [system_message] : []
+      non_system = system_message ? @messages.drop(1) : @messages
 
       kept = if keep_recent
         recent_turns(non_system, keep_recent).flatten
@@ -149,13 +153,12 @@ module AgentHarness
     #
     # @return [Hash] :system [String, nil] and :messages [Array<Hash>]
     def to_anthropic_messages
-      system_messages = []
+      system_prompt = initial_system_message&.dig(:content)
       result_messages = []
 
-      @messages.each do |msg|
+      start_index = system_prompt ? 1 : 0
+      @messages.drop(start_index).each do |msg|
         case msg[:role]
-        when :system
-          system_messages << msg[:content]
         when :user
           result_messages << {
             role: "user",
@@ -204,7 +207,7 @@ module AgentHarness
         end
       end
 
-      {system: system_messages.empty? ? nil : system_messages.join("\n\n"), messages: result_messages}
+      {system: system_prompt, messages: result_messages}
     end
 
     # Returns the most recent assistant message, or nil.
@@ -221,10 +224,15 @@ module AgentHarness
     #
     # @return [void]
     def clear!
-      @messages.select! { |m| m[:role] == :system }
+      system_message = initial_system_message
+      @messages = system_message ? [system_message] : []
     end
 
     private
+
+    def initial_system_message
+      @messages.first if @messages.first&.dig(:role) == :system
+    end
 
     def recent_turns(non_system_messages, keep_recent)
       turns = non_system_messages.each_with_object([]) do |msg, grouped_turns|

--- a/lib/agent_harness/conversation.rb
+++ b/lib/agent_harness/conversation.rb
@@ -169,7 +169,7 @@ module AgentHarness
           content_blocks << {type: "text", text: msg[:content]} if msg[:content]
 
           msg[:tool_calls]&.each do |tc|
-            arguments = tc[:arguments]
+            arguments = tool_call_arguments(tc)
             parsed_arguments = if arguments.is_a?(String)
               begin
                 JSON.parse(arguments)
@@ -182,8 +182,8 @@ module AgentHarness
 
             content_blocks << {
               type: "tool_use",
-              id: tc[:id],
-              name: tc[:name],
+              id: tool_call_value(tc, :id),
+              name: tool_call_name(tc),
               input: parsed_arguments
             }
           end
@@ -259,11 +259,11 @@ module AgentHarness
         if msg[:tool_calls]
           formatted[:tool_calls] = msg[:tool_calls].map do |tc|
             {
-              id: tc[:id],
+              id: tool_call_value(tc, :id),
               type: "function",
               function: {
-                name: tc[:name],
-                arguments: tc[:arguments].is_a?(Hash) ? JSON.generate(tc[:arguments]) : tc[:arguments]
+                name: tool_call_name(tc),
+                arguments: serialize_tool_call_arguments(tc)
               }
             }
           end
@@ -289,6 +289,38 @@ module AgentHarness
           value
         end
       end
+    end
+
+    def serialize_tool_call_arguments(tool_call)
+      arguments = tool_call_arguments(tool_call)
+      arguments.is_a?(Hash) ? JSON.generate(arguments) : arguments
+    end
+
+    def tool_call_name(tool_call)
+      tool_call_value(tool_call, :name) || nested_tool_call_value(tool_call, :function, :name)
+    end
+
+    def tool_call_arguments(tool_call)
+      tool_call_value(tool_call, :arguments) || nested_tool_call_value(tool_call, :function, :arguments)
+    end
+
+    def nested_tool_call_value(tool_call, *keys)
+      value = tool_call
+      keys.each do |key|
+        value = hash_value(value, key)
+        return nil if value.nil?
+      end
+      value
+    end
+
+    def tool_call_value(tool_call, key)
+      hash_value(tool_call, key)
+    end
+
+    def hash_value(hash, key)
+      return nil unless hash.is_a?(Hash)
+
+      hash[key] || hash[key.to_s]
     end
   end
 end

--- a/lib/agent_harness/conversation.rb
+++ b/lib/agent_harness/conversation.rb
@@ -65,14 +65,14 @@ module AgentHarness
       message[:tokens] = metadata[:tokens] if metadata[:tokens]
 
       @messages << message
-      message
+      deep_copy(message)
     end
 
     # Returns the full message history.
     #
     # @return [Array<Hash>] all messages in chronological order
     def messages
-      @messages.dup
+      deep_copy(@messages)
     end
 
     # @return [Integer] the number of messages in the conversation
@@ -212,7 +212,7 @@ module AgentHarness
     # @return [Hash, nil]
     def last_assistant_message
       @messages.reverse_each do |msg|
-        return msg if msg[:role] == :assistant
+        return deep_copy(msg) if msg[:role] == :assistant
       end
       nil
     end
@@ -263,6 +263,23 @@ module AgentHarness
         formatted
       else
         {role: msg[:role].to_s, content: msg[:content]}
+      end
+    end
+
+    def deep_copy(value)
+      case value
+      when Array
+        value.map { |item| deep_copy(item) }
+      when Hash
+        value.each_with_object({}) do |(key, nested_value), copy|
+          copy[key] = deep_copy(nested_value)
+        end
+      else
+        begin
+          value.dup
+        rescue TypeError
+          value
+        end
       end
     end
   end

--- a/lib/agent_harness/conversation.rb
+++ b/lib/agent_harness/conversation.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+module AgentHarness
+  # Manages multi-turn conversation history with token tracking and
+  # transport-specific message formatting.
+  #
+  # Encapsulates message storage, token budget awareness, context window
+  # truncation, and serialisation to OpenAI and Anthropic API formats.
+  #
+  # @example Basic usage
+  #   convo = AgentHarness::Conversation.new(system_prompt: "You are helpful.")
+  #   convo.add_message(:user, "Hello")
+  #   convo.add_message(:assistant, "Hi there!", tokens: { input: 10, output: 5 })
+  #   convo.to_openai_messages
+  #
+  # @example Token-aware truncation
+  #   convo = AgentHarness::Conversation.new(system_prompt: "...", token_limit: 8000)
+  #   # ... add many messages ...
+  #   convo.truncate(keep_recent: 4) if convo.approaching_limit?
+  class Conversation
+    VALID_ROLES = %i[system user assistant tool].freeze
+
+    # @return [Integer, nil] the token budget for this conversation
+    attr_reader :token_limit
+
+    # @param system_prompt [String, nil] optional system prompt prepended to messages
+    # @param token_limit [Integer, nil] optional context-window token budget
+    def initialize(system_prompt: nil, token_limit: nil)
+      @messages = []
+      @token_limit = token_limit
+
+      if system_prompt
+        add_message(:system, system_prompt)
+      end
+    end
+
+    # Append a message to the conversation.
+    #
+    # @param role [Symbol] one of :system, :user, :assistant, :tool
+    # @param content [String, nil] message text
+    # @param metadata [Hash] optional fields — :tool_calls, :tool_call_id,
+    #   :tool_name, :tool_arguments, :tool_result, :model, :tokens
+    # @return [Hash] the message that was added
+    # @raise [ArgumentError] if role is invalid
+    def add_message(role, content = nil, **metadata)
+      role = role.to_sym
+      unless VALID_ROLES.include?(role)
+        raise ArgumentError, "Invalid role: #{role}. Must be one of #{VALID_ROLES.join(", ")}"
+      end
+
+      message = {
+        role: role,
+        content: content,
+        created_at: Time.now
+      }
+
+      message[:tool_calls] = metadata[:tool_calls] if metadata[:tool_calls]
+      message[:tool_call_id] = metadata[:tool_call_id] if metadata[:tool_call_id]
+      message[:tool_name] = metadata[:tool_name] if metadata[:tool_name]
+      message[:tool_arguments] = metadata[:tool_arguments] if metadata[:tool_arguments]
+      message[:tool_result] = metadata[:tool_result] if metadata[:tool_result]
+      message[:model] = metadata[:model] if metadata[:model]
+      message[:tokens] = metadata[:tokens] if metadata[:tokens]
+
+      @messages << message
+      message
+    end
+
+    # Returns the full message history.
+    #
+    # @return [Array<Hash>] all messages in chronological order
+    def messages
+      @messages.dup
+    end
+
+    # @return [Integer] the number of messages in the conversation
+    def message_count
+      @messages.size
+    end
+
+    # Sum of all tracked tokens (input + output) across messages.
+    #
+    # @return [Integer] total tokens consumed
+    def token_count
+      @messages.sum do |msg|
+        tokens = msg[:tokens]
+        next 0 unless tokens
+
+        (tokens[:input] || 0) + (tokens[:output] || 0)
+      end
+    end
+
+    # Tokens remaining before hitting the limit.
+    #
+    # @return [Integer, nil] remaining tokens, or nil when no limit is set
+    def token_remaining
+      return nil unless @token_limit
+
+      @token_limit - token_count
+    end
+
+    # Whether token usage has reached or exceeded the given threshold of the limit.
+    #
+    # @param threshold [Float] fraction of token_limit (0.0–1.0) at which to warn
+    # @return [Boolean] true when usage >= threshold * limit; false when no limit set
+    def approaching_limit?(threshold: 0.8)
+      return false unless @token_limit
+
+      token_count >= (threshold * @token_limit)
+    end
+
+    # Remove oldest non-system messages to free context window.
+    #
+    # @param keep_recent [Integer, nil] minimum number of recent messages to preserve
+    # @param keep_system_prompt [Boolean] whether to preserve the system prompt
+    # @return [Integer] number of messages removed
+    def truncate(keep_recent: nil, keep_system_prompt: true)
+      system_messages = keep_system_prompt ? @messages.select { |m| m[:role] == :system } : []
+      non_system = @messages.reject { |m| m[:role] == :system }
+
+      if keep_recent && keep_recent < non_system.size
+        kept = non_system.last(keep_recent)
+        removed_count = non_system.size - kept.size
+        @messages = system_messages + kept
+        removed_count
+      else
+        0
+      end
+    end
+
+    # Format messages for OpenAI-compatible chat completions APIs.
+    #
+    # @return [Array<Hash>] messages with string roles and content
+    def to_openai_messages
+      @messages.map { |msg| openai_format(msg) }
+    end
+
+    # Format messages for the Anthropic Messages API.
+    #
+    # The system prompt is returned separately; tool results are wrapped as
+    # content blocks inside user messages per Anthropic's schema.
+    #
+    # @return [Hash] :system [String, nil] and :messages [Array<Hash>]
+    def to_anthropic_messages
+      system_text = nil
+      result_messages = []
+
+      @messages.each do |msg|
+        case msg[:role]
+        when :system
+          system_text = msg[:content]
+        when :user
+          result_messages << {
+            role: "user",
+            content: [{type: "text", text: msg[:content]}]
+          }
+        when :assistant
+          content_blocks = []
+          content_blocks << {type: "text", text: msg[:content]} if msg[:content]
+
+          msg[:tool_calls]&.each do |tc|
+            arguments = tc[:arguments]
+            parsed_arguments = if arguments.is_a?(String)
+              begin
+                JSON.parse(arguments)
+              rescue JSON::ParserError
+                arguments
+              end
+            else
+              arguments
+            end
+
+            content_blocks << {
+              type: "tool_use",
+              id: tc[:id],
+              name: tc[:name],
+              input: parsed_arguments
+            }
+          end
+
+          result_messages << {role: "assistant", content: content_blocks}
+        when :tool
+          result_messages << {
+            role: "user",
+            content: [{
+              type: "tool_result",
+              tool_use_id: msg[:tool_call_id],
+              content: msg[:content]
+            }]
+          }
+        end
+      end
+
+      {system: system_text, messages: result_messages}
+    end
+
+    # Returns the most recent assistant message, or nil.
+    #
+    # @return [Hash, nil]
+    def last_assistant_message
+      @messages.reverse_each do |msg|
+        return msg if msg[:role] == :assistant
+      end
+      nil
+    end
+
+    # Remove all messages except the system prompt.
+    #
+    # @return [void]
+    def clear!
+      @messages.select! { |m| m[:role] == :system }
+    end
+
+    private
+
+    def openai_format(msg)
+      case msg[:role]
+      when :tool
+        {
+          role: "tool",
+          content: msg[:content],
+          tool_call_id: msg[:tool_call_id]
+        }
+      when :assistant
+        formatted = {role: "assistant", content: msg[:content]}
+        if msg[:tool_calls]
+          formatted[:tool_calls] = msg[:tool_calls].map do |tc|
+            {
+              id: tc[:id],
+              type: "function",
+              function: {
+                name: tc[:name],
+                arguments: tc[:arguments].is_a?(Hash) ? JSON.generate(tc[:arguments]) : tc[:arguments]
+              }
+            }
+          end
+        end
+        formatted
+      else
+        {role: msg[:role].to_s, content: msg[:content]}
+      end
+    end
+  end
+end

--- a/spec/agent_harness/conversation_spec.rb
+++ b/spec/agent_harness/conversation_spec.rb
@@ -169,8 +169,24 @@ RSpec.describe AgentHarness::Conversation do
 
     it "removes system prompt when keep_system_prompt is false" do
       removed = convo.truncate(keep_recent: 2, keep_system_prompt: false)
-      expect(removed).to eq(4)
+      expect(removed).to eq(5)
       expect(convo.message_count).to eq(2)
+      expect(convo.messages.none? { |m| m[:role] == :system }).to be true
+    end
+
+    it "removes only the system prompt when keep_recent is nil" do
+      removed = convo.truncate(keep_system_prompt: false)
+
+      expect(removed).to eq(1)
+      expect(convo.message_count).to eq(6)
+      expect(convo.messages.none? { |m| m[:role] == :system }).to be true
+    end
+
+    it "removes only the system prompt when keep_recent covers all non-system messages" do
+      removed = convo.truncate(keep_recent: 10, keep_system_prompt: false)
+
+      expect(removed).to eq(1)
+      expect(convo.message_count).to eq(6)
       expect(convo.messages.none? { |m| m[:role] == :system }).to be true
     end
   end

--- a/spec/agent_harness/conversation_spec.rb
+++ b/spec/agent_harness/conversation_spec.rb
@@ -70,6 +70,17 @@ RSpec.describe AgentHarness::Conversation do
       expect(msg[:tool_result]).to eq("found")
       expect(msg[:model]).to eq("gpt-4o")
     end
+
+    it "returns a defensive copy of the stored message" do
+      msg = conversation.add_message(:assistant, "Hi!", tokens: {input: 10, output: 5})
+
+      msg[:content] = "Mutated"
+      msg[:tokens][:input] = 999
+
+      stored_message = conversation.messages.first
+      expect(stored_message[:content]).to eq("Hi!")
+      expect(stored_message[:tokens]).to eq({input: 10, output: 5})
+    end
   end
 
   describe "#messages" do
@@ -78,6 +89,22 @@ RSpec.describe AgentHarness::Conversation do
       msgs = conversation.messages
       msgs.clear
       expect(conversation.message_count).to eq(1)
+    end
+
+    it "returns deep-copied messages" do
+      conversation.add_message(:assistant, "Hi!", tool_calls: [
+        {id: "call_1", name: "search", arguments: {q: "test"}}
+      ])
+
+      msgs = conversation.messages
+      msgs.first[:content] = "Mutated"
+      msgs.first[:tool_calls].first[:arguments][:q] = "changed"
+
+      stored_message = conversation.messages.first
+      expect(stored_message[:content]).to eq("Hi!")
+      expect(stored_message[:tool_calls]).to eq([
+        {id: "call_1", name: "search", arguments: {q: "test"}}
+      ])
     end
   end
 
@@ -377,6 +404,22 @@ RSpec.describe AgentHarness::Conversation do
 
       msg = conversation.last_assistant_message
       expect(msg[:content]).to eq("Second")
+    end
+
+    it "returns a defensive copy" do
+      conversation.add_message(:assistant, "Second", tool_calls: [
+        {id: "call_1", name: "search", arguments: {q: "test"}}
+      ])
+
+      msg = conversation.last_assistant_message
+      msg[:content] = "Mutated"
+      msg[:tool_calls].first[:arguments][:q] = "changed"
+
+      stored_message = conversation.messages.first
+      expect(stored_message[:content]).to eq("Second")
+      expect(stored_message[:tool_calls]).to eq([
+        {id: "call_1", name: "search", arguments: {q: "test"}}
+      ])
     end
   end
 

--- a/spec/agent_harness/conversation_spec.rb
+++ b/spec/agent_harness/conversation_spec.rb
@@ -273,6 +273,22 @@ RSpec.describe AgentHarness::Conversation do
       }])
     end
 
+    it "preserves native OpenAI tool_call shape when re-serializing" do
+      tool_calls = [{
+        id: "call_1",
+        type: "function",
+        function: {name: "search", arguments: '{"q":"test"}'}
+      }]
+      conversation.add_message(:assistant, nil, tool_calls: tool_calls)
+
+      result = conversation.to_openai_messages
+      expect(result.first[:tool_calls]).to eq([{
+        id: "call_1",
+        type: "function",
+        function: {name: "search", arguments: '{"q":"test"}'}
+      }])
+    end
+
     it "formats tool result messages" do
       conversation.add_message(:tool, "result text", tool_call_id: "call_1")
 
@@ -336,6 +352,24 @@ RSpec.describe AgentHarness::Conversation do
       assistant = result[:messages].first
       expect(assistant[:content].size).to eq(2)
       expect(assistant[:content][0]).to eq({type: "text", text: "Let me search."})
+      expect(assistant[:content][1]).to eq({
+        type: "tool_use",
+        id: "call_1",
+        name: "search",
+        input: {"q" => "test"}
+      })
+    end
+
+    it "formats native OpenAI tool_calls as tool_use blocks" do
+      tool_calls = [{
+        "id" => "call_1",
+        "type" => "function",
+        "function" => {"name" => "search", "arguments" => '{"q":"test"}'}
+      }]
+      conversation.add_message(:assistant, "Let me search.", tool_calls: tool_calls)
+
+      result = conversation.to_anthropic_messages
+      assistant = result[:messages].first
       expect(assistant[:content][1]).to eq({
         type: "tool_use",
         id: "call_1",

--- a/spec/agent_harness/conversation_spec.rb
+++ b/spec/agent_harness/conversation_spec.rb
@@ -294,6 +294,25 @@ RSpec.describe AgentHarness::Conversation do
       expect(assistant[:content].first[:type]).to eq("tool_use")
     end
 
+    it "merges consecutive tool results into a single user message" do
+      tool_calls = [
+        {id: "call_1", name: "search", arguments: '{"q":"ruby"}'},
+        {id: "call_2", name: "search", arguments: '{"q":"python"}'}
+      ]
+      conversation.add_message(:assistant, nil, tool_calls: tool_calls)
+      conversation.add_message(:tool, "ruby result", tool_call_id: "call_1")
+      conversation.add_message(:tool, "python result", tool_call_id: "call_2")
+
+      result = conversation.to_anthropic_messages
+      # Two tool results should be merged into one user message
+      expect(result[:messages].size).to eq(2) # assistant + single user
+      user_msg = result[:messages].last
+      expect(user_msg[:role]).to eq("user")
+      expect(user_msg[:content].size).to eq(2)
+      expect(user_msg[:content][0][:tool_use_id]).to eq("call_1")
+      expect(user_msg[:content][1][:tool_use_id]).to eq("call_2")
+    end
+
     it "handles hash arguments in tool_calls" do
       tool_calls = [{id: "call_1", name: "search", arguments: {q: "test"}}]
       conversation.add_message(:assistant, nil, tool_calls: tool_calls)

--- a/spec/agent_harness/conversation_spec.rb
+++ b/spec/agent_harness/conversation_spec.rb
@@ -53,6 +53,13 @@ RSpec.describe AgentHarness::Conversation do
       expect(msg[:role]).to eq(:user)
     end
 
+    it "allows a system message only as the first message" do
+      conversation.add_message(:user, "Hello")
+
+      expect { conversation.add_message(:system, "Late instruction") }
+        .to raise_error(ArgumentError, /only allowed as the first message/)
+    end
+
     it "raises ArgumentError for invalid roles" do
       expect { conversation.add_message(:invalid, "Hello") }
         .to raise_error(ArgumentError, /Invalid role/)
@@ -303,14 +310,12 @@ RSpec.describe AgentHarness::Conversation do
       expect(result[:system]).to be_nil
     end
 
-    it "preserves multiple system messages in order" do
+    it "rejects non-leading system messages" do
       conversation.add_message(:system, "First instruction")
       conversation.add_message(:user, "Hello")
-      conversation.add_message(:system, "Second instruction")
 
-      result = conversation.to_anthropic_messages
-
-      expect(result[:system]).to eq("First instruction\n\nSecond instruction")
+      expect { conversation.add_message(:system, "Second instruction") }
+        .to raise_error(ArgumentError, /only allowed as the first message/)
     end
 
     it "wraps user content in text blocks" do

--- a/spec/agent_harness/conversation_spec.rb
+++ b/spec/agent_harness/conversation_spec.rb
@@ -1,0 +1,391 @@
+# frozen_string_literal: true
+
+RSpec.describe AgentHarness::Conversation do
+  subject(:conversation) { described_class.new }
+
+  describe "#initialize" do
+    it "creates an empty conversation" do
+      expect(conversation.message_count).to eq(0)
+      expect(conversation.messages).to eq([])
+    end
+
+    it "accepts an optional system prompt" do
+      convo = described_class.new(system_prompt: "You are helpful.")
+      expect(convo.message_count).to eq(1)
+      expect(convo.messages.first[:role]).to eq(:system)
+      expect(convo.messages.first[:content]).to eq("You are helpful.")
+    end
+
+    it "accepts an optional token limit" do
+      convo = described_class.new(token_limit: 8000)
+      expect(convo.token_limit).to eq(8000)
+    end
+  end
+
+  describe "#add_message" do
+    it "adds a user message" do
+      msg = conversation.add_message(:user, "Hello")
+      expect(msg[:role]).to eq(:user)
+      expect(msg[:content]).to eq("Hello")
+      expect(msg[:created_at]).to be_a(Time)
+      expect(conversation.message_count).to eq(1)
+    end
+
+    it "adds an assistant message with token metadata" do
+      msg = conversation.add_message(:assistant, "Hi!", tokens: {input: 10, output: 5})
+      expect(msg[:tokens]).to eq({input: 10, output: 5})
+    end
+
+    it "adds a tool message with tool_call_id" do
+      msg = conversation.add_message(:tool, "result", tool_call_id: "call_123")
+      expect(msg[:role]).to eq(:tool)
+      expect(msg[:tool_call_id]).to eq("call_123")
+    end
+
+    it "adds an assistant message with tool_calls" do
+      tool_calls = [{id: "call_1", name: "search", arguments: '{"q":"test"}'}]
+      msg = conversation.add_message(:assistant, nil, tool_calls: tool_calls)
+      expect(msg[:tool_calls]).to eq(tool_calls)
+    end
+
+    it "accepts string roles and converts to symbols" do
+      msg = conversation.add_message("user", "Hello")
+      expect(msg[:role]).to eq(:user)
+    end
+
+    it "raises ArgumentError for invalid roles" do
+      expect { conversation.add_message(:invalid, "Hello") }
+        .to raise_error(ArgumentError, /Invalid role/)
+    end
+
+    it "stores optional metadata fields" do
+      msg = conversation.add_message(:tool, "ok",
+        tool_call_id: "tc_1",
+        tool_name: "search",
+        tool_arguments: '{"q":"x"}',
+        tool_result: "found",
+        model: "gpt-4o")
+      expect(msg[:tool_name]).to eq("search")
+      expect(msg[:tool_arguments]).to eq('{"q":"x"}')
+      expect(msg[:tool_result]).to eq("found")
+      expect(msg[:model]).to eq("gpt-4o")
+    end
+  end
+
+  describe "#messages" do
+    it "returns a copy of the messages array" do
+      conversation.add_message(:user, "Hello")
+      msgs = conversation.messages
+      msgs.clear
+      expect(conversation.message_count).to eq(1)
+    end
+  end
+
+  describe "#token_count" do
+    it "returns 0 when no tokens tracked" do
+      conversation.add_message(:user, "Hello")
+      expect(conversation.token_count).to eq(0)
+    end
+
+    it "sums input and output tokens across messages" do
+      conversation.add_message(:user, "Hello", tokens: {input: 10, output: 0})
+      conversation.add_message(:assistant, "Hi!", tokens: {input: 15, output: 8})
+      expect(conversation.token_count).to eq(33)
+    end
+
+    it "handles messages with partial token data" do
+      conversation.add_message(:user, "Hello", tokens: {input: 10})
+      expect(conversation.token_count).to eq(10)
+    end
+  end
+
+  describe "#token_remaining" do
+    it "returns nil when no limit is set" do
+      expect(conversation.token_remaining).to be_nil
+    end
+
+    it "returns remaining tokens" do
+      convo = described_class.new(token_limit: 1000)
+      convo.add_message(:user, "Hello", tokens: {input: 100, output: 0})
+      expect(convo.token_remaining).to eq(900)
+    end
+  end
+
+  describe "#approaching_limit?" do
+    it "returns false when no limit is set" do
+      expect(conversation.approaching_limit?).to be false
+    end
+
+    it "returns false when under threshold" do
+      convo = described_class.new(token_limit: 1000)
+      convo.add_message(:user, "Hello", tokens: {input: 100, output: 0})
+      expect(convo.approaching_limit?).to be false
+    end
+
+    it "returns true when at or above threshold" do
+      convo = described_class.new(token_limit: 1000)
+      convo.add_message(:user, "Hello", tokens: {input: 800, output: 0})
+      expect(convo.approaching_limit?).to be true
+    end
+
+    it "supports custom threshold" do
+      convo = described_class.new(token_limit: 1000)
+      convo.add_message(:user, "Hello", tokens: {input: 500, output: 0})
+      expect(convo.approaching_limit?(threshold: 0.5)).to be true
+      expect(convo.approaching_limit?(threshold: 0.6)).to be false
+    end
+  end
+
+  describe "#truncate" do
+    let(:convo) { described_class.new(system_prompt: "System") }
+
+    before do
+      convo.add_message(:user, "msg1")
+      convo.add_message(:assistant, "resp1")
+      convo.add_message(:user, "msg2")
+      convo.add_message(:assistant, "resp2")
+      convo.add_message(:user, "msg3")
+      convo.add_message(:assistant, "resp3")
+    end
+
+    it "preserves system prompt and keeps recent messages" do
+      removed = convo.truncate(keep_recent: 2)
+      expect(removed).to eq(4)
+      expect(convo.message_count).to eq(3) # system + 2 recent
+      expect(convo.messages.first[:role]).to eq(:system)
+      expect(convo.messages.last[:content]).to eq("resp3")
+    end
+
+    it "returns 0 when keep_recent covers all messages" do
+      removed = convo.truncate(keep_recent: 10)
+      expect(removed).to eq(0)
+      expect(convo.message_count).to eq(7)
+    end
+
+    it "returns 0 when keep_recent is nil" do
+      removed = convo.truncate
+      expect(removed).to eq(0)
+    end
+
+    it "removes system prompt when keep_system_prompt is false" do
+      removed = convo.truncate(keep_recent: 2, keep_system_prompt: false)
+      expect(removed).to eq(4)
+      expect(convo.message_count).to eq(2)
+      expect(convo.messages.none? { |m| m[:role] == :system }).to be true
+    end
+  end
+
+  describe "#to_openai_messages" do
+    it "formats basic messages" do
+      conversation.add_message(:user, "Hello")
+      conversation.add_message(:assistant, "Hi!")
+
+      result = conversation.to_openai_messages
+      expect(result).to eq([
+        {role: "user", content: "Hello"},
+        {role: "assistant", content: "Hi!"}
+      ])
+    end
+
+    it "includes system prompt" do
+      convo = described_class.new(system_prompt: "You are helpful.")
+      convo.add_message(:user, "Hello")
+
+      result = convo.to_openai_messages
+      expect(result.first).to eq({role: "system", content: "You are helpful."})
+    end
+
+    it "formats assistant messages with tool_calls" do
+      tool_calls = [{id: "call_1", name: "search", arguments: '{"q":"test"}'}]
+      conversation.add_message(:assistant, nil, tool_calls: tool_calls)
+
+      result = conversation.to_openai_messages
+      expect(result.first[:tool_calls]).to eq([{
+        id: "call_1",
+        type: "function",
+        function: {name: "search", arguments: '{"q":"test"}'}
+      }])
+    end
+
+    it "formats tool result messages" do
+      conversation.add_message(:tool, "result text", tool_call_id: "call_1")
+
+      result = conversation.to_openai_messages
+      expect(result.first).to eq({
+        role: "tool",
+        content: "result text",
+        tool_call_id: "call_1"
+      })
+    end
+
+    it "serializes hash arguments to JSON string" do
+      tool_calls = [{id: "call_1", name: "search", arguments: {q: "test"}}]
+      conversation.add_message(:assistant, nil, tool_calls: tool_calls)
+
+      result = conversation.to_openai_messages
+      expect(result.first[:tool_calls].first[:function][:arguments]).to eq('{"q":"test"}')
+    end
+  end
+
+  describe "#to_anthropic_messages" do
+    it "separates system prompt" do
+      convo = described_class.new(system_prompt: "You are helpful.")
+      convo.add_message(:user, "Hello")
+
+      result = convo.to_anthropic_messages
+      expect(result[:system]).to eq("You are helpful.")
+      expect(result[:messages].size).to eq(1)
+    end
+
+    it "returns nil system when no system prompt" do
+      conversation.add_message(:user, "Hello")
+
+      result = conversation.to_anthropic_messages
+      expect(result[:system]).to be_nil
+    end
+
+    it "wraps user content in text blocks" do
+      conversation.add_message(:user, "Hello")
+
+      result = conversation.to_anthropic_messages
+      expect(result[:messages].first).to eq({
+        role: "user",
+        content: [{type: "text", text: "Hello"}]
+      })
+    end
+
+    it "formats assistant messages with tool_use blocks" do
+      tool_calls = [{id: "call_1", name: "search", arguments: '{"q":"test"}'}]
+      conversation.add_message(:assistant, "Let me search.", tool_calls: tool_calls)
+
+      result = conversation.to_anthropic_messages
+      assistant = result[:messages].first
+      expect(assistant[:content].size).to eq(2)
+      expect(assistant[:content][0]).to eq({type: "text", text: "Let me search."})
+      expect(assistant[:content][1]).to eq({
+        type: "tool_use",
+        id: "call_1",
+        name: "search",
+        input: {"q" => "test"}
+      })
+    end
+
+    it "formats tool results as user messages with tool_result block" do
+      conversation.add_message(:tool, "found it", tool_call_id: "call_1")
+
+      result = conversation.to_anthropic_messages
+      expect(result[:messages].first).to eq({
+        role: "user",
+        content: [{
+          type: "tool_result",
+          tool_use_id: "call_1",
+          content: "found it"
+        }]
+      })
+    end
+
+    it "handles assistant messages with only tool_calls and no content" do
+      tool_calls = [{id: "call_1", name: "search", arguments: '{"q":"test"}'}]
+      conversation.add_message(:assistant, nil, tool_calls: tool_calls)
+
+      result = conversation.to_anthropic_messages
+      assistant = result[:messages].first
+      expect(assistant[:content].size).to eq(1)
+      expect(assistant[:content].first[:type]).to eq("tool_use")
+    end
+
+    it "handles hash arguments in tool_calls" do
+      tool_calls = [{id: "call_1", name: "search", arguments: {q: "test"}}]
+      conversation.add_message(:assistant, nil, tool_calls: tool_calls)
+
+      result = conversation.to_anthropic_messages
+      expect(result[:messages].first[:content].first[:input]).to eq({q: "test"})
+    end
+  end
+
+  describe "#last_assistant_message" do
+    it "returns nil when no assistant messages exist" do
+      conversation.add_message(:user, "Hello")
+      expect(conversation.last_assistant_message).to be_nil
+    end
+
+    it "returns the most recent assistant message" do
+      conversation.add_message(:assistant, "First")
+      conversation.add_message(:user, "Hello")
+      conversation.add_message(:assistant, "Second")
+
+      msg = conversation.last_assistant_message
+      expect(msg[:content]).to eq("Second")
+    end
+  end
+
+  describe "#clear!" do
+    it "removes all non-system messages" do
+      convo = described_class.new(system_prompt: "System")
+      convo.add_message(:user, "Hello")
+      convo.add_message(:assistant, "Hi!")
+      convo.clear!
+
+      expect(convo.message_count).to eq(1)
+      expect(convo.messages.first[:role]).to eq(:system)
+    end
+
+    it "results in empty conversation when no system prompt" do
+      conversation.add_message(:user, "Hello")
+      conversation.clear!
+      expect(conversation.message_count).to eq(0)
+    end
+  end
+
+  describe "edge cases" do
+    it "handles empty conversation for all methods" do
+      expect(conversation.messages).to eq([])
+      expect(conversation.message_count).to eq(0)
+      expect(conversation.token_count).to eq(0)
+      expect(conversation.last_assistant_message).to be_nil
+      expect(conversation.to_openai_messages).to eq([])
+      expect(conversation.to_anthropic_messages).to eq({system: nil, messages: []})
+    end
+
+    it "handles system-prompt-only conversation" do
+      convo = described_class.new(system_prompt: "System")
+      expect(convo.message_count).to eq(1)
+      expect(convo.to_openai_messages).to eq([{role: "system", content: "System"}])
+
+      anthropic = convo.to_anthropic_messages
+      expect(anthropic[:system]).to eq("System")
+      expect(anthropic[:messages]).to eq([])
+    end
+
+    it "handles conversation with only tool messages" do
+      conversation.add_message(:tool, "result1", tool_call_id: "call_1")
+      conversation.add_message(:tool, "result2", tool_call_id: "call_2")
+
+      openai = conversation.to_openai_messages
+      expect(openai.size).to eq(2)
+      expect(openai.all? { |m| m[:role] == "tool" }).to be true
+    end
+
+    it "handles a full multi-turn tool-use conversation" do
+      convo = described_class.new(system_prompt: "You can search.")
+      convo.add_message(:user, "Find info about Ruby")
+      convo.add_message(:assistant, "Let me search.", tool_calls: [
+        {id: "call_1", name: "search", arguments: '{"q":"Ruby"}'}
+      ])
+      convo.add_message(:tool, '{"results":["Ruby lang"]}', tool_call_id: "call_1")
+      convo.add_message(:assistant, "Ruby is a programming language.")
+
+      expect(convo.message_count).to eq(5)
+
+      openai = convo.to_openai_messages
+      expect(openai.size).to eq(5)
+      expect(openai[0][:role]).to eq("system")
+      expect(openai[2][:tool_calls]).to be_a(Array)
+      expect(openai[3][:role]).to eq("tool")
+
+      anthropic = convo.to_anthropic_messages
+      expect(anthropic[:system]).to eq("You can search.")
+      expect(anthropic[:messages].size).to eq(4)
+    end
+  end
+end

--- a/spec/agent_harness/conversation_spec.rb
+++ b/spec/agent_harness/conversation_spec.rb
@@ -150,10 +150,26 @@ RSpec.describe AgentHarness::Conversation do
 
     it "preserves system prompt and keeps recent messages" do
       removed = convo.truncate(keep_recent: 2)
-      expect(removed).to eq(4)
-      expect(convo.message_count).to eq(3) # system + 2 recent
+      expect(removed).to eq(2)
+      expect(convo.message_count).to eq(5) # system + 2 recent turns
       expect(convo.messages.first[:role]).to eq(:system)
+      expect(convo.messages[1..].map { |msg| msg[:content] }).to eq(%w[msg2 resp2 msg3 resp3])
       expect(convo.messages.last[:content]).to eq("resp3")
+    end
+
+    it "keeps complete recent turns when assistant tool activity follows a user prompt" do
+      convo.add_message(:user, "msg4")
+      convo.add_message(:assistant, "thinking", tool_calls: [
+        {id: "call_1", name: "search", arguments: '{"q":"msg4"}'}
+      ])
+      convo.add_message(:tool, "tool result", tool_call_id: "call_1")
+      convo.add_message(:assistant, "final answer")
+
+      removed = convo.truncate(keep_recent: 1)
+
+      expect(removed).to eq(6)
+      expect(convo.messages.map { |msg| msg[:role] }).to eq([:system, :user, :assistant, :tool, :assistant])
+      expect(convo.messages[1][:content]).to eq("msg4")
     end
 
     it "returns 0 when keep_recent covers all messages" do
@@ -169,8 +185,8 @@ RSpec.describe AgentHarness::Conversation do
 
     it "removes system prompt when keep_system_prompt is false" do
       removed = convo.truncate(keep_recent: 2, keep_system_prompt: false)
-      expect(removed).to eq(5)
-      expect(convo.message_count).to eq(2)
+      expect(removed).to eq(3)
+      expect(convo.message_count).to eq(4)
       expect(convo.messages.none? { |m| m[:role] == :system }).to be true
     end
 
@@ -258,6 +274,16 @@ RSpec.describe AgentHarness::Conversation do
 
       result = conversation.to_anthropic_messages
       expect(result[:system]).to be_nil
+    end
+
+    it "preserves multiple system messages in order" do
+      conversation.add_message(:system, "First instruction")
+      conversation.add_message(:user, "Hello")
+      conversation.add_message(:system, "Second instruction")
+
+      result = conversation.to_anthropic_messages
+
+      expect(result[:system]).to eq("First instruction\n\nSecond instruction")
     end
 
     it "wraps user content in text blocks" do


### PR DESCRIPTION
## Summary

feat: add conversation manager for multi-turn chat

See #152 for context. Paid was unable to auto-generate a description for this PR;
the diff is the authoritative source of truth.

---

Closes #152