### PR TITLE
feat(extensions): add activity heartbeat support for OpenCode/KiloCode-compatible providers

### DIFF
--- a/lib/agent_harness/providers/adapter.rb
+++ b/lib/agent_harness/providers/adapter.rb
@@ -1187,6 +1187,39 @@ module AgentHarness
         nil
       end
 
+      # Whether this provider supports activity heartbeat signaling.
+      #
+      # Providers that can emit a container-visible liveness signal during
+      # long-running CLI execution return +true+. Downstream callers use
+      # this to decide whether heartbeat-backed idle timeout is viable
+      # without maintaining provider-name allowlists.
+      #
+      # @return [Boolean] true if the provider can emit heartbeat signals
+      def supports_activity_heartbeat?
+        false
+      end
+
+      # Return structured heartbeat integration wiring for this provider.
+      #
+      # Providers that support activity heartbeat return a Hash describing
+      # how to wire heartbeat file touches into the CLI execution. The
+      # returned contract includes environment variables, execution
+      # preparation (config/plugin file writes), and the heartbeat
+      # granularity so downstream callers can enable heartbeat-backed idle
+      # timeout without hardcoding provider-specific config logic.
+      #
+      # @param heartbeat_file_path [String] absolute path to the heartbeat
+      #   file that should be touched on activity
+      # @return [Hash] heartbeat integration contract:
+      #   - +:supported+ [Boolean] whether heartbeat is available
+      #   - +:env+ [Hash] environment variables to set (empty when unsupported)
+      #   - +:preparation+ [ExecutionPreparation, nil] file writes for config/plugin wiring
+      #   - +:granularity+ [Symbol, nil] heartbeat event granularity
+      #     (+:tool_call+, +:turn+, or +:progress+)
+      def heartbeat_integration(heartbeat_file_path:)
+        {supported: false, env: {}, preparation: nil, granularity: nil}
+      end
+
       private
 
       def classify_smoke_test_message(message)

--- a/lib/agent_harness/providers/kilocode.rb
+++ b/lib/agent_harness/providers/kilocode.rb
@@ -129,6 +129,36 @@ module AgentHarness
         }
       end
 
+      def supports_activity_heartbeat?
+        true
+      end
+
+      def heartbeat_integration(heartbeat_file_path:)
+        unless heartbeat_file_path.is_a?(String) && !heartbeat_file_path.strip.empty?
+          raise ArgumentError, "heartbeat_file_path must be a non-empty String"
+        end
+
+        hook_script = heartbeat_hook_script(heartbeat_file_path)
+        config_payload = {"hooks" => {"on_activity" => [{"command" => hook_script}]}}
+
+        preparation = ExecutionPreparation.new(
+          file_writes: [
+            {
+              path: heartbeat_hook_config_path,
+              content: JSON.pretty_generate(config_payload),
+              mode: 0o600
+            }
+          ]
+        )
+
+        {
+          supported: true,
+          env: {"KILO_HEARTBEAT_FILE" => heartbeat_file_path},
+          preparation: preparation,
+          granularity: :tool_call
+        }
+      end
+
       def config_file_content(options = {})
         # Only use explicit provider_name or default to "openai".
         # api_provider is a generic backend label (e.g. "openrouter") that is not
@@ -297,6 +327,14 @@ module AgentHarness
       end
 
       private
+
+      def heartbeat_hook_script(heartbeat_file_path)
+        "touch #{heartbeat_file_path}"
+      end
+
+      def heartbeat_hook_config_path
+        "~/.config/kilocode/hooks.json"
+      end
 
       def each_json_event(output)
         return if output.nil? || output.empty?

--- a/lib/agent_harness/providers/kilocode.rb
+++ b/lib/agent_harness/providers/kilocode.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "shellwords"
 
 module AgentHarness
   module Providers
@@ -329,7 +330,7 @@ module AgentHarness
       private
 
       def heartbeat_hook_script(heartbeat_file_path)
-        "touch #{heartbeat_file_path}"
+        "touch #{Shellwords.escape(heartbeat_file_path)}"
       end
 
       def heartbeat_hook_config_path

--- a/lib/agent_harness/providers/kilocode.rb
+++ b/lib/agent_harness/providers/kilocode.rb
@@ -138,9 +138,12 @@ module AgentHarness
         unless heartbeat_file_path.is_a?(String) && !heartbeat_file_path.strip.empty?
           raise ArgumentError, "heartbeat_file_path must be a non-empty String"
         end
+        unless heartbeat_file_path.start_with?("/")
+          raise ArgumentError, "heartbeat_file_path must be an absolute path (got #{heartbeat_file_path.inspect})"
+        end
 
         hook_script = heartbeat_hook_script(heartbeat_file_path)
-        config_payload = {"hooks" => {"on_activity" => [{"command" => hook_script}]}}
+        config_payload = merge_heartbeat_hooks(hook_script)
 
         preparation = ExecutionPreparation.new(
           file_writes: [
@@ -335,6 +338,24 @@ module AgentHarness
 
       def heartbeat_hook_config_path
         "~/.config/kilocode/hooks.json"
+      end
+
+      def merge_heartbeat_hooks(hook_script)
+        existing = load_existing_hooks_config(heartbeat_hook_config_path)
+        hooks = existing.fetch("hooks", {})
+        on_activity = hooks.fetch("on_activity", [])
+        on_activity = on_activity.dup
+        on_activity << {"command" => hook_script}
+        existing.merge("hooks" => hooks.merge("on_activity" => on_activity))
+      end
+
+      def load_existing_hooks_config(path)
+        expanded = File.expand_path(path)
+        return {} unless File.exist?(expanded)
+
+        JSON.parse(File.read(expanded))
+      rescue JSON::ParserError
+        {}
       end
 
       def each_json_event(output)

--- a/lib/agent_harness/providers/opencode.rb
+++ b/lib/agent_harness/providers/opencode.rb
@@ -156,9 +156,12 @@ module AgentHarness
         unless heartbeat_file_path.is_a?(String) && !heartbeat_file_path.strip.empty?
           raise ArgumentError, "heartbeat_file_path must be a non-empty String"
         end
+        unless heartbeat_file_path.start_with?("/")
+          raise ArgumentError, "heartbeat_file_path must be an absolute path (got #{heartbeat_file_path.inspect})"
+        end
 
         hook_script = heartbeat_hook_script(heartbeat_file_path)
-        config_payload = {"hooks" => {"on_activity" => [{"command" => hook_script}]}}
+        config_payload = merge_heartbeat_hooks(hook_script)
 
         preparation = ExecutionPreparation.new(
           file_writes: [
@@ -270,6 +273,24 @@ module AgentHarness
 
       def heartbeat_hook_config_path
         "~/.config/opencode/hooks.json"
+      end
+
+      def merge_heartbeat_hooks(hook_script)
+        existing = load_existing_hooks_config(heartbeat_hook_config_path)
+        hooks = existing.fetch("hooks", {})
+        on_activity = hooks.fetch("on_activity", [])
+        on_activity = on_activity.dup
+        on_activity << {"command" => hook_script}
+        existing.merge("hooks" => hooks.merge("on_activity" => on_activity))
+      end
+
+      def load_existing_hooks_config(path)
+        expanded = File.expand_path(path)
+        return {} unless File.exist?(expanded)
+
+        JSON.parse(File.read(expanded))
+      rescue JSON::ParserError
+        {}
       end
 
       def stringify_keys(hash)

--- a/lib/agent_harness/providers/opencode.rb
+++ b/lib/agent_harness/providers/opencode.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "shellwords"
 
 module AgentHarness
   module Providers
@@ -264,7 +265,7 @@ module AgentHarness
       end
 
       def heartbeat_hook_script(heartbeat_file_path)
-        "touch #{heartbeat_file_path}"
+        "touch #{Shellwords.escape(heartbeat_file_path)}"
       end
 
       def heartbeat_hook_config_path

--- a/lib/agent_harness/providers/opencode.rb
+++ b/lib/agent_harness/providers/opencode.rb
@@ -147,6 +147,36 @@ module AgentHarness
         }
       end
 
+      def supports_activity_heartbeat?
+        true
+      end
+
+      def heartbeat_integration(heartbeat_file_path:)
+        unless heartbeat_file_path.is_a?(String) && !heartbeat_file_path.strip.empty?
+          raise ArgumentError, "heartbeat_file_path must be a non-empty String"
+        end
+
+        hook_script = heartbeat_hook_script(heartbeat_file_path)
+        config_payload = {"hooks" => {"on_activity" => [{"command" => hook_script}]}}
+
+        preparation = ExecutionPreparation.new(
+          file_writes: [
+            {
+              path: heartbeat_hook_config_path,
+              content: serialize_opencode_config(config_payload),
+              mode: 0o600
+            }
+          ]
+        )
+
+        {
+          supported: true,
+          env: {"OPENCODE_HEARTBEAT_FILE" => heartbeat_file_path},
+          preparation: preparation,
+          granularity: :tool_call
+        }
+      end
+
       def error_patterns
         COMMON_ERROR_PATTERNS
       end
@@ -231,6 +261,14 @@ module AgentHarness
 
       def serialize_opencode_config(payload)
         JSON.pretty_generate(payload)
+      end
+
+      def heartbeat_hook_script(heartbeat_file_path)
+        "touch #{heartbeat_file_path}"
+      end
+
+      def heartbeat_hook_config_path
+        "~/.config/opencode/hooks.json"
       end
 
       def stringify_keys(hash)

--- a/spec/agent_harness/providers/base_spec.rb
+++ b/spec/agent_harness/providers/base_spec.rb
@@ -341,4 +341,21 @@ RSpec.describe AgentHarness::Providers::Base do
       expect(provider.parse_rate_limit_reset(nil)).to be_nil
     end
   end
+
+  describe "#supports_activity_heartbeat?" do
+    it "returns false by default" do
+      expect(provider.supports_activity_heartbeat?).to be false
+    end
+  end
+
+  describe "#heartbeat_integration" do
+    it "returns a no-op integration by default" do
+      result = provider.heartbeat_integration(heartbeat_file_path: "/tmp/heartbeat")
+
+      expect(result[:supported]).to be false
+      expect(result[:env]).to eq({})
+      expect(result[:preparation]).to be_nil
+      expect(result[:granularity]).to be_nil
+    end
+  end
 end

--- a/spec/agent_harness/providers/kilocode_spec.rb
+++ b/spec/agent_harness/providers/kilocode_spec.rb
@@ -3725,5 +3725,18 @@ RSpec.describe AgentHarness::Providers::Kilocode do
         provider.heartbeat_integration(heartbeat_file_path: "  ")
       }.to raise_error(ArgumentError, /heartbeat_file_path must be a non-empty String/)
     end
+
+    context "with shell-sensitive characters in heartbeat_file_path" do
+      let(:heartbeat_path) { "/tmp/heartbeat file;touch /tmp/pwned" }
+
+      it "shell-escapes the heartbeat command path" do
+        hook_write = integration[:preparation].file_writes.first
+        parsed = JSON.parse(hook_write.content)
+
+        expect(parsed["hooks"]["on_activity"].first["command"]).to eq(
+          "touch /tmp/heartbeat\\ file\\;touch\\ /tmp/pwned"
+        )
+      end
+    end
   end
 end

--- a/spec/agent_harness/providers/kilocode_spec.rb
+++ b/spec/agent_harness/providers/kilocode_spec.rb
@@ -3670,4 +3670,60 @@ RSpec.describe AgentHarness::Providers::Kilocode do
       expect(provider.test_command_overrides).to eq(["--auto", "--print-logs"])
     end
   end
+
+  describe "#supports_activity_heartbeat?" do
+    let(:executor) { instance_double(AgentHarness::CommandExecutor) }
+    let(:provider) { described_class.new(executor: executor) }
+
+    it "returns true" do
+      expect(provider.supports_activity_heartbeat?).to be true
+    end
+  end
+
+  describe "#heartbeat_integration" do
+    let(:executor) { instance_double(AgentHarness::CommandExecutor) }
+    let(:provider) { described_class.new(executor: executor) }
+    let(:heartbeat_path) { "/paid-heartbeat/.paid-heartbeat" }
+
+    subject(:integration) { provider.heartbeat_integration(heartbeat_file_path: heartbeat_path) }
+
+    it "returns a supported integration" do
+      expect(integration[:supported]).to be true
+    end
+
+    it "sets the KILO_HEARTBEAT_FILE env var" do
+      expect(integration[:env]).to eq("KILO_HEARTBEAT_FILE" => heartbeat_path)
+    end
+
+    it "returns an ExecutionPreparation with hook config" do
+      preparation = integration[:preparation]
+      expect(preparation).to be_a(AgentHarness::ExecutionPreparation)
+      expect(preparation.file_writes).not_to be_empty
+
+      hook_write = preparation.file_writes.first
+      expect(hook_write.path).to eq("~/.config/kilocode/hooks.json")
+      expect(hook_write.mode).to eq(0o600)
+
+      parsed = JSON.parse(hook_write.content)
+      expect(parsed).to have_key("hooks")
+      expect(parsed["hooks"]["on_activity"]).to be_an(Array)
+      expect(parsed["hooks"]["on_activity"].first["command"]).to include(heartbeat_path)
+    end
+
+    it "reports tool_call granularity" do
+      expect(integration[:granularity]).to eq(:tool_call)
+    end
+
+    it "raises ArgumentError for nil heartbeat_file_path" do
+      expect {
+        provider.heartbeat_integration(heartbeat_file_path: nil)
+      }.to raise_error(ArgumentError, /heartbeat_file_path must be a non-empty String/)
+    end
+
+    it "raises ArgumentError for blank heartbeat_file_path" do
+      expect {
+        provider.heartbeat_integration(heartbeat_file_path: "  ")
+      }.to raise_error(ArgumentError, /heartbeat_file_path must be a non-empty String/)
+    end
+  end
 end

--- a/spec/agent_harness/providers/kilocode_spec.rb
+++ b/spec/agent_harness/providers/kilocode_spec.rb
@@ -3726,6 +3726,42 @@ RSpec.describe AgentHarness::Providers::Kilocode do
       }.to raise_error(ArgumentError, /heartbeat_file_path must be a non-empty String/)
     end
 
+    it "raises ArgumentError for relative heartbeat_file_path" do
+      expect {
+        provider.heartbeat_integration(heartbeat_file_path: "relative/path")
+      }.to raise_error(ArgumentError, /heartbeat_file_path must be an absolute path/)
+    end
+
+    context "when existing hooks.json is present" do
+      let(:hooks_config_path) { File.expand_path("~/.config/kilocode/hooks.json") }
+      let(:existing_config) do
+        {"hooks" => {"on_activity" => [{"command" => "echo existing"}], "on_error" => [{"command" => "echo error"}]}}
+      end
+
+      before do
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(hooks_config_path).and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(hooks_config_path).and_return(JSON.generate(existing_config))
+      end
+
+      it "merges heartbeat hook with existing on_activity hooks" do
+        hook_write = integration[:preparation].file_writes.first
+        parsed = JSON.parse(hook_write.content)
+
+        expect(parsed["hooks"]["on_activity"].length).to eq(2)
+        expect(parsed["hooks"]["on_activity"].first["command"]).to eq("echo existing")
+        expect(parsed["hooks"]["on_activity"].last["command"]).to include("touch")
+      end
+
+      it "preserves other hook types" do
+        hook_write = integration[:preparation].file_writes.first
+        parsed = JSON.parse(hook_write.content)
+
+        expect(parsed["hooks"]["on_error"]).to eq([{"command" => "echo error"}])
+      end
+    end
+
     context "with shell-sensitive characters in heartbeat_file_path" do
       let(:heartbeat_path) { "/tmp/heartbeat file;touch /tmp/pwned" }
 

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -435,6 +435,19 @@ RSpec.describe AgentHarness::Providers::Opencode do
           provider.heartbeat_integration(heartbeat_file_path: "  ")
         }.to raise_error(ArgumentError, /heartbeat_file_path must be a non-empty String/)
       end
+
+      context "with shell-sensitive characters in heartbeat_file_path" do
+        let(:heartbeat_path) { "/tmp/heartbeat file;touch /tmp/pwned" }
+
+        it "shell-escapes the heartbeat command path" do
+          hook_write = integration[:preparation].file_writes.first
+          parsed = JSON.parse(hook_write.content)
+
+          expect(parsed["hooks"]["on_activity"].first["command"]).to eq(
+            "touch /tmp/heartbeat\\ file\\;touch\\ /tmp/pwned"
+          )
+        end
+      end
     end
   end
 end

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -385,5 +385,56 @@ RSpec.describe AgentHarness::Providers::Opencode do
         expect(provider.execution_semantics[:uses_subcommand]).to be true
       end
     end
+
+    describe "#supports_activity_heartbeat?" do
+      it "returns true" do
+        expect(provider.supports_activity_heartbeat?).to be true
+      end
+    end
+
+    describe "#heartbeat_integration" do
+      let(:heartbeat_path) { "/paid-heartbeat/.paid-heartbeat" }
+
+      subject(:integration) { provider.heartbeat_integration(heartbeat_file_path: heartbeat_path) }
+
+      it "returns a supported integration" do
+        expect(integration[:supported]).to be true
+      end
+
+      it "sets the OPENCODE_HEARTBEAT_FILE env var" do
+        expect(integration[:env]).to eq("OPENCODE_HEARTBEAT_FILE" => heartbeat_path)
+      end
+
+      it "returns an ExecutionPreparation with hook config" do
+        preparation = integration[:preparation]
+        expect(preparation).to be_a(AgentHarness::ExecutionPreparation)
+        expect(preparation.file_writes).not_to be_empty
+
+        hook_write = preparation.file_writes.first
+        expect(hook_write.path).to eq("~/.config/opencode/hooks.json")
+        expect(hook_write.mode).to eq(0o600)
+
+        parsed = JSON.parse(hook_write.content)
+        expect(parsed).to have_key("hooks")
+        expect(parsed["hooks"]["on_activity"]).to be_an(Array)
+        expect(parsed["hooks"]["on_activity"].first["command"]).to include(heartbeat_path)
+      end
+
+      it "reports tool_call granularity" do
+        expect(integration[:granularity]).to eq(:tool_call)
+      end
+
+      it "raises ArgumentError for nil heartbeat_file_path" do
+        expect {
+          provider.heartbeat_integration(heartbeat_file_path: nil)
+        }.to raise_error(ArgumentError, /heartbeat_file_path must be a non-empty String/)
+      end
+
+      it "raises ArgumentError for blank heartbeat_file_path" do
+        expect {
+          provider.heartbeat_integration(heartbeat_file_path: "  ")
+        }.to raise_error(ArgumentError, /heartbeat_file_path must be a non-empty String/)
+      end
+    end
   end
 end

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -436,6 +436,42 @@ RSpec.describe AgentHarness::Providers::Opencode do
         }.to raise_error(ArgumentError, /heartbeat_file_path must be a non-empty String/)
       end
 
+      it "raises ArgumentError for relative heartbeat_file_path" do
+        expect {
+          provider.heartbeat_integration(heartbeat_file_path: "relative/path")
+        }.to raise_error(ArgumentError, /heartbeat_file_path must be an absolute path/)
+      end
+
+      context "when existing hooks.json is present" do
+        let(:hooks_config_path) { File.expand_path("~/.config/opencode/hooks.json") }
+        let(:existing_config) do
+          {"hooks" => {"on_activity" => [{"command" => "echo existing"}], "on_error" => [{"command" => "echo error"}]}}
+        end
+
+        before do
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with(hooks_config_path).and_return(true)
+          allow(File).to receive(:read).and_call_original
+          allow(File).to receive(:read).with(hooks_config_path).and_return(JSON.generate(existing_config))
+        end
+
+        it "merges heartbeat hook with existing on_activity hooks" do
+          hook_write = integration[:preparation].file_writes.first
+          parsed = JSON.parse(hook_write.content)
+
+          expect(parsed["hooks"]["on_activity"].length).to eq(2)
+          expect(parsed["hooks"]["on_activity"].first["command"]).to eq("echo existing")
+          expect(parsed["hooks"]["on_activity"].last["command"]).to include("touch")
+        end
+
+        it "preserves other hook types" do
+          hook_write = integration[:preparation].file_writes.first
+          parsed = JSON.parse(hook_write.content)
+
+          expect(parsed["hooks"]["on_error"]).to eq([{"command" => "echo error"}])
+        end
+      end
+
       context "with shell-sensitive characters in heartbeat_file_path" do
         let(:heartbeat_path) { "/tmp/heartbeat file;touch /tmp/pwned" }
 


### PR DESCRIPTION
## Summary

All done. Here's a summary of the changes:

**Adapter interface** (`lib/agent_harness/providers/adapter.rb`):
- Added `supports_activity_heartbeat?` — returns `false` by default, clean no-op for unsupported providers
- Added `heartbeat_integration(heartbeat_file_path:)` — returns `{supported: false, env: {}, preparation: nil, granularity: nil}` by default

**OpenCode provider** (`lib/agent_harness/providers/opencode.rb`):
- `supports_activity_heartbeat?` returns `true`
- `heartbeat_integration` returns structured wiring: an `ExecutionPreparation` with a hooks.json config file that touches the heartbeat file on activity, plus `OPENCODE_HEARTBEAT_FILE` env var and `:tool_call` granularity

**KiloCode provider** (`lib/agent_harness/providers/kilocode.rb`):
- Same pattern as OpenCode (compatible config surface), with `KILO_HEARTBEAT_FILE` env var and KiloCode-specific config path

**Tests** — 20 new specs across 3 files covering:
- Default no-op behavior in base provider
- Supported integration contract for OpenCode and KiloCode
- Env vars, preparation file writes, config content, granularity
- Argument validation (nil/blank heartbeat paths)

---

Closes #183