### PR TITLE
fix(kilocode): test_command_overrides never wired into smoke test — kilo hangs without --auto

### DIFF
--- a/lib/agent_harness/providers/adapter.rb
+++ b/lib/agent_harness/providers/adapter.rb
@@ -765,6 +765,11 @@ module AgentHarness
       #   For providers that delegate to Providers::Base#send_message, a plain Hash
       #   is automatically coerced into a ProviderRuntime. Providers that override
       #   #send_message directly are responsible for handling this option.
+      # @option options [Boolean] :smoke_test when +true+, signals that this
+      #   invocation is a lightweight connectivity/health check issued by
+      #   {#smoke_test}. Providers may use this flag to adjust command-line
+      #   arguments (e.g. Kilocode appends +--auto --print-logs+) or skip
+      #   interactive features that would cause the process to hang.
       # @return [Response] response object with output and metadata
       def send_message(prompt:, **options)
         raise NotImplementedError, "#{self.class} must implement #send_message"

--- a/lib/agent_harness/providers/adapter.rb
+++ b/lib/agent_harness/providers/adapter.rb
@@ -1061,7 +1061,8 @@ module AgentHarness
         response = send_message(
           prompt: prompt,
           timeout: timeout || contract[:timeout],
-          provider_runtime: provider_runtime
+          provider_runtime: provider_runtime,
+          smoke_test: true
         )
 
         output = response.output.to_s.strip

--- a/lib/agent_harness/providers/kilocode.rb
+++ b/lib/agent_harness/providers/kilocode.rb
@@ -157,6 +157,7 @@ module AgentHarness
 
       def build_command(prompt, options)
         cmd = [self.class.binary_name, "run", "--format", "json"]
+        cmd.concat(test_command_overrides) if options[:smoke_test]
         cmd << prompt
         cmd
       end

--- a/spec/agent_harness/providers/adapter_spec.rb
+++ b/spec/agent_harness/providers/adapter_spec.rb
@@ -2082,7 +2082,8 @@ RSpec.describe AgentHarness::Providers::Adapter do
         expect(adapter).to receive(:send_message).with(
           prompt: "Reply with exactly OK.",
           timeout: 5,
-          provider_runtime: nil
+          provider_runtime: nil,
+          smoke_test: true
         ).and_return(
           AgentHarness::Response.new(
             output: "OK",

--- a/spec/agent_harness/providers/kilocode_spec.rb
+++ b/spec/agent_harness/providers/kilocode_spec.rb
@@ -170,6 +170,24 @@ RSpec.describe AgentHarness::Providers::Kilocode do
 
         provider.send_message(prompt: "Hello")
       end
+
+      it "appends smoke-test flags for smoke test invocations" do
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: '{"type":"text","part":{"text":"response"}}',
+            stderr: "",
+            exit_code: 0,
+            duration: 1.0
+          )
+        )
+
+        expect(mock_executor).to receive(:execute).with(
+          ["kilo", "run", "--format", "json", "--auto", "--print-logs", "Hello"],
+          anything
+        )
+
+        provider.send_message(prompt: "Hello", smoke_test: true)
+      end
     end
 
     describe "#error_patterns" do


### PR DESCRIPTION
## Summary

Implemented the smoke-test wiring for Kilocode and committed it as `07a0a20` with message `fix(kilocode): wire smoke test command overrides`.

`Adapter#smoke_test` now passes `smoke_test: true` into `send_message`, and `Kilocode#build_command` appends `--auto --print-logs` only for that path. I also added regression coverage for both the adapter smoke-test call and the Kilocode command assembly.

Verification ran clean:
- `bundle exec rubocop`
- `bundle exec rspec`

The worktree is clean with no uncommitted changes.

---

Closes #181