### PR TITLE
feat: Expose public provider registry and config factory methods

### DIFF
--- a/lib/agent_harness.rb
+++ b/lib/agent_harness.rb
@@ -142,6 +142,33 @@ module AgentHarness
       conductor.provider_manager.get_provider(name)
     end
 
+    # List all registered provider names
+    #
+    # @return [Array<Symbol>] canonical provider names
+    def providers
+      Providers::Registry.instance.all
+    end
+
+    # Look up the provider class for a given name or alias
+    #
+    # @param name [Symbol, String] the provider name or alias
+    # @return [Class] the provider class
+    # @raise [ConfigurationError] if provider not found
+    def provider_class(name)
+      Providers::Registry.instance.get(name)
+    end
+
+    # Build a new ProviderConfig with defaults for the given provider
+    #
+    # @param name [Symbol, String] the provider name
+    # @param options [Hash] optional attribute overrides to merge
+    # @return [ProviderConfig] a new config instance
+    def build_config(name, **options)
+      config = ProviderConfig.new(name)
+      config.merge!(options) unless options.empty?
+      config
+    end
+
     # Get install contract metadata for a provider
     # @param name [Symbol, String] the provider name
     # @return [Hash] install contract metadata

--- a/spec/agent_harness_spec.rb
+++ b/spec/agent_harness_spec.rb
@@ -47,6 +47,52 @@ RSpec.describe AgentHarness do
     end
   end
 
+  describe ".providers" do
+    it "returns an array of registered provider name symbols" do
+      result = AgentHarness.providers
+      expect(result).to be_an(Array)
+      expect(result).to include(:claude, :cursor, :gemini)
+    end
+
+    it "delegates to Registry#all" do
+      expect(AgentHarness.providers).to eq(AgentHarness::Providers::Registry.instance.all)
+    end
+  end
+
+  describe ".provider_class" do
+    it "returns the provider class for a known provider" do
+      expect(AgentHarness.provider_class(:claude)).to eq(AgentHarness::Providers::Anthropic)
+    end
+
+    it "resolves aliases" do
+      expect(AgentHarness.provider_class(:anthropic)).to eq(AgentHarness::Providers::Anthropic)
+    end
+
+    it "raises ConfigurationError for an unknown provider" do
+      expect { AgentHarness.provider_class(:nonexistent) }.to raise_error(AgentHarness::ConfigurationError)
+    end
+  end
+
+  describe ".build_config" do
+    it "returns a ProviderConfig with the given name" do
+      config = AgentHarness.build_config(:claude)
+      expect(config).to be_a(AgentHarness::ProviderConfig)
+      expect(config.name).to eq(:claude)
+    end
+
+    it "applies default values" do
+      config = AgentHarness.build_config(:cursor)
+      expect(config.enabled).to be true
+      expect(config.priority).to eq(10)
+    end
+
+    it "merges provided options" do
+      config = AgentHarness.build_config(:claude, priority: 5, model: "opus")
+      expect(config.priority).to eq(5)
+      expect(config.model).to eq("opus")
+    end
+  end
+
   describe ".sub_agent" do
     it "resolves configured sub-agents" do
       AgentHarness.configure do |config|


### PR DESCRIPTION
## Summary

Commit succeeded. The pre-commit hooks ran rubocop on all 102 files with no offenses.

Here's what was added to `AgentHarness`:

- **`AgentHarness.providers`** — returns all registered provider names (delegates to `Registry#all`)
- **`AgentHarness.provider_class(name)`** — looks up the provider class by name or alias (delegates to `Registry#get`)
- **`AgentHarness.build_config(name, **options)`** — creates a new `ProviderConfig` with defaults, optionally merging overrides

All three methods have corresponding tests in `spec/agent_harness_spec.rb` (42 examples, 0 failures).

---

Closes #175