### PR TITLE
fix: Gem name (agent-harness) and require file (agent_harness) naming mismatch

### DIFF
--- a/lib/agent-harness.rb
+++ b/lib/agent-harness.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "agent_harness"

--- a/spec/agent_harness/hyphenated_require_spec.rb
+++ b/spec/agent_harness/hyphenated_require_spec.rb
@@ -5,7 +5,7 @@ require "open3"
 RSpec.describe "hyphenated require entrypoint" do
   it 'loads the gem via `require "agent-harness"`' do
     stdout, stderr, status = Open3.capture3(
-      "ruby",
+      RbConfig.ruby,
       "-I",
       File.expand_path("../../lib", __dir__),
       "-e",

--- a/spec/agent_harness/hyphenated_require_spec.rb
+++ b/spec/agent_harness/hyphenated_require_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "open3"
+
+RSpec.describe "hyphenated require entrypoint" do
+  it 'loads the gem via `require "agent-harness"`' do
+    stdout, stderr, status = Open3.capture3(
+      "ruby",
+      "-I",
+      File.expand_path("../../lib", __dir__),
+      "-e",
+      'require "agent-harness"; print AgentHarness::VERSION'
+    )
+
+    expect(status).to be_success, stderr
+    expect(stdout).to eq(AgentHarness::VERSION)
+  end
+end


### PR DESCRIPTION
## Summary

Added a hyphenated shim entrypoint at [lib/agent-harness.rb](/workspace/lib/agent-harness.rb:1) that delegates to `agent_harness`, which makes `require "agent-harness"` work and restores Bundler autorequire compatibility for the `agent-harness` gem name. I also added a regression spec at [spec/agent_harness/hyphenated_require_spec.rb](/workspace/spec/agent_harness/hyphenated_require_spec.rb:1) that boots a fresh Ruby process and verifies the hyphenated require loads the gem.

Verification passed with `bundle exec rubocop` and `bundle exec rspec` before commit, and the git hook passed during commit as well. Commit: `e833292` (`Fix hyphenated gem autorequire entrypoint`). Worktree is clean.

---

Closes #176