### PR TITLE
feat: streaming JSONL event parser for real-time Codex progress tracking

### DIFF
--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -154,6 +154,9 @@ module AgentHarness
           new.send(:parse_jsonl_output, output)
         end
 
+        # Parse a single Codex JSONL event as it arrives on stdout and classify it
+        # for real-time progress tracking. Returns nil for malformed JSON, scalar
+        # JSON values, plain-text output, or unsupported event types.
         def parse_streaming_event(line)
           event = JSON.parse(line.to_s)
           return unless event.is_a?(Hash)

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -525,12 +525,10 @@ module AgentHarness
       private
 
       def build_streaming_event(event)
-        raw_event, payload = unwrap_streaming_event(event)
+        raw_event, payload, dispatch_type = unwrap_streaming_event(event)
         return unless payload.is_a?(Hash)
 
-        type = payload["type"]
-
-        case type
+        case dispatch_type
         when "message.delta", "agent_message_delta"
           build_progress_streaming_event(raw_event, payload)
         when "turn.completed", "task_complete", "turn_complete"
@@ -545,15 +543,19 @@ module AgentHarness
       end
 
       def unwrap_streaming_event(event)
-        payload = if event["type"] == "event_msg"
-          event["payload"]
-        elsif event["type"] == "response_item"
-          event["payload"]
-        else
-          event
-        end
+        event_type = event["type"]
 
-        [event, payload]
+        if event_type == "event_msg"
+          payload = event["payload"]
+          [event, payload, payload.is_a?(Hash) ? payload["type"] : nil]
+        elsif event_type == "response_item"
+          # Preserve the original "response_item" dispatch type so
+          # build_streaming_event routes to build_item_streaming_event
+          # even after unwrapping the inner payload.
+          [event, event["payload"], "response_item"]
+        else
+          [event, event, event_type]
+        end
       end
 
       def build_progress_streaming_event(raw_event, payload)

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -147,11 +147,11 @@ module AgentHarness
         end
 
         def parse_cli_jsonl_transcript(raw_output, max_events: nil)
-          return new.send(:parse_jsonl_output, "") if max_events && max_events <= 0
+          return parser_instance.send(:parse_jsonl_output, "") if max_events && max_events <= 0
 
           output = max_events ? tail_nonempty_lines(raw_output, limit: max_events).join("\n") : raw_output
 
-          new.send(:parse_jsonl_output, output)
+          parser_instance.send(:parse_jsonl_output, output)
         end
 
         # Parse a single Codex JSONL event as it arrives on stdout and classify it
@@ -161,12 +161,16 @@ module AgentHarness
           event = JSON.parse(line.to_s)
           return unless event.is_a?(Hash)
 
-          new.send(:build_streaming_event, event)
+          parser_instance.send(:build_streaming_event, event)
         rescue JSON::ParserError, TypeError
           nil
         end
 
         private
+
+        def parser_instance
+          @parser_instance ||= allocate.freeze
+        end
 
         def tail_nonempty_lines(text, limit:)
           return [] if limit <= 0

--- a/lib/agent_harness/providers/codex.rb
+++ b/lib/agent_harness/providers/codex.rb
@@ -11,6 +11,11 @@ module AgentHarness
       include RateLimitResetParsing
       include McpConfigFileSupport
 
+      StreamingEvent = Struct.new(
+        :type, :turn, :tokens, :error_message, :tool_name, :raw_event,
+        keyword_init: true
+      )
+
       SUPPORTED_CLI_VERSION = "0.116.0"
       SUPPORTED_CLI_REQUIREMENT = Gem::Requirement.new(">= #{SUPPORTED_CLI_VERSION}", "< 0.117.0").freeze
       OAUTH_REFRESH_FAILURE_PATTERNS = [
@@ -147,6 +152,15 @@ module AgentHarness
           output = max_events ? tail_nonempty_lines(raw_output, limit: max_events).join("\n") : raw_output
 
           new.send(:parse_jsonl_output, output)
+        end
+
+        def parse_streaming_event(line)
+          event = JSON.parse(line.to_s)
+          return unless event.is_a?(Hash)
+
+          new.send(:build_streaming_event, event)
+        rescue JSON::ParserError, TypeError
+          nil
         end
 
         private
@@ -506,6 +520,150 @@ module AgentHarness
       end
 
       private
+
+      def build_streaming_event(event)
+        raw_event, payload = unwrap_streaming_event(event)
+        return unless payload.is_a?(Hash)
+
+        type = payload["type"]
+
+        case type
+        when "message.delta", "agent_message_delta"
+          build_progress_streaming_event(raw_event, payload)
+        when "turn.completed", "task_complete", "turn_complete"
+          build_turn_complete_streaming_event(raw_event, payload)
+        when "turn.failed"
+          build_error_streaming_event(raw_event, payload)
+        when "item.completed", "response_item", "agent_message"
+          build_item_streaming_event(raw_event, payload)
+        when "token_count"
+          build_token_usage_streaming_event(raw_event, payload)
+        end
+      end
+
+      def unwrap_streaming_event(event)
+        payload = if event["type"] == "event_msg"
+          event["payload"]
+        elsif event["type"] == "response_item"
+          event["payload"]
+        else
+          event
+        end
+
+        [event, payload]
+      end
+
+      def build_progress_streaming_event(raw_event, payload)
+        return unless progress_payload?(payload)
+
+        StreamingEvent.new(
+          type: :progress,
+          turn: extract_streaming_turn(payload),
+          raw_event: raw_event
+        )
+      end
+
+      def build_turn_complete_streaming_event(raw_event, payload)
+        StreamingEvent.new(
+          type: :turn_complete,
+          turn: extract_streaming_turn(payload),
+          tokens: compact_streaming_tokens(build_token_usage(payload["usage"])),
+          raw_event: raw_event
+        )
+      end
+
+      def build_error_streaming_event(raw_event, payload)
+        StreamingEvent.new(
+          type: :error,
+          turn: extract_streaming_turn(payload),
+          tokens: compact_streaming_tokens(build_token_usage(payload["usage"])),
+          error_message: extract_error_message(payload),
+          raw_event: raw_event
+        )
+      end
+
+      def build_item_streaming_event(raw_event, payload)
+        item = payload["item"].is_a?(Hash) ? payload["item"] : payload
+
+        if tool_use_payload?(item)
+          return StreamingEvent.new(
+            type: :tool_use,
+            turn: extract_streaming_turn(payload),
+            tool_name: extract_tool_name(item),
+            raw_event: raw_event
+          )
+        end
+
+        return unless assistant_message_item?(item) || response_item_assistant_payload?(item) || wrapped_assistant_payload?(item)
+
+        StreamingEvent.new(
+          type: :progress,
+          turn: extract_streaming_turn(payload),
+          raw_event: raw_event
+        )
+      end
+
+      def build_token_usage_streaming_event(raw_event, payload)
+        wrapped_token_usage = extract_wrapped_tokens(payload["info"])
+        usage = wrapped_token_usage&.fetch(:last, nil) || wrapped_token_usage&.fetch(:total, nil)
+        return unless usage
+
+        StreamingEvent.new(
+          type: :token_usage,
+          turn: extract_streaming_turn(payload),
+          tokens: compact_streaming_tokens(usage),
+          raw_event: raw_event
+        )
+      end
+
+      def progress_payload?(payload)
+        case payload["type"]
+        when "message.delta"
+          payload["delta"].is_a?(Hash)
+        when "agent_message_delta"
+          wrapped_assistant_payload?(payload)
+        else
+          false
+        end
+      end
+
+      def tool_use_payload?(item)
+        item.is_a?(Hash) && item["type"] == "tool_call"
+      end
+
+      def extract_tool_name(item)
+        item["tool_name"] || item["name"] || item.dig("function", "name") || item.dig("call", "name")
+      end
+
+      def extract_streaming_turn(payload)
+        value = payload["turn"] || payload["turn_id"] || payload["turn_index"] || payload.dig("context", "turn")
+        return value if value.is_a?(Integer)
+
+        value.to_i if value.is_a?(String) && /\A\d+\z/.match?(value.strip)
+      end
+
+      def compact_streaming_tokens(usage)
+        return unless usage
+
+        {
+          input: usage[:input],
+          output: usage[:output],
+          total: usage[:total]
+        }
+      end
+
+      def extract_error_message(payload)
+        error = payload["error"]
+
+        case error
+        when String
+          error
+        when Hash
+          error["message"] || error["error"] || error["detail"]
+        else
+          payload["message"]
+        end
+      end
 
       def escape_toml_string(val)
         val.to_s.gsub("\\") { "\\\\" }.gsub('"') { "\\\"" }.gsub("\n") { "\\n" }

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -300,6 +300,46 @@ RSpec.describe AgentHarness::Providers::Codex do
       )
     end
 
+    it "classifies top-level response_item with assistant message as progress" do
+      line = JSON.generate({
+        "type" => "response_item",
+        "payload" => {
+          "type" => "message",
+          "role" => "assistant",
+          "item_type" => "assistant_message",
+          "content" => [{"type" => "text", "text" => "hello"}]
+        }
+      })
+
+      expect(described_class.parse_streaming_event(line)).to eq(
+        described_class::StreamingEvent.new(
+          type: :progress,
+          turn: nil,
+          raw_event: JSON.parse(line)
+        )
+      )
+    end
+
+    it "classifies top-level response_item with tool call as tool use" do
+      line = JSON.generate({
+        "type" => "response_item",
+        "payload" => {
+          "type" => "tool_call",
+          "name" => "shell",
+          "item_type" => "tool_call"
+        }
+      })
+
+      expect(described_class.parse_streaming_event(line)).to eq(
+        described_class::StreamingEvent.new(
+          type: :tool_use,
+          turn: nil,
+          tool_name: "shell",
+          raw_event: JSON.parse(line)
+        )
+      )
+    end
+
     it "classifies wrapped token_count payloads as token usage" do
       line = JSON.generate({
         "type" => "event_msg",

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -189,6 +189,10 @@ RSpec.describe AgentHarness::Providers::Codex do
       expect(described_class.parse_streaming_event("{")).to be_nil
     end
 
+    it "returns nil for scalar JSON values" do
+      expect(described_class.parse_streaming_event("123")).to be_nil
+    end
+
     it "returns nil for non-JSONL text" do
       expect(described_class.parse_streaming_event("plain text output")).to be_nil
     end

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -184,6 +184,144 @@ RSpec.describe AgentHarness::Providers::Codex do
     end
   end
 
+  describe ".parse_streaming_event" do
+    it "returns nil for malformed JSON" do
+      expect(described_class.parse_streaming_event("{")).to be_nil
+    end
+
+    it "returns nil for non-JSONL text" do
+      expect(described_class.parse_streaming_event("plain text output")).to be_nil
+    end
+
+    it "returns nil for unrecognized event types" do
+      line = JSON.generate({"type" => "unknown.event"})
+
+      expect(described_class.parse_streaming_event(line)).to be_nil
+    end
+
+    it "classifies message.delta events as progress" do
+      line = JSON.generate({"type" => "message.delta", "turn" => 2, "delta" => {"text" => "partial"}})
+
+      expect(described_class.parse_streaming_event(line)).to eq(
+        described_class::StreamingEvent.new(
+          type: :progress,
+          turn: 2,
+          raw_event: JSON.parse(line)
+        )
+      )
+    end
+
+    it "classifies turn.completed events with token usage" do
+      line = JSON.generate({
+        "type" => "turn.completed",
+        "turn" => 3,
+        "usage" => {"input_tokens" => 12, "output_tokens" => 5}
+      })
+
+      expect(described_class.parse_streaming_event(line)).to eq(
+        described_class::StreamingEvent.new(
+          type: :turn_complete,
+          turn: 3,
+          tokens: {input: 12, output: 5, total: 17},
+          raw_event: JSON.parse(line)
+        )
+      )
+    end
+
+    it "classifies turn.failed events as errors" do
+      line = JSON.generate({
+        "type" => "turn.failed",
+        "turn" => 4,
+        "error" => {"message" => "provider timeout"},
+        "usage" => {"total_tokens" => 99}
+      })
+
+      expect(described_class.parse_streaming_event(line)).to eq(
+        described_class::StreamingEvent.new(
+          type: :error,
+          turn: 4,
+          tokens: {input: 0, output: 0, total: 99},
+          error_message: "provider timeout",
+          raw_event: JSON.parse(line)
+        )
+      )
+    end
+
+    it "classifies assistant item.completed events as progress" do
+      line = JSON.generate({
+        "type" => "item.completed",
+        "turn" => 5,
+        "item" => {"type" => "message", "role" => "assistant", "text" => "done"}
+      })
+
+      expect(described_class.parse_streaming_event(line)).to eq(
+        described_class::StreamingEvent.new(
+          type: :progress,
+          turn: 5,
+          raw_event: JSON.parse(line)
+        )
+      )
+    end
+
+    it "classifies tool item.completed events as tool use" do
+      line = JSON.generate({
+        "type" => "item.completed",
+        "turn" => 6,
+        "item" => {"type" => "tool_call", "name" => "shell"}
+      })
+
+      expect(described_class.parse_streaming_event(line)).to eq(
+        described_class::StreamingEvent.new(
+          type: :tool_use,
+          turn: 6,
+          tool_name: "shell",
+          raw_event: JSON.parse(line)
+        )
+      )
+    end
+
+    it "classifies task_complete events as turn completion" do
+      line = JSON.generate({
+        "type" => "task_complete",
+        "turn" => 7,
+        "last_agent_message" => "final answer"
+      })
+
+      expect(described_class.parse_streaming_event(line)).to eq(
+        described_class::StreamingEvent.new(
+          type: :turn_complete,
+          turn: 7,
+          raw_event: JSON.parse(line)
+        )
+      )
+    end
+
+    it "classifies wrapped token_count payloads as token usage" do
+      line = JSON.generate({
+        "type" => "event_msg",
+        "payload" => {
+          "type" => "token_count",
+          "turn" => 8,
+          "info" => {
+            "last_token_usage" => {
+              "input_tokens" => 9,
+              "output_tokens" => 4
+            }
+          }
+        }
+      })
+
+      expect(described_class.parse_streaming_event(line)).to eq(
+        described_class::StreamingEvent.new(
+          type: :token_usage,
+          turn: 8,
+          tokens: {input: 9, output: 4, total: 13},
+          raw_event: JSON.parse(line)
+        )
+      )
+    end
+  end
+
   describe ".firewall_requirements" do
     it "returns required domains" do
       requirements = described_class.firewall_requirements

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -111,6 +111,14 @@ RSpec.describe AgentHarness::Providers::Codex do
   end
 
   describe ".parse_cli_jsonl_transcript" do
+    it "reuses a memoized parser instance instead of constructing a provider" do
+      allow(described_class).to receive(:new).and_call_original
+
+      described_class.parse_cli_jsonl_transcript("")
+
+      expect(described_class).not_to have_received(:new)
+    end
+
     it "extracts final assistant text from a single JSONL event" do
       output = JSON.generate({
         "type" => "turn.completed",
@@ -185,6 +193,15 @@ RSpec.describe AgentHarness::Providers::Codex do
   end
 
   describe ".parse_streaming_event" do
+    it "reuses a memoized parser instance instead of constructing a provider" do
+      line = JSON.generate({"type" => "message.delta", "delta" => {"text" => "partial"}})
+      allow(described_class).to receive(:new).and_call_original
+
+      described_class.parse_streaming_event(line)
+
+      expect(described_class).not_to have_received(:new)
+    end
+
     it "returns nil for malformed JSON" do
       expect(described_class.parse_streaming_event("{")).to be_nil
     end


### PR DESCRIPTION
## Summary

Committed as `03395fa` (`Document Codex streaming event parsing`).

The Codex provider already had the streaming JSONL parser and typed `StreamingEvent` API in place, so I kept the code delta minimal and issue-focused: I documented `Codex.parse_streaming_event` as a public real-time classification API in [lib/agent_harness/providers/codex.rb](/workspace/lib/agent_harness/providers/codex.rb), and added a regression spec in [spec/agent_harness/providers/codex_spec.rb](/workspace/spec/agent_harness/providers/codex_spec.rb) to lock in the graceful `nil` behavior for scalar JSON input.

Verification passed with `bundle exec rubocop` and `bundle exec rspec` (2238 examples, 0 failures). The worktree is clean.

---

Closes #178