### PR TITLE
feat: Expose public parse_container_output method on provider interface

### DIFF
--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -263,6 +263,30 @@ module AgentHarness
         cleanup_llm_history_file!(llm_history_path)
       end
 
+      # Parse raw container output into a Response.
+      #
+      # Overrides the base implementation to support the
+      # +llm_history_path+ option for token usage extraction from
+      # Aider's LLM history file.
+      #
+      # @param stdout [String] captured standard output
+      # @param stderr [String] captured standard error
+      # @param exit_code [Integer] process exit code
+      # @param duration [Float] execution duration in seconds
+      # @param options [Hash] additional options
+      # @option options [String, nil] :llm_history_path path to LLM history file
+      # @return [Response] parsed response
+      def parse_container_output(stdout:, stderr: "", exit_code: 0, duration: 0.0, **options)
+        result = CommandExecutor::Result.new(
+          stdout: stdout,
+          stderr: stderr,
+          exit_code: exit_code,
+          duration: duration
+        )
+        parse_response(result, duration: duration,
+          llm_history_path: options[:llm_history_path])
+      end
+
       protected
 
       def build_command(prompt, options)

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -283,8 +283,11 @@ module AgentHarness
           exit_code: exit_code,
           duration: duration
         )
-        parse_response(result, duration: duration,
-          llm_history_path: options[:llm_history_path])
+        parse_response(
+          result,
+          duration: duration,
+          llm_history_path: options[:llm_history_path]
+        )
       end
 
       protected

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -265,6 +265,29 @@ module AgentHarness
         handle_error(e, prompt: (last_msg&.dig(:content) || last_msg&.dig("content")).to_s, options: options)
       end
 
+      # Parse raw container output into a Response.
+      #
+      # This is the public interface for parsing CLI output captured from
+      # external execution (e.g. Docker containers) without going through
+      # send_message. It accepts the same data a CommandExecutor::Result
+      # holds and returns an AgentHarness::Response.
+      #
+      # @param stdout [String] captured standard output
+      # @param stderr [String] captured standard error
+      # @param exit_code [Integer] process exit code
+      # @param duration [Float] execution duration in seconds
+      # @param options [Hash] additional provider-specific options
+      # @return [Response] parsed response
+      def parse_container_output(stdout:, stderr: "", exit_code: 0, duration: 0.0, **options)
+        result = CommandExecutor::Result.new(
+          stdout: stdout,
+          stderr: stderr,
+          exit_code: exit_code,
+          duration: duration
+        )
+        parse_response(result, duration: duration)
+      end
+
       # Provider name for display
       #
       # @return [String] display name

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -365,8 +365,11 @@ module AgentHarness
           exit_code: exit_code,
           duration: duration
         )
-        parse_response(result, duration: duration,
-          json_output_requested: options.fetch(:json_output_requested, false))
+        parse_response(
+          result,
+          duration: duration,
+          json_output_requested: options.fetch(:json_output_requested, false)
+        )
       end
 
       protected

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -345,6 +345,30 @@ module AgentHarness
         handle_error(e, prompt: prompt, options: options)
       end
 
+      # Parse raw container output into a Response.
+      #
+      # Overrides the base implementation to support the
+      # +json_output_requested+ option, which controls whether JSONL
+      # output is parsed for token extraction.
+      #
+      # @param stdout [String] captured standard output
+      # @param stderr [String] captured standard error
+      # @param exit_code [Integer] process exit code
+      # @param duration [Float] execution duration in seconds
+      # @param options [Hash] additional options
+      # @option options [Boolean] :json_output_requested whether to parse JSONL output
+      # @return [Response] parsed response
+      def parse_container_output(stdout:, stderr: "", exit_code: 0, duration: 0.0, **options)
+        result = CommandExecutor::Result.new(
+          stdout: stdout,
+          stderr: stderr,
+          exit_code: exit_code,
+          duration: duration
+        )
+        parse_response(result, duration: duration,
+          json_output_requested: options.fetch(:json_output_requested, false))
+      end
+
       protected
 
       def build_command(prompt, options)

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -1887,5 +1887,46 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(provider.instance_variable_get(:@aider_history_path)).to be_nil
       end
     end
+
+    describe "#parse_container_output" do
+      it "parses plain text output" do
+        response = provider.parse_container_output(
+          stdout: "Hello from Aider",
+          stderr: "",
+          exit_code: 0,
+          duration: 5.0
+        )
+
+        expect(response).to be_a(AgentHarness::Response)
+        expect(response.output).to eq("Hello from Aider")
+        expect(response.success?).to be true
+        expect(response.duration).to eq(5.0)
+        expect(response.provider).to eq(:aider)
+      end
+
+      it "captures errors for non-zero exit codes" do
+        response = provider.parse_container_output(
+          stdout: "",
+          stderr: "aider crashed",
+          exit_code: 1,
+          duration: 0.5
+        )
+
+        expect(response.failed?).to be true
+        expect(response.error).to include("aider crashed")
+      end
+
+      it "accepts llm_history_path option" do
+        response = provider.parse_container_output(
+          stdout: "done",
+          stderr: "",
+          exit_code: 0,
+          duration: 1.0,
+          llm_history_path: nil
+        )
+
+        expect(response.success?).to be true
+      end
+    end
   end
 end

--- a/spec/agent_harness/providers/anthropic_spec.rb
+++ b/spec/agent_harness/providers/anthropic_spec.rb
@@ -1359,5 +1359,41 @@ RSpec.describe AgentHarness::Providers::Anthropic do
         expect(semantics[:parses_rate_limit_reset]).to be false
       end
     end
+
+    describe "#parse_container_output" do
+      it "parses JSON envelope output into a Response" do
+        envelope = JSON.generate({
+          "type" => "result",
+          "subtype" => "success",
+          "result" => "Hello from Claude",
+          "usage" => {"input_tokens" => 10, "output_tokens" => 5}
+        })
+
+        response = provider.parse_container_output(
+          stdout: envelope,
+          stderr: "",
+          exit_code: 0,
+          duration: 2.5
+        )
+
+        expect(response).to be_a(AgentHarness::Response)
+        expect(response.output).to eq("Hello from Claude")
+        expect(response.success?).to be true
+        expect(response.duration).to eq(2.5)
+      end
+
+      it "captures errors for failed exit codes" do
+        response = provider.parse_container_output(
+          stdout: "",
+          stderr: "something went wrong",
+          exit_code: 1,
+          duration: 0.5
+        )
+
+        expect(response.failed?).to be true
+        expect(response.error).to be_a(String)
+        expect(response.error).not_to be_empty
+      end
+    end
   end
 end

--- a/spec/agent_harness/providers/base_spec.rb
+++ b/spec/agent_harness/providers/base_spec.rb
@@ -206,6 +206,63 @@ RSpec.describe AgentHarness::Providers::Base do
     end
   end
 
+  describe "#parse_container_output" do
+    it "returns a Response from raw stdout/stderr/exit_code/duration" do
+      response = provider.parse_container_output(
+        stdout: "hello world",
+        stderr: "",
+        exit_code: 0,
+        duration: 1.5
+      )
+
+      expect(response).to be_a(AgentHarness::Response)
+      expect(response.output).to eq("hello world")
+      expect(response.exit_code).to eq(0)
+      expect(response.duration).to eq(1.5)
+      expect(response.provider).to eq(:test_provider)
+      expect(response.success?).to be true
+    end
+
+    it "captures errors for non-zero exit codes" do
+      response = provider.parse_container_output(
+        stdout: "",
+        stderr: "something went wrong",
+        exit_code: 1,
+        duration: 2.0
+      )
+
+      expect(response.exit_code).to eq(1)
+      expect(response.error).to include("something went wrong")
+      expect(response.failed?).to be true
+    end
+
+    it "uses default values for optional parameters" do
+      response = provider.parse_container_output(stdout: "ok")
+
+      expect(response.exit_code).to eq(0)
+      expect(response.duration).to eq(0.0)
+      expect(response.success?).to be true
+    end
+
+    it "respects legitimate_exit_codes from execution_semantics" do
+      provider_with_codes = Class.new(test_provider_class) do
+        def execution_semantics
+          super.merge(legitimate_exit_codes: [0, 1])
+        end
+      end.new
+
+      response = provider_with_codes.parse_container_output(
+        stdout: "done",
+        stderr: "",
+        exit_code: 1,
+        duration: 1.0
+      )
+
+      expect(response.error).to be_nil
+      expect(response.success?).to be true
+    end
+  end
+
   describe "#sandboxed_environment?" do
     it "returns false with standard CommandExecutor" do
       expect(provider.sandboxed_environment?).to be false

--- a/spec/agent_harness/providers/codex_spec.rb
+++ b/spec/agent_harness/providers/codex_spec.rb
@@ -5997,4 +5997,35 @@ RSpec.describe AgentHarness::Providers::Codex do
       expect(provider.test_command_overrides).to eq(["--skip-git-repo-check", "--output-last-message"])
     end
   end
+
+  describe "#parse_container_output" do
+    subject(:provider) { described_class.new }
+
+    it "parses plain text output" do
+      response = provider.parse_container_output(
+        stdout: "Hello from Codex",
+        stderr: "",
+        exit_code: 0,
+        duration: 3.0
+      )
+
+      expect(response).to be_a(AgentHarness::Response)
+      expect(response.output).to eq("Hello from Codex")
+      expect(response.success?).to be true
+      expect(response.duration).to eq(3.0)
+      expect(response.provider).to eq(:codex)
+    end
+
+    it "captures errors for non-zero exit codes" do
+      response = provider.parse_container_output(
+        stdout: "",
+        stderr: "command failed",
+        exit_code: 1,
+        duration: 0.5
+      )
+
+      expect(response.failed?).to be true
+      expect(response.error).to include("command failed")
+    end
+  end
 end

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -3171,7 +3171,8 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
 
       it "passes json_output_requested option to parse_response" do
         jsonl_output = [
-          '{"type":"message","message":{"content":[{"type":"text","text":"result text"}],"usage":{"input_tokens":10,"output_tokens":5}}}'
+          '{"text":"result text"}',
+          '{"usage":{"input_tokens":10,"output_tokens":5}}'
         ].join("\n")
 
         response = provider.parse_container_output(
@@ -3183,6 +3184,8 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         )
 
         expect(response).to be_a(AgentHarness::Response)
+        expect(response.output).to eq("result text")
+        expect(response.tokens).to eq({input: 10, output: 5, total: 15})
         expect(response.success?).to be true
       end
 

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -3153,5 +3153,50 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         )
       end
     end
+
+    describe "#parse_container_output" do
+      it "parses plain text output" do
+        response = provider.parse_container_output(
+          stdout: "Hello from Copilot",
+          stderr: "",
+          exit_code: 0,
+          duration: 1.5
+        )
+
+        expect(response).to be_a(AgentHarness::Response)
+        expect(response.output).to eq("Hello from Copilot")
+        expect(response.success?).to be true
+        expect(response.duration).to eq(1.5)
+      end
+
+      it "passes json_output_requested option to parse_response" do
+        jsonl_output = [
+          '{"type":"message","message":{"content":[{"type":"text","text":"result text"}],"usage":{"input_tokens":10,"output_tokens":5}}}'
+        ].join("\n")
+
+        response = provider.parse_container_output(
+          stdout: jsonl_output,
+          stderr: "",
+          exit_code: 0,
+          duration: 2.0,
+          json_output_requested: true
+        )
+
+        expect(response).to be_a(AgentHarness::Response)
+        expect(response.success?).to be true
+      end
+
+      it "captures errors for non-zero exit codes" do
+        response = provider.parse_container_output(
+          stdout: "",
+          stderr: "something went wrong",
+          exit_code: 1,
+          duration: 0.5
+        )
+
+        expect(response.failed?).to be true
+        expect(response.error).to include("something went wrong")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Commit succeeded. Here's a summary of the changes:

**Added `parse_container_output` public method** to the provider interface that:

- **`Base#parse_container_output`** (`lib/agent_harness/providers/base.rb:200-220`) — Accepts `stdout:`, `stderr:`, `exit_code:`, `duration:`, and `**options`. Constructs a `CommandExecutor::Result` and delegates to `parse_response`.

- **`GithubCopilot#parse_container_output`** (`lib/agent_harness/providers/github_copilot.rb:348-370`) — Overrides to forward the `json_output_requested:` option to its `parse_response`.

- **`Aider#parse_container_output`** (`lib/agent_harness/providers/aider.rb:266-288`) — Overrides to forward the `llm_history_path:` option to its `parse_response`.

- **Anthropic and Codex** inherit the base implementation since their `parse_response` has the standard `(result, duration:)` signature.

This eliminates the need for callers to:
1. Use `provider.send(:parse_response, ...)` to bypass protected visibility
2. Introspect method signatures to detect optional parameters
3. Call provider-specific class methods like `parse_cli_json_envelope` or `parse_cli_jsonl_transcript`

---

Closes #174