### PR TITLE
Fix #161: Support provider-agnostic skills system

### DIFF
--- a/lib/agent_harness.rb
+++ b/lib/agent_harness.rb
@@ -47,6 +47,7 @@ module AgentHarness
       @configuration = nil
       @conductor = nil
       @token_tracker = nil
+      Skills.reset! if defined?(Skills)
     end
 
     # Returns the global logger
@@ -346,6 +347,8 @@ end
 # Core components
 require_relative "agent_harness/errors"
 require_relative "agent_harness/extensions"
+require_relative "agent_harness/skill"
+require_relative "agent_harness/skills"
 require_relative "agent_harness/mcp_server"
 require_relative "agent_harness/mcp_config_loader"
 require_relative "agent_harness/mcp_config_translator"

--- a/lib/agent_harness/configuration.rb
+++ b/lib/agent_harness/configuration.rb
@@ -420,7 +420,10 @@ module AgentHarness
     end
 
     def mapping_for(provider)
-      deep_dup(@provider_mappings[provider.to_sym])
+      provider_key = provider.to_sym
+      mapping = @provider_mappings[provider_key]
+      mapping ||= @provider_mappings[normalize_provider_family(provider_key)]
+      deep_dup(mapping)
     end
 
     def to_h
@@ -428,6 +431,15 @@ module AgentHarness
     end
 
     private
+
+    def normalize_provider_family(provider)
+      case provider
+      when :claude then :anthropic
+      when :gemini then :google
+      when :cursor, :github_copilot, :codex, :opencode, :openai_compatible then :openai
+      else provider
+      end
+    end
 
     def deep_dup(value)
       case value

--- a/lib/agent_harness/provider_runtime.rb
+++ b/lib/agent_harness/provider_runtime.rb
@@ -226,7 +226,21 @@ module AgentHarness
       return override_tools unless base_tools
       return base_tools unless override_tools
 
-      base_tools + override_tools
+      merged = base_tools + override_tools
+      names = merged.map { |t| tool_name(t) }.compact
+      duplicates = names.group_by { |n| n }.select { |_, v| v.size > 1 }.keys
+      unless duplicates.empty?
+        raise AgentHarness::ConfigurationError,
+          "Duplicate chat tool names across merged runtimes: #{duplicates.join(", ")}"
+      end
+      merged
+    end
+
+    def tool_name(tool)
+      return unless tool.is_a?(Hash)
+
+      tool[:name] || tool["name"] ||
+        tool.dig(:function, :name) || tool.dig("function", "name")
     end
 
     def validate_optional_string!(name, value)

--- a/lib/agent_harness/provider_runtime.rb
+++ b/lib/agent_harness/provider_runtime.rb
@@ -174,6 +174,23 @@ module AgentHarness
         chat_tools.nil?
     end
 
+    def to_h
+      {
+        model: model,
+        base_url: base_url,
+        api_provider: api_provider,
+        env: env.empty? ? nil : env.dup,
+        flags: flags.empty? ? nil : flags.dup,
+        unset_env: unset_env.empty? ? nil : unset_env.dup,
+        metadata: metadata.empty? ? nil : metadata.dup,
+        chat_base_url: chat_base_url,
+        chat_model: chat_model,
+        chat_api_key: chat_api_key,
+        chat_max_tokens: chat_max_tokens,
+        chat_tools: chat_tools&.dup
+      }.compact
+    end
+
     def merge(other)
       other_runtime = ProviderRuntime.wrap(other)
       return self if other_runtime.nil? || other_runtime.empty?
@@ -189,7 +206,7 @@ module AgentHarness
         chat_base_url: other_runtime.chat_base_url || chat_base_url,
         chat_model: other_runtime.chat_model || chat_model,
         chat_api_key: other_runtime.chat_api_key || chat_api_key,
-        chat_max_tokens: other_runtime.chat_max_tokens || chat_max_tokens,
+        chat_max_tokens: other_runtime.chat_max_tokens.nil? ? chat_max_tokens : other_runtime.chat_max_tokens,
         chat_tools: merge_chat_tools(chat_tools, other_runtime.chat_tools)
       )
     end

--- a/lib/agent_harness/provider_runtime.rb
+++ b/lib/agent_harness/provider_runtime.rb
@@ -174,6 +174,26 @@ module AgentHarness
         chat_tools.nil?
     end
 
+    def merge(other)
+      other_runtime = ProviderRuntime.wrap(other)
+      return self if other_runtime.nil? || other_runtime.empty?
+
+      ProviderRuntime.new(
+        model: other_runtime.model || model,
+        base_url: other_runtime.base_url || base_url,
+        api_provider: other_runtime.api_provider || api_provider,
+        env: env.merge(other_runtime.env),
+        flags: flags + other_runtime.flags,
+        unset_env: unset_env + other_runtime.unset_env,
+        metadata: metadata.merge(other_runtime.metadata),
+        chat_base_url: other_runtime.chat_base_url || chat_base_url,
+        chat_model: other_runtime.chat_model || chat_model,
+        chat_api_key: other_runtime.chat_api_key || chat_api_key,
+        chat_max_tokens: other_runtime.chat_max_tokens || chat_max_tokens,
+        chat_tools: merge_chat_tools(chat_tools, other_runtime.chat_tools)
+      )
+    end
+
     private_class_method def self.hash_value(hash, key)
       sym_value = hash[key]
       str_value = hash[key.to_s]
@@ -184,6 +204,13 @@ module AgentHarness
     end
 
     private
+
+    def merge_chat_tools(base_tools, override_tools)
+      return override_tools unless base_tools
+      return base_tools unless override_tools
+
+      base_tools + override_tools
+    end
 
     def validate_optional_string!(name, value)
       return if value.nil?

--- a/lib/agent_harness/providers/adapter.rb
+++ b/lib/agent_harness/providers/adapter.rb
@@ -950,6 +950,15 @@ module AgentHarness
         false
       end
 
+      # Check if provider message mode can inject available tool definitions
+      # through the +tools:+ option. Providers that use +tools:+ strictly for
+      # disallow lists should leave this as +false+.
+      #
+      # @return [Boolean] true if skill tools can be merged into message mode
+      def supports_message_tool_injection?
+        false
+      end
+
       # Check if provider supports text-only mode via direct HTTP transport.
       #
       # Providers that return +true+ will route +mode: :text+ requests

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -211,6 +211,9 @@ module AgentHarness
         log_debug("send_message_start", prompt_length: prompt.length, options: options.keys)
 
         options = normalize_provider_runtime(options)
+        skill_context = resolve_skills(options)
+        prompt = apply_skills_to_prompt(prompt, skill_context)
+        options = skill_context[:options]
         runtime = options[:provider_runtime]
 
         options = normalize_mcp_servers(options)
@@ -267,6 +270,9 @@ module AgentHarness
         log_debug("plan_execution_start", prompt_length: prompt.length, options: options.keys)
 
         options = normalize_provider_runtime(options)
+        skill_context = resolve_skills(options)
+        prompt = apply_skills_to_prompt(prompt, skill_context)
+        options = skill_context[:options]
         options = normalize_mcp_servers(options)
         validate_mcp_servers!(options[:mcp_servers]) if options[:mcp_servers]&.any?
 

--- a/lib/agent_harness/providers/aider.rb
+++ b/lib/agent_harness/providers/aider.rb
@@ -258,7 +258,7 @@ module AgentHarness
         log_debug("send_message_complete", duration: duration, tokens: response.tokens)
 
         response
-      rescue McpConfigurationError, McpUnsupportedError, McpTransportUnsupportedError
+      rescue ConfigurationError, McpConfigurationError, McpUnsupportedError, McpTransportUnsupportedError
         raise
       rescue => e
         handle_error(e, prompt: prompt, options: options)
@@ -283,7 +283,7 @@ module AgentHarness
           env: build_env(options),
           preparation: build_execution_preparation(options)
         }
-      rescue McpConfigurationError, McpUnsupportedError, McpTransportUnsupportedError
+      rescue ConfigurationError, McpConfigurationError, McpUnsupportedError, McpTransportUnsupportedError
         raise
       rescue => e
         handle_error(e, prompt: prompt, options: options)

--- a/lib/agent_harness/providers/anthropic.rb
+++ b/lib/agent_harness/providers/anthropic.rb
@@ -378,7 +378,10 @@ module AgentHarness
 
       def send_message(prompt:, **options)
         if options[:mode] == :text
-          return send_text_message(prompt, **options.except(:mode))
+          options = normalize_provider_runtime(options)
+          skill_context = resolve_skills(options)
+          prompt = apply_skills_to_prompt(prompt, skill_context)
+          return send_text_message(prompt, **skill_context[:options].except(:mode, :skills))
         end
 
         super

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -129,6 +129,9 @@ module AgentHarness
 
         # Coerce provider_runtime from Hash if needed
         options = normalize_provider_runtime(options)
+        skill_context = resolve_skills(options)
+        prompt = apply_skills_to_prompt(prompt, skill_context)
+        options = skill_context[:options]
 
         # Capture execution options (callbacks, observer) before extensions
         # processing deep-dups the options hash, which would replace identity-
@@ -276,6 +279,8 @@ module AgentHarness
         end
 
         options = normalize_provider_runtime(options)
+        skill_context = resolve_skills(options)
+        options = skill_context[:options]
         options = normalize_sub_agent(options)
         runtime = options[:provider_runtime]
         conversation ||= messages
@@ -284,6 +289,8 @@ module AgentHarness
 
         transport = resolve_chat_transport(options)
         messages = format_messages_for_transport(conversation, transport)
+        messages = apply_skills_to_messages(messages, skill_context)
+        tools = merge_skill_chat_tools(tools, skill_context[:tools])
         extension_context = apply_extensions_to_chat(messages, tools, options)
         messages = extension_context.messages
         tools = extension_context.tools
@@ -525,6 +532,28 @@ module AgentHarness
         options.merge(provider_runtime: ProviderRuntime.wrap(raw))
       end
 
+      def resolve_skills(options)
+        skill_refs = options[:skills]
+        skills = Skills.resolve_all(skill_refs)
+        return {skills: [], options: options, instructions: nil, tools: []} if skills.empty?
+
+        runtime = skills.map { |skill| ProviderRuntime.wrap(skill.provider_override_for(self.class.provider_name)) }
+          .compact
+          .reduce(nil) { |merged, skill_runtime| merged ? merged.merge(skill_runtime) : skill_runtime }
+
+        runtime = runtime&.merge(options[:provider_runtime]) || options[:provider_runtime]
+        merged_options = options.merge(provider_runtime: runtime)
+        merged_options = merge_skill_message_tools(merged_options, skills)
+        merged_options = merge_skill_mcp_servers(merged_options, skills)
+
+        {
+          skills: skills,
+          options: merged_options,
+          instructions: skills.map(&:instructions).join("\n\n"),
+          tools: resolve_skill_chat_tools(skills)
+        }
+      end
+
       def normalize_mcp_servers(options)
         if options.key?(:mcp_servers)
           servers = options[:mcp_servers]
@@ -582,6 +611,20 @@ module AgentHarness
         return prompt unless translated_sub_agent
 
         [translated_sub_agent[:runtime_instructions], "User task:\n#{prompt}"].join("\n\n")
+      end
+
+      def apply_skills_to_prompt(prompt, skill_context)
+        instructions = skill_context[:instructions]
+        return prompt if instructions.nil? || instructions.empty?
+
+        [instructions, prompt].join("\n\n")
+      end
+
+      def apply_skills_to_messages(messages, skill_context)
+        instructions = skill_context[:instructions]
+        return messages if instructions.nil? || instructions.empty?
+
+        [{role: "system", content: instructions}] + messages
       end
 
       def apply_sub_agent_to_messages(messages, translated_sub_agent)
@@ -715,6 +758,80 @@ module AgentHarness
             "Tool name conflict between user-provided and extension tools: #{duplicates.join(", ")}"
         end
         merged
+      end
+
+      def merge_skill_message_tools(options, skills)
+        return options if skills.empty?
+        return options if options[:tools] == :none
+
+        skill_tools = skills.flat_map { |skill| skill.tools.map { |tool| resolve_skill_message_tool(tool) } }.compact
+        return options if skill_tools.empty?
+
+        current_tools = options[:tools]
+        merged_tools = Array(current_tools) + skill_tools
+        duplicates = merged_tools.group_by(&:itself).select { |_, entries| entries.size > 1 }.keys
+        unless duplicates.empty?
+          raise ConfigurationError, "Tool name conflict between explicit and skill tools: #{duplicates.join(", ")}"
+        end
+
+        options.merge(tools: merged_tools)
+      end
+
+      def merge_skill_mcp_servers(options, skills)
+        skill_servers = skills.flat_map(&:mcp_servers)
+        return options if skill_servers.empty?
+
+        merged = Array(options[:mcp_servers]) + deep_dup(skill_servers)
+        options.merge(mcp_servers: merged)
+      end
+
+      def resolve_skill_chat_tools(skills)
+        skills.flat_map do |skill|
+          skill.tools.map { |tool| normalize_skill_chat_tool_for_provider(resolve_skill_tool_mapping(tool)) }
+        end
+      end
+
+      def merge_skill_chat_tools(tools, skill_tools)
+        return tools if skill_tools.empty?
+
+        merged = Array(tools) + skill_tools
+        names = merged.map { |tool| extract_tool_name(tool) }.compact
+        duplicates = names.group_by { |name| name }.select { |_, entries| entries.size > 1 }.keys
+        unless duplicates.empty?
+          raise ConfigurationError, "Tool name conflict between explicit and skill tools: #{duplicates.join(", ")}"
+        end
+
+        merged
+      end
+
+      def resolve_skill_message_tool(tool)
+        resolved = resolve_skill_tool_mapping(tool)
+        return resolved if resolved.is_a?(String)
+        return extract_tool_name(resolved) if resolved.is_a?(Hash)
+
+        raise ConfigurationError, "Unsupported skill tool mapping for message mode: #{resolved.inspect}"
+      end
+
+      def normalize_skill_chat_tool_for_provider(tool)
+        return normalize_extension_tool_for_provider(tool) if tool.is_a?(Hash)
+
+        {name: tool.to_s}
+      end
+
+      def resolve_skill_tool_mapping(tool)
+        case tool
+        when Symbol, String
+          if @configuration.tool_registry.registered?(tool)
+            mapping = @configuration.tool_registry.fetch(tool).mapping_for(self.class.provider_name)
+            mapping.nil? ? tool.to_s : mapping
+          else
+            tool.to_s
+          end
+        when Hash
+          deep_dup(tool)
+        else
+          raise ConfigurationError, "Unsupported tool reference #{tool.inspect} in skill definition"
+        end
       end
 
       def extract_tool_name(tool)

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -194,7 +194,8 @@ module AgentHarness
         log_debug("send_message_complete", duration: duration, tokens: response.tokens)
 
         response
-      rescue ExtensionCompatibilityError, McpConfigurationError, McpUnsupportedError, McpTransportUnsupportedError
+      rescue ExtensionCompatibilityError, ConfigurationError, McpConfigurationError, McpUnsupportedError,
+        McpTransportUnsupportedError
         raise
       rescue => e
         handle_error(e, prompt: prompt, options: options)
@@ -288,7 +289,7 @@ module AgentHarness
         runtime = options[:provider_runtime]
         conversation ||= messages
         raise ArgumentError, "conversation or messages is required" unless conversation
-        tools = merge_skill_chat_tools(tools, runtime&.chat_tools || [])
+        tools = runtime.chat_tools if tools.nil? && runtime&.chat_tools
 
         transport = resolve_chat_transport(options)
         messages = format_messages_for_transport(conversation, transport)
@@ -540,11 +541,11 @@ module AgentHarness
         skills = Skills.resolve_all(skill_refs)
         return {skills: [], options: options, instructions: nil, tools: []} if skills.empty?
 
-        runtime = skills.map { |skill| ProviderRuntime.wrap(skill.provider_override_for(self.class.provider_name)) }
+        skill_runtime = skills.map { |skill| ProviderRuntime.wrap(skill.provider_override_for(self.class.provider_name)) }
           .compact
           .reduce(nil) { |merged, skill_runtime| merged ? merged.merge(skill_runtime) : skill_runtime }
 
-        runtime = runtime&.merge(options[:provider_runtime]) || options[:provider_runtime]
+        runtime = skill_runtime&.merge(options[:provider_runtime]) || options[:provider_runtime]
         merged_options = options.merge(provider_runtime: runtime)
         merged_options = merge_skill_message_tools(merged_options, skills)
         merged_options = merge_skill_mcp_servers(merged_options, skills)
@@ -553,7 +554,7 @@ module AgentHarness
           skills: skills,
           options: merged_options,
           instructions: skills.map(&:instructions).join("\n\n"),
-          tools: resolve_skill_chat_tools(skills)
+          tools: resolve_skill_chat_tools(skills, runtime: skill_runtime)
         }
       end
 
@@ -782,17 +783,31 @@ module AgentHarness
       end
 
       def merge_skill_mcp_servers(options, skills)
-        skill_servers = skills.flat_map(&:mcp_servers)
+        skill_servers = skills.flat_map do |skill|
+          skill.mcp_servers.map { |server| [skill.name, server] }
+        end
         return options if skill_servers.empty?
 
-        merged = Array(options[:mcp_servers]) + deep_dup(skill_servers)
+        merged = Array(options[:mcp_servers]) + deep_dup(skill_servers.map(&:last))
+        duplicates = duplicate_skill_mcp_server_names(Array(options[:mcp_servers]), skill_servers)
+        unless duplicates.empty?
+          conflicts = duplicates.map do |name, owners|
+            formatted_owners = owners.map { |owner| (owner == :explicit) ? "explicit" : "skill: #{owner}" }.join(", ")
+            "#{name} (#{formatted_owners})"
+          end
+          raise ConfigurationError,
+            "MCP server name conflict across explicit and skill servers: #{conflicts.join(", ")}"
+        end
+
         options.merge(mcp_servers: merged)
       end
 
-      def resolve_skill_chat_tools(skills)
-        skills.flat_map do |skill|
+      def resolve_skill_chat_tools(skills, runtime: nil)
+        skill_tools = skills.flat_map do |skill|
           skill.tools.map { |tool| normalize_skill_chat_tool_for_provider(resolve_skill_tool_mapping(tool)) }
         end
+
+        merge_skill_chat_tools(skill_tools, Array(runtime&.chat_tools))
       end
 
       def merge_skill_chat_tools(tools, skill_tools)
@@ -820,6 +835,23 @@ module AgentHarness
         return normalize_extension_tool_for_provider(tool) if tool.is_a?(Hash)
 
         {name: tool.to_s}
+      end
+
+      def duplicate_skill_mcp_server_names(existing_servers, skill_servers)
+        owners_by_name = Hash.new { |hash, key| hash[key] = [] }
+        existing_servers.each do |server|
+          name = server[:name] || server["name"]
+          owners_by_name[name] << :explicit if name
+        end
+
+        skill_servers.each do |(skill_name, server)|
+          name = server[:name] || server["name"]
+          owners_by_name[name] << skill_name if name
+        end
+
+        owners_by_name.each_with_object({}) do |(name, owners), duplicates|
+          duplicates[name] = owners if owners.uniq.size > 1
+        end
       end
 
       def resolve_skill_tool_mapping(tool)

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -307,7 +307,7 @@ module AgentHarness
         tools = extension_context.tools
         options = extension_context.options
         messages = apply_sub_agent_to_messages(messages, options[:translated_sub_agent])
-        validate_chat_mcp_servers!(options[:mcp_servers])
+        validate_chat_mcp_servers!(options)
         transport_opts = chat_transport_options(runtime, options)
         transport_opts[:on_chat_chunk] = on_chat_chunk if on_chat_chunk
         transport_opts[:observer] = observer if observer
@@ -569,21 +569,23 @@ module AgentHarness
       end
 
       def normalize_mcp_servers(options)
-        if options.key?(:mcp_servers)
-          servers = options[:mcp_servers]
+        base_servers = if options.key?(:mcp_servers)
+          options[:mcp_servers]
         else
           # Configuration stores mcp_servers as a Hash keyed by name; extract values.
           config_servers = @configuration.mcp_servers
-          servers = config_servers.is_a?(Hash) ? config_servers.values : config_servers
+          config_servers.is_a?(Hash) ? config_servers.values : config_servers
         end
-        return options if servers.nil?
+        skill_servers = Array(options[:skill_mcp_servers])
+        return options.except(:skill_mcp_servers) if base_servers.nil? && skill_servers.empty?
 
-        unless servers.is_a?(Array)
+        unless base_servers.nil? || base_servers.is_a?(Array)
           raise McpConfigurationError,
-            "mcp_servers must be an Array of Hash or McpServer, got #{servers.class}"
+            "mcp_servers must be an Array of Hash or McpServer, got #{base_servers.class}"
         end
 
-        return options if servers.empty?
+        servers = Array(base_servers) + skill_servers
+        return options.except(:skill_mcp_servers) if servers.empty?
 
         normalized = servers.map do |server|
           if server.is_a?(McpServer)
@@ -603,7 +605,7 @@ module AgentHarness
             "Duplicate MCP server names detected: #{duplicate_names.join(", ")}"
         end
 
-        options.merge(mcp_servers: normalized)
+        options.except(:skill_mcp_servers).merge(mcp_servers: normalized)
       end
 
       def normalize_sub_agent(options)
@@ -724,8 +726,9 @@ module AgentHarness
         end
       end
 
-      def validate_chat_mcp_servers!(mcp_servers)
-        return if mcp_servers.nil? || mcp_servers.empty?
+      def validate_chat_mcp_servers!(options)
+        mcp_servers = normalized_mcp_server_sources(options) + Array(options[:skill_mcp_servers])
+        return if mcp_servers.empty?
 
         # Chat transports do not support request-scoped MCP servers.
         # Raise early so extensions with MCP requirements are not silently ignored.
@@ -806,8 +809,8 @@ module AgentHarness
         end
         return options if skill_servers.empty?
 
-        merged = Array(options[:mcp_servers]) + deep_dup(skill_servers.map(&:last))
-        duplicates = duplicate_skill_mcp_server_names(Array(options[:mcp_servers]), skill_servers)
+        existing_servers = normalized_mcp_server_sources(options)
+        duplicates = duplicate_skill_mcp_server_names(existing_servers, skill_servers)
         unless duplicates.empty?
           conflicts = duplicates.map do |name, owners|
             formatted_owners = owners.map { |owner| (owner == :explicit) ? "explicit" : "skill: #{owner}" }.join(", ")
@@ -817,7 +820,7 @@ module AgentHarness
             "MCP server name conflict across explicit and skill servers: #{conflicts.join(", ")}"
         end
 
-        options.merge(mcp_servers: merged)
+        options.merge(skill_mcp_servers: deep_dup(skill_servers.map(&:last)))
       end
 
       def resolve_skill_chat_tools(skills)
@@ -855,17 +858,35 @@ module AgentHarness
       def duplicate_skill_mcp_server_names(existing_servers, skill_servers)
         owners_by_name = Hash.new { |hash, key| hash[key] = [] }
         existing_servers.each do |server|
-          name = server[:name] || server["name"]
+          name = server_name(server)
           owners_by_name[name] << :explicit if name
         end
 
         skill_servers.each do |(skill_name, server)|
-          name = server[:name] || server["name"]
+          name = server_name(server)
           owners_by_name[name] << skill_name if name
         end
 
         owners_by_name.each_with_object({}) do |(name, owners), duplicates|
           duplicates[name] = owners if owners.uniq.size > 1
+        end
+      end
+
+      def normalized_mcp_server_sources(options)
+        if options.key?(:mcp_servers)
+          Array(options[:mcp_servers])
+        else
+          config_servers = @configuration.mcp_servers
+          config_servers = config_servers.values if config_servers.is_a?(Hash)
+          Array(config_servers)
+        end
+      end
+
+      def server_name(server)
+        if server.is_a?(McpServer)
+          server.name
+        else
+          server[:name] || server["name"]
         end
       end
 

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -642,7 +642,7 @@ module AgentHarness
         # rather than inserting a separate system turn that could be overridden.
         if messages.any? && messages.first[:role] == "system"
           merged = messages.dup
-          merged[0] = merged[0].merge(content: "#{instructions}\n\n#{merged[0][:content]}")
+          merged[0] = merged[0].merge(content: prepend_text_to_message_content(merged[0][:content], instructions))
           merged
         else
           [{role: "system", content: instructions}] + messages
@@ -882,6 +882,21 @@ module AgentHarness
           deep_dup(tool)
         else
           raise ConfigurationError, "Unsupported tool reference #{tool.inspect} in skill definition"
+        end
+      end
+
+      def prepend_text_to_message_content(content, text)
+        case content
+        when nil
+          text
+        when String
+          "#{text}\n\n#{content}"
+        when Array
+          [{type: "text", text: "#{text}\n\n"}] + deep_dup(content)
+        when Hash
+          [{type: "text", text: "#{text}\n\n"}, deep_dup(content)]
+        else
+          raise ConfigurationError, "Unsupported system message content type for skill instructions: #{content.class}"
         end
       end
 

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -545,7 +545,9 @@ module AgentHarness
 
       def resolve_skills(options)
         skill_refs = options[:skills]
-        skills = Skills.resolve_all(skill_refs)
+        cwd = options.fetch(:cwd, Dir.pwd)
+        home = options.fetch(:home, Dir.home)
+        skills = Skills.resolve_all(skill_refs, cwd: cwd, home: home)
         return {skills: [], options: options, instructions: nil, tools: [], runtime_tools: []} if skills.empty?
 
         skill_runtime = skills.map { |skill| ProviderRuntime.wrap(skill.provider_override_for(self.class.provider_name)) }
@@ -636,7 +638,15 @@ module AgentHarness
         instructions = skill_context[:instructions]
         return messages if instructions.nil? || instructions.empty?
 
-        [{role: "system", content: instructions}] + messages
+        # Prepend skill instructions to the first system message if one exists,
+        # rather than inserting a separate system turn that could be overridden.
+        if messages.any? && messages.first[:role] == "system"
+          merged = messages.dup
+          merged[0] = merged[0].merge(content: "#{instructions}\n\n#{merged[0][:content]}")
+          merged
+        else
+          [{role: "system", content: instructions}] + messages
+        end
       end
 
       def apply_sub_agent_to_messages(messages, translated_sub_agent)

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -243,7 +243,8 @@ module AgentHarness
           env: build_env(options),
           preparation: build_execution_preparation(options)
         }
-      rescue ExtensionCompatibilityError, McpConfigurationError, McpUnsupportedError, McpTransportUnsupportedError
+      rescue ExtensionCompatibilityError, ConfigurationError, McpConfigurationError, McpUnsupportedError,
+        McpTransportUnsupportedError
         raise
       rescue => e
         handle_error(e, prompt: prompt, options: options)
@@ -289,12 +290,18 @@ module AgentHarness
         runtime = options[:provider_runtime]
         conversation ||= messages
         raise ArgumentError, "conversation or messages is required" unless conversation
-        tools = runtime.chat_tools if tools.nil? && runtime&.chat_tools
+        use_runtime_chat_tools = tools.nil?
+        tools = runtime.chat_tools if use_runtime_chat_tools && runtime&.chat_tools
 
         transport = resolve_chat_transport(options)
         messages = format_messages_for_transport(conversation, transport)
         messages = apply_skills_to_messages(messages, skill_context)
-        tools = merge_skill_chat_tools(tools, skill_context[:tools])
+        skill_tools = if use_runtime_chat_tools
+          skill_context[:tools]
+        else
+          merge_skill_chat_tools(skill_context[:tools], skill_context[:runtime_tools])
+        end
+        tools = merge_skill_chat_tools(tools, skill_tools)
         extension_context = apply_extensions_to_chat(messages, tools, options)
         messages = extension_context.messages
         tools = extension_context.tools
@@ -539,7 +546,7 @@ module AgentHarness
       def resolve_skills(options)
         skill_refs = options[:skills]
         skills = Skills.resolve_all(skill_refs)
-        return {skills: [], options: options, instructions: nil, tools: []} if skills.empty?
+        return {skills: [], options: options, instructions: nil, tools: [], runtime_tools: []} if skills.empty?
 
         skill_runtime = skills.map { |skill| ProviderRuntime.wrap(skill.provider_override_for(self.class.provider_name)) }
           .compact
@@ -554,7 +561,8 @@ module AgentHarness
           skills: skills,
           options: merged_options,
           instructions: skills.map(&:instructions).join("\n\n"),
-          tools: resolve_skill_chat_tools(skills, runtime: skill_runtime)
+          tools: resolve_skill_chat_tools(skills),
+          runtime_tools: Array(skill_runtime&.chat_tools)
         }
       end
 
@@ -802,12 +810,10 @@ module AgentHarness
         options.merge(mcp_servers: merged)
       end
 
-      def resolve_skill_chat_tools(skills, runtime: nil)
-        skill_tools = skills.flat_map do |skill|
+      def resolve_skill_chat_tools(skills)
+        skills.flat_map do |skill|
           skill.tools.map { |tool| normalize_skill_chat_tool_for_provider(resolve_skill_tool_mapping(tool)) }
         end
-
-        merge_skill_chat_tools(skill_tools, Array(runtime&.chat_tools))
       end
 
       def merge_skill_chat_tools(tools, skill_tools)

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -224,6 +224,9 @@ module AgentHarness
         end
 
         options = normalize_provider_runtime(options)
+        skill_context = resolve_skills(options)
+        prompt = apply_skills_to_prompt(prompt, skill_context)
+        options = skill_context[:options]
 
         extension_context = apply_extensions_to_prompt(prompt, options)
         prompt = extension_context.prompt

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -550,7 +550,7 @@ module AgentHarness
 
         skill_runtime = skills.map { |skill| ProviderRuntime.wrap(skill.provider_override_for(self.class.provider_name)) }
           .compact
-          .reduce(nil) { |merged, skill_runtime| merged ? merged.merge(skill_runtime) : skill_runtime }
+          .reduce(nil) { |merged, sr| merged ? merged.merge(sr) : sr }
 
         runtime = skill_runtime&.merge(options[:provider_runtime]) || options[:provider_runtime]
         merged_options = options.merge(provider_runtime: runtime)

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -727,7 +727,10 @@ module AgentHarness
       end
 
       def validate_chat_mcp_servers!(options)
-        mcp_servers = normalized_mcp_server_sources(options) + Array(options[:skill_mcp_servers])
+        # Chat mode only needs to reject MCP servers introduced by the
+        # current request. Global configuration may still define default MCP
+        # servers for non-chat flows and should not make every chat call fail.
+        mcp_servers = Array(options[:mcp_servers]) + Array(options[:skill_mcp_servers])
         return if mcp_servers.empty?
 
         # Chat transports do not support request-scoped MCP servers.

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -284,7 +284,7 @@ module AgentHarness
         end
 
         options = normalize_provider_runtime(options)
-        skill_context = resolve_skills(options)
+        skill_context = resolve_skills(options, mode: :chat)
         options = skill_context[:options]
         options = normalize_sub_agent(options)
         runtime = options[:provider_runtime]
@@ -543,7 +543,7 @@ module AgentHarness
         options.merge(provider_runtime: ProviderRuntime.wrap(raw))
       end
 
-      def resolve_skills(options)
+      def resolve_skills(options, mode: :message)
         skill_refs = options[:skills]
         cwd = options.fetch(:cwd, Dir.pwd)
         home = options.fetch(:home, Dir.home)
@@ -556,7 +556,7 @@ module AgentHarness
 
         runtime = skill_runtime&.merge(options[:provider_runtime]) || options[:provider_runtime]
         merged_options = options.merge(provider_runtime: runtime)
-        merged_options = merge_skill_message_tools(merged_options, skills)
+        merged_options = merge_skill_message_tools(merged_options, skills) if mode == :message
         merged_options = merge_skill_mcp_servers(merged_options, skills)
 
         {
@@ -788,10 +788,17 @@ module AgentHarness
       def merge_skill_message_tools(options, skills)
         return options if skills.empty?
         return options if options[:tools] == :none
-        return options unless supports_message_tool_injection?
 
         skill_tools = skills.flat_map { |skill| skill.tools.map { |tool| resolve_skill_message_tool(tool) } }.compact
         return options if skill_tools.empty?
+
+        unless supports_message_tool_injection?
+          tool_names = skill_tools.map { |t| t.is_a?(Hash) ? extract_tool_name(t) : t }.compact
+          skill_names = skills.select { |s| s.tools.any? }.map(&:name)
+          raise ConfigurationError,
+            "Skills #{skill_names.join(", ")} define message-mode tools (#{tool_names.join(", ")}) " \
+            "but provider #{self.class.provider_name} does not support message-mode tool injection"
+        end
 
         current_tools = options[:tools]
         merged_tools = Array(current_tools) + skill_tools

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -288,7 +288,7 @@ module AgentHarness
         runtime = options[:provider_runtime]
         conversation ||= messages
         raise ArgumentError, "conversation or messages is required" unless conversation
-        tools = runtime.chat_tools if tools.nil? && runtime&.chat_tools
+        tools = merge_skill_chat_tools(tools, runtime&.chat_tools || [])
 
         transport = resolve_chat_transport(options)
         messages = format_messages_for_transport(conversation, transport)
@@ -318,7 +318,7 @@ module AgentHarness
         log_debug("send_chat_message_complete", duration: response.duration, tokens: response.tokens)
 
         response
-      rescue ExtensionCompatibilityError, ProviderError, AuthenticationError, RateLimitError, TimeoutError
+      rescue ExtensionCompatibilityError, ConfigurationError, ProviderError, AuthenticationError, RateLimitError, TimeoutError
         raise
       rescue => e
         last_msg = conversation&.last || messages&.last
@@ -766,6 +766,7 @@ module AgentHarness
       def merge_skill_message_tools(options, skills)
         return options if skills.empty?
         return options if options[:tools] == :none
+        return options unless supports_message_tool_injection?
 
         skill_tools = skills.flat_map { |skill| skill.tools.map { |tool| resolve_skill_message_tool(tool) } }.compact
         return options if skill_tools.empty?

--- a/lib/agent_harness/providers/base.rb
+++ b/lib/agent_harness/providers/base.rb
@@ -838,9 +838,8 @@ module AgentHarness
       end
 
       def normalize_skill_chat_tool_for_provider(tool)
-        return normalize_extension_tool_for_provider(tool) if tool.is_a?(Hash)
-
-        {name: tool.to_s}
+        normalized_tool = tool.is_a?(Hash) ? tool : {name: tool.to_s}
+        normalize_extension_tool_for_provider(normalized_tool)
       end
 
       def duplicate_skill_mcp_server_names(existing_servers, skill_servers)

--- a/lib/agent_harness/providers/cursor.rb
+++ b/lib/agent_harness/providers/cursor.rb
@@ -309,7 +309,7 @@ module AgentHarness
         log_debug("send_message_complete", duration: duration)
 
         response
-      rescue McpConfigurationError, McpUnsupportedError, McpTransportUnsupportedError
+      rescue ConfigurationError, McpConfigurationError, McpUnsupportedError, McpTransportUnsupportedError
         raise
       rescue => e
         handle_error(e, prompt: prompt, options: options)
@@ -334,7 +334,7 @@ module AgentHarness
           env: build_env(options),
           preparation: build_execution_preparation(options)
         }
-      rescue McpConfigurationError, McpUnsupportedError, McpTransportUnsupportedError
+      rescue ConfigurationError, McpConfigurationError, McpUnsupportedError, McpTransportUnsupportedError
         raise
       rescue => e
         handle_error(e, prompt: prompt, options: options)

--- a/lib/agent_harness/providers/cursor.rb
+++ b/lib/agent_harness/providers/cursor.rb
@@ -255,6 +255,9 @@ module AgentHarness
 
         # Coerce provider_runtime from Hash if needed (same as Base#send_message)
         options = normalize_provider_runtime(options)
+        skill_context = resolve_skills(options)
+        prompt = apply_skills_to_prompt(prompt, skill_context)
+        options = skill_context[:options]
         runtime = options[:provider_runtime]
 
         # Normalize and validate MCP servers (same as Base#send_message)
@@ -316,6 +319,9 @@ module AgentHarness
         log_debug("plan_execution_start", prompt_length: prompt.length, options: options.keys)
 
         options = normalize_provider_runtime(options)
+        skill_context = resolve_skills(options)
+        prompt = apply_skills_to_prompt(prompt, skill_context)
+        options = skill_context[:options]
         options = normalize_mcp_servers(options)
         validate_mcp_servers!(options[:mcp_servers]) if options[:mcp_servers]&.any?
 

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -292,6 +292,9 @@ module AgentHarness
         log_debug("send_message_start", prompt_length: prompt.length, options: options.keys)
 
         options = normalize_provider_runtime(options)
+        skill_context = resolve_skills(options)
+        prompt = apply_skills_to_prompt(prompt, skill_context)
+        options = skill_context[:options]
         options = normalize_mcp_servers(options)
         validate_mcp_servers!(options[:mcp_servers]) if options[:mcp_servers]&.any?
 
@@ -349,6 +352,9 @@ module AgentHarness
         log_debug("plan_execution_start", prompt_length: prompt.length, options: options.keys)
 
         options = normalize_provider_runtime(options)
+        skill_context = resolve_skills(options)
+        prompt = apply_skills_to_prompt(prompt, skill_context)
+        options = skill_context[:options]
         options = normalize_mcp_servers(options)
         validate_mcp_servers!(options[:mcp_servers]) if options[:mcp_servers]&.any?
 

--- a/lib/agent_harness/providers/github_copilot.rb
+++ b/lib/agent_harness/providers/github_copilot.rb
@@ -342,7 +342,7 @@ module AgentHarness
         log_debug("send_message_complete", duration: duration, tokens: response.tokens)
 
         response
-      rescue McpConfigurationError, McpUnsupportedError, McpTransportUnsupportedError
+      rescue ConfigurationError, McpConfigurationError, McpUnsupportedError, McpTransportUnsupportedError
         raise
       rescue => e
         handle_error(e, prompt: prompt, options: options)
@@ -369,7 +369,7 @@ module AgentHarness
           env: env,
           preparation: build_execution_preparation(options)
         }
-      rescue McpConfigurationError, McpUnsupportedError, McpTransportUnsupportedError
+      rescue ConfigurationError, McpConfigurationError, McpUnsupportedError, McpTransportUnsupportedError
         raise
       rescue => e
         handle_error(e, prompt: prompt, options: options)

--- a/lib/agent_harness/skill.rb
+++ b/lib/agent_harness/skill.rb
@@ -5,6 +5,13 @@ require "yaml"
 module AgentHarness
   # Canonical provider-agnostic skill definition loaded from SKILL.md.
   class Skill
+    PROVIDER_FAMILY_ALIASES = {
+      anthropic: :anthropic,
+      google: :google,
+      openai: :openai,
+      openai_compatible: :openai
+    }.freeze
+
     attr_reader :name, :description, :instructions, :trigger, :tools, :mcp_servers
     attr_reader :provider_overrides, :source_path
 
@@ -54,9 +61,12 @@ module AgentHarness
     end
 
     def provider_override_for(provider)
-      provider_key = provider_lookup_key(provider)
-      merged = ProviderRuntime.wrap(@provider_overrides[:all])
-      merged = merged ? merged.merge(@provider_overrides[provider_key]) : ProviderRuntime.wrap(@provider_overrides[provider_key])
+      merged = provider_override_keys_for(provider).reduce(nil) do |runtime, key|
+        override = @provider_overrides[key]
+        next runtime unless override
+
+        runtime ? runtime.merge(override) : ProviderRuntime.wrap(override)
+      end
 
       merged ? merged.to_h : {}
     end
@@ -158,6 +168,8 @@ module AgentHarness
       key = provider.to_sym
       return :all if key == :all
 
+      return PROVIDER_FAMILY_ALIASES[key] if PROVIDER_FAMILY_ALIASES.key?(key)
+
       registry = Providers::Registry.instance
       canonical = registry.canonical_name(key)
       raise ConfigurationError, "Unknown provider in skill definition: #{provider}" unless registry.registered?(canonical)
@@ -165,13 +177,25 @@ module AgentHarness
       canonical.to_sym
     end
 
-    def provider_lookup_key(provider)
+    def provider_override_keys_for(provider)
       key = provider.to_sym
-      return :all if key == :all
+      return [:all] if key == :all
 
       registry = Providers::Registry.instance
       canonical = registry.canonical_name(key)
-      registry.registered?(canonical) ? canonical.to_sym : key
+      concrete = registry.registered?(canonical) ? canonical.to_sym : key
+      family = normalize_provider_family(concrete)
+
+      [:all, family, concrete].uniq
+    end
+
+    def normalize_provider_family(provider)
+      case provider
+      when :claude then :anthropic
+      when :gemini then :google
+      when :cursor, :github_copilot, :codex, :opencode, :openai_compatible then :openai
+      else provider
+      end
     end
 
     def deep_dup(value)

--- a/lib/agent_harness/skill.rb
+++ b/lib/agent_harness/skill.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module AgentHarness
+  # Canonical provider-agnostic skill definition loaded from SKILL.md.
+  class Skill
+    attr_reader :name, :description, :instructions, :trigger, :tools, :mcp_servers
+    attr_reader :provider_overrides, :source_path
+
+    def initialize(name:, description:, instructions:, trigger: nil, tools: [], mcp_servers: [],
+      providers: {}, source_path: nil)
+      @name = normalize_name(name)
+      @description = validate_string!(:description, description)
+      @instructions = validate_string!(:instructions, instructions)
+      @trigger = trigger.nil? ? nil : validate_string!(:trigger, trigger)
+      @tools = normalize_array(:tools, tools)
+      @mcp_servers = normalize_mcp_servers(mcp_servers)
+      @provider_overrides = normalize_provider_overrides(providers)
+      @source_path = source_path && File.expand_path(source_path)
+    end
+
+    def self.from_hash(hash = nil, source_path: nil, **kwargs)
+      hash = kwargs if hash.nil? && !kwargs.empty?
+
+      unless hash.is_a?(Hash)
+        raise ConfigurationError, "Skill definition must be a Hash, got #{hash.class}"
+      end
+
+      attrs = hash.each_with_object({}) do |(key, value), memo|
+        memo[key.to_sym] = value
+      end
+
+      %i[name description instructions].each do |field|
+        value = attrs[field]
+        next if value.is_a?(String) && !value.strip.empty?
+        next if value.is_a?(Symbol)
+
+        raise ConfigurationError, "#{field} is required"
+      end
+
+      new(**attrs.merge(source_path: source_path))
+    end
+
+    def self.load_file(path)
+      expanded_path = File.expand_path(path)
+      content = File.read(expanded_path)
+      frontmatter, body = parse_markdown(content)
+      from_hash(frontmatter.merge(instructions: body), source_path: expanded_path)
+    rescue Errno::ENOENT
+      raise ConfigurationError, "Skill file not found: #{path}"
+    rescue Psych::Exception => e
+      raise ConfigurationError, "Invalid YAML frontmatter in skill #{path}: #{e.message}"
+    end
+
+    def provider_override_for(provider)
+      provider_key = provider_lookup_key(provider)
+      merged = {}
+
+      all_override = @provider_overrides[:all]
+      merged.merge!(deep_dup(all_override)) if all_override
+
+      specific_override = @provider_overrides[provider_key]
+      merged.merge!(deep_dup(specific_override)) if specific_override
+
+      merged
+    end
+
+    def to_h
+      {
+        name: @name,
+        description: @description,
+        instructions: @instructions,
+        trigger: @trigger,
+        tools: deep_dup(@tools),
+        mcp_servers: deep_dup(@mcp_servers),
+        providers: deep_dup(@provider_overrides),
+        source_path: @source_path
+      }.compact
+    end
+
+    private
+
+    def self.parse_markdown(content)
+      match = content.match(/\A---\s*\n(.*?)\n---\s*\n?(.*)\z/m)
+      raise ConfigurationError, "Skill markdown must begin with YAML frontmatter" unless match
+
+      frontmatter = YAML.safe_load(match[1], permitted_classes: [], aliases: false) || {}
+      unless frontmatter.is_a?(Hash)
+        raise ConfigurationError, "Skill frontmatter must be a Hash"
+      end
+
+      [frontmatter, match[2].to_s.strip]
+    end
+    private_class_method :parse_markdown
+
+    def normalize_name(name)
+      value = validate_string!(:name, name)
+      value.tr(" -", "__").to_sym
+    end
+
+    def validate_string!(field, value)
+      unless value.is_a?(String) || value.is_a?(Symbol)
+        raise ConfigurationError, "#{field} must be a String or Symbol"
+      end
+
+      string = value.to_s.strip
+      raise ConfigurationError, "#{field} is required" if string.empty?
+
+      string
+    end
+
+    def normalize_array(field, value)
+      return [].freeze if value.nil?
+
+      unless value.is_a?(Array)
+        raise ConfigurationError, "#{field} must be an Array"
+      end
+
+      deep_dup(value).freeze
+    end
+
+    def normalize_mcp_servers(mcp_servers)
+      normalize_array(:mcp_servers, mcp_servers).map do |server|
+        case server
+        when McpServer
+          server.to_h.freeze
+        when Hash
+          McpServer.from_hash(server).to_h.freeze
+        else
+          raise ConfigurationError, "Unsupported MCP server reference #{server.inspect} in skill definition"
+        end
+      end.freeze
+    end
+
+    def normalize_provider_overrides(providers)
+      return {}.freeze if providers.nil?
+
+      unless providers.is_a?(Hash)
+        raise ConfigurationError, "providers must be a Hash"
+      end
+
+      providers.each_with_object({}) do |(key, value), memo|
+        provider_key = normalize_provider_key(key)
+        memo[provider_key] = normalize_provider_override_value(provider_key, value)
+      end.freeze
+    end
+
+    def normalize_provider_override_value(provider_key, value)
+      case value
+      when true
+        (provider_key == :all) ? nil : {}
+      when nil
+        {}
+      when Hash
+        deep_dup(value).transform_keys(&:to_sym).freeze
+      else
+        raise ConfigurationError, "providers.#{provider_key} must be true or a Hash"
+      end
+    end
+
+    def normalize_provider_key(provider)
+      key = provider.to_sym
+      return :all if key == :all
+
+      registry = Providers::Registry.instance
+      canonical = registry.canonical_name(key)
+      raise ConfigurationError, "Unknown provider in skill definition: #{provider}" unless registry.registered?(canonical)
+
+      canonical.to_sym
+    end
+
+    def provider_lookup_key(provider)
+      key = provider.to_sym
+      return :all if key == :all
+
+      registry = Providers::Registry.instance
+      canonical = registry.canonical_name(key)
+      registry.registered?(canonical) ? canonical.to_sym : key
+    end
+
+    def deep_dup(value)
+      case value
+      when Array
+        value.map { |entry| deep_dup(entry) }
+      when Hash
+        value.each_with_object({}) { |(key, entry), copy| copy[key] = deep_dup(entry) }
+      else
+        value.dup
+      end
+    rescue TypeError
+      value
+    end
+  end
+end

--- a/lib/agent_harness/skill.rb
+++ b/lib/agent_harness/skill.rb
@@ -55,15 +55,10 @@ module AgentHarness
 
     def provider_override_for(provider)
       provider_key = provider_lookup_key(provider)
-      merged = {}
+      merged = ProviderRuntime.wrap(@provider_overrides[:all])
+      merged = merged ? merged.merge(@provider_overrides[provider_key]) : ProviderRuntime.wrap(@provider_overrides[provider_key])
 
-      all_override = @provider_overrides[:all]
-      merged.merge!(deep_dup(all_override)) if all_override
-
-      specific_override = @provider_overrides[provider_key]
-      merged.merge!(deep_dup(specific_override)) if specific_override
-
-      merged
+      merged ? merged.to_h : {}
     end
 
     def to_h

--- a/lib/agent_harness/skills.rb
+++ b/lib/agent_harness/skills.rb
@@ -21,7 +21,7 @@ module AgentHarness
         cache_key = [File.expand_path(cwd), File.expand_path(home)]
         discover(cwd: cwd, home: home)
 
-        combined_registry(cache_key).fetch(name.to_sym) do
+        combined_registry(cache_key).fetch(normalize_lookup_key(name)) do
           raise ConfigurationError, "Unknown skill: #{name}"
         end
       end
@@ -63,6 +63,10 @@ module AgentHarness
       end
 
       private
+
+      def normalize_lookup_key(name)
+        name.to_s.tr(" -", "__").to_sym
+      end
 
       def combined_registry(cache_key)
         discovered_registry = @discovered.fetch(cache_key)

--- a/lib/agent_harness/skills.rb
+++ b/lib/agent_harness/skills.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module AgentHarness
+  # Filesystem-backed registry for reusable agent skills.
+  module Skills
+    GLOBAL_SKILLS_DIR = File.join(".agent-harness", "skills")
+    PROJECT_SKILLS_DIR = File.join(".agent-harness", "skills")
+    SHARED_SKILLS_DIR = File.join(".agents", "skills")
+
+    class << self
+      def discover(cwd: Dir.pwd, home: Dir.home, refresh: false)
+        cache_key = [File.expand_path(cwd), File.expand_path(home)]
+        @discovered ||= {}
+        @registry ||= {}
+        @discovered.delete(cache_key) if refresh
+        @discovered[cache_key] ||= discover_registry(cwd: cwd, home: home)
+
+        combined_registry(cache_key).values
+      end
+
+      def find(name, cwd: Dir.pwd, home: Dir.home)
+        cache_key = [File.expand_path(cwd), File.expand_path(home)]
+        discover(cwd: cwd, home: home)
+
+        combined_registry(cache_key).fetch(name.to_sym) do
+          raise ConfigurationError, "Unknown skill: #{name}"
+        end
+      end
+
+      def register(name, attributes)
+        @registry ||= {}
+        skill = case attributes
+        when Skill
+          attributes
+        when Hash
+          Skill.from_hash(attributes.merge(name: name))
+        else
+          raise ConfigurationError, "Skill registration must be a Skill or Hash"
+        end
+
+        @registry[skill.name] = skill
+      end
+
+      def resolve(reference, cwd: Dir.pwd, home: Dir.home)
+        case reference
+        when nil
+          nil
+        when Skill
+          reference
+        when Hash
+          Skill.from_hash(reference)
+        else
+          find(reference, cwd: cwd, home: home)
+        end
+      end
+
+      def resolve_all(references, cwd: Dir.pwd, home: Dir.home)
+        Array(references).filter_map { |reference| resolve(reference, cwd: cwd, home: home) }
+      end
+
+      def reset!
+        @registry = {}
+        @discovered = {}
+      end
+
+      private
+
+      def combined_registry(cache_key)
+        discovered_registry = @discovered.fetch(cache_key)
+        discovered_registry.merge(@registry || {})
+      end
+
+      def discover_registry(cwd:, home:)
+        skill_paths_for(cwd: cwd, home: home).each_with_object({}) do |path, memo|
+          skill = Skill.load_file(path)
+          memo[skill.name] = skill
+        end
+      end
+
+      def skill_paths_for(cwd:, home:)
+        [
+          File.join(File.expand_path(home), GLOBAL_SKILLS_DIR),
+          File.join(File.expand_path(cwd), SHARED_SKILLS_DIR),
+          File.join(File.expand_path(cwd), PROJECT_SKILLS_DIR)
+        ].flat_map do |directory|
+          next [] unless Dir.exist?(directory)
+
+          direct_skill = File.join(directory, "SKILL.md")
+          nested_skills = Dir.glob(File.join(directory, "*", "SKILL.md")).sort
+          ([direct_skill] + nested_skills).select { |path| File.file?(path) }
+        end
+      end
+    end
+  end
+end

--- a/lib/agent_harness/skills.rb
+++ b/lib/agent_harness/skills.rb
@@ -3,8 +3,7 @@
 module AgentHarness
   # Filesystem-backed registry for reusable agent skills.
   module Skills
-    GLOBAL_SKILLS_DIR = File.join(".agent-harness", "skills")
-    PROJECT_SKILLS_DIR = File.join(".agent-harness", "skills")
+    AGENT_HARNESS_SKILLS_DIR = File.join(".agent-harness", "skills")
     SHARED_SKILLS_DIR = File.join(".agents", "skills")
 
     class << self
@@ -79,9 +78,9 @@ module AgentHarness
 
       def skill_paths_for(cwd:, home:)
         [
-          File.join(File.expand_path(home), GLOBAL_SKILLS_DIR),
+          File.join(File.expand_path(home), AGENT_HARNESS_SKILLS_DIR),
           File.join(File.expand_path(cwd), SHARED_SKILLS_DIR),
-          File.join(File.expand_path(cwd), PROJECT_SKILLS_DIR)
+          File.join(File.expand_path(cwd), AGENT_HARNESS_SKILLS_DIR)
         ].flat_map do |directory|
           next [] unless Dir.exist?(directory)
 

--- a/spec/agent_harness/configuration_spec.rb
+++ b/spec/agent_harness/configuration_spec.rb
@@ -146,6 +146,14 @@ RSpec.describe AgentHarness::Configuration do
       expect(tool.mapping_for(:anthropic)).to eq("Read")
       expect(tool.mapping_for(:openai)).to eq({type: "function", name: "read_file"})
     end
+
+    it "falls back from concrete providers to provider family mappings" do
+      config.register_tool(:read_file, anthropic: "Read", openai: {type: "function", name: "read_file"})
+
+      tool = config.tool_registry.fetch(:read_file)
+      expect(tool.mapping_for(:claude)).to eq("Read")
+      expect(tool.mapping_for(:github_copilot)).to eq({type: "function", name: "read_file"})
+    end
   end
 
   describe "#register_mcp_server" do

--- a/spec/agent_harness/provider_runtime_spec.rb
+++ b/spec/agent_harness/provider_runtime_spec.rb
@@ -334,5 +334,19 @@ RSpec.describe AgentHarness::ProviderRuntime do
         {type: "function", function: {name: "user_tool"}}
       ])
     end
+
+    it "raises ConfigurationError when chat_tools contain duplicate tool names" do
+      base = described_class.new(
+        chat_tools: [{type: "function", function: {name: "dup_tool"}}]
+      )
+      other = described_class.new(
+        chat_tools: [{type: "function", function: {name: "dup_tool"}}]
+      )
+
+      expect { base.merge(other) }.to raise_error(
+        AgentHarness::ConfigurationError,
+        /Duplicate chat tool names.*dup_tool/
+      )
+    end
   end
 end

--- a/spec/agent_harness/provider_runtime_spec.rb
+++ b/spec/agent_harness/provider_runtime_spec.rb
@@ -305,4 +305,34 @@ RSpec.describe AgentHarness::ProviderRuntime do
       expect(runtime).not_to be_empty
     end
   end
+
+  describe "#merge" do
+    it "merges hashes and arrays while letting explicit overrides win" do
+      base = described_class.new(
+        model: "skill-model",
+        env: {"SKILL_ENV" => "1"},
+        flags: ["--from-skill"],
+        metadata: {skill: true},
+        chat_tools: [{type: "function", function: {name: "skill_tool"}}]
+      )
+      override = described_class.new(
+        model: "user-model",
+        env: {"USER_ENV" => "1"},
+        flags: ["--from-user"],
+        metadata: {user: true},
+        chat_tools: [{type: "function", function: {name: "user_tool"}}]
+      )
+
+      merged = base.merge(override)
+
+      expect(merged.model).to eq("user-model")
+      expect(merged.env).to eq("SKILL_ENV" => "1", "USER_ENV" => "1")
+      expect(merged.flags).to eq(["--from-skill", "--from-user"])
+      expect(merged.metadata).to eq(skill: true, user: true)
+      expect(merged.chat_tools).to eq([
+        {type: "function", function: {name: "skill_tool"}},
+        {type: "function", function: {name: "user_tool"}}
+      ])
+    end
+  end
 end

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -478,6 +478,12 @@ RSpec.describe AgentHarness::Providers::Aider do
         provider.send_message(prompt: "Hello", skills: [:code_review])
       end
 
+      it "preserves configuration errors for unknown skills" do
+        expect {
+          provider.send_message(prompt: "Hello", skills: [:missing_skill])
+        }.to raise_error(AgentHarness::ConfigurationError, /Unknown skill: missing_skill/)
+      end
+
       it "parses comma-delimited token counts from command output when history lacks usage" do
         allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
           history_path = cmd[cmd.index("--llm-history-file") + 1]
@@ -879,6 +885,12 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(history_path).to match(%r{/tmp/aider_llm_history_})
         expect(plan[:env]).to eq({"AIDER_SKILL_ENV" => "1"})
         expect(plan[:preparation]).to be_nil
+      end
+
+      it "preserves configuration errors for unknown skills" do
+        expect {
+          provider.plan_execution(prompt: "Hello", skills: [:missing_skill])
+        }.to raise_error(AgentHarness::ConfigurationError, /Unknown skill: missing_skill/)
       end
     end
 

--- a/spec/agent_harness/providers/aider_spec.rb
+++ b/spec/agent_harness/providers/aider_spec.rb
@@ -454,6 +454,30 @@ RSpec.describe AgentHarness::Providers::Aider do
         expect(response.model).to eq("claude-3-5-sonnet")
       end
 
+      it "prepends skill instructions and merges skill runtime overrides" do
+        AgentHarness::Skills.register(:code_review, {
+          description: "Reviews code",
+          instructions: "Review the changed files before answering.",
+          providers: {
+            all: {
+              env: {"AIDER_SKILL_ENV" => "1"},
+              flags: ["--skill-flag"]
+            }
+          }
+        })
+
+        expect(mock_executor).to receive(:execute) do |cmd, env:, **|
+          expect(cmd).to include("--skill-flag")
+          expect(cmd).to include("Review the changed files before answering.\n\nHello")
+          expect(env).to eq({"AIDER_SKILL_ENV" => "1"})
+          history_path = cmd[cmd.index("--llm-history-file") + 1]
+          File.write(history_path, "")
+          result
+        end
+
+        provider.send_message(prompt: "Hello", skills: [:code_review])
+      end
+
       it "parses comma-delimited token counts from command output when history lacks usage" do
         allow(mock_executor).to receive(:execute) do |cmd, **kwargs|
           history_path = cmd[cmd.index("--llm-history-file") + 1]
@@ -831,6 +855,29 @@ RSpec.describe AgentHarness::Providers::Aider do
         history_path = plan[:command][plan[:command].index("--llm-history-file") + 1]
         expect(history_path).to match(%r{/tmp/aider_llm_history_})
         expect(plan[:env]).to eq({})
+        expect(plan[:preparation]).to be_nil
+      end
+
+      it "applies skill runtime overrides to the planned command" do
+        AgentHarness::Skills.register(:code_review, {
+          description: "Reviews code",
+          instructions: "Review the changed files before answering.",
+          providers: {
+            all: {
+              env: {"AIDER_SKILL_ENV" => "1"},
+              flags: ["--skill-flag"]
+            }
+          }
+        })
+        expect(mock_executor).not_to receive(:execute)
+
+        plan = provider.plan_execution(prompt: "Hello", skills: [:code_review])
+
+        expect(plan[:command]).to include("--skill-flag")
+        expect(plan[:command]).to include("Review the changed files before answering.\n\nHello")
+        history_path = plan[:command][plan[:command].index("--llm-history-file") + 1]
+        expect(history_path).to match(%r{/tmp/aider_llm_history_})
+        expect(plan[:env]).to eq({"AIDER_SKILL_ENV" => "1"})
         expect(plan[:preparation]).to be_nil
       end
     end

--- a/spec/agent_harness/providers/anthropic_spec.rb
+++ b/spec/agent_harness/providers/anthropic_spec.rb
@@ -1136,6 +1136,23 @@ RSpec.describe AgentHarness::Providers::Anthropic do
 
           provider.send_message(prompt: "Hello")
         end
+
+        it "does not convert skill tools into disallowed tools" do
+          AgentHarness.configuration.register_tool(:read_file, anthropic: "Read")
+          AgentHarness::Skills.register(:code_review, {
+            description: "Reviews code",
+            instructions: "Review the changed files before answering.",
+            tools: [:read_file]
+          })
+
+          allow(mock_executor).to receive(:execute) do |cmd, **_opts|
+            expect(cmd).not_to include("--disallowedTools")
+            expect(cmd).not_to include("--permission-mode")
+            success_result
+          end
+
+          provider.send_message(prompt: "Hello", skills: [:code_review])
+        end
       end
 
       context "when tools: is an empty array" do

--- a/spec/agent_harness/providers/anthropic_spec.rb
+++ b/spec/agent_harness/providers/anthropic_spec.rb
@@ -1305,6 +1305,36 @@ RSpec.describe AgentHarness::Providers::Anthropic do
           provider.send_message(prompt: "prompt", mode: :text)
         end
 
+        it "applies skill instructions before HTTP text-mode dispatch" do
+          AgentHarness::Skills.register(:code_review, {
+            description: "Reviews code",
+            instructions: "Review the changed files before answering."
+          })
+
+          http = instance_double(Net::HTTP)
+          allow(Net::HTTP).to receive(:new).and_return(http)
+          allow(http).to receive(:use_ssl=)
+          allow(http).to receive(:open_timeout=)
+          allow(http).to receive(:read_timeout=)
+
+          expect(http).to receive(:request) do |req|
+            body = JSON.parse(req.body)
+            expect(body.dig("messages", 0, "content")).to eq(
+              "Review the changed files before answering.\n\nprompt"
+            )
+
+            instance_double(Net::HTTPOK,
+              code: "200",
+              body: JSON.generate({
+                "content" => [{"type" => "text", "text" => "ok"}],
+                "model" => "claude-sonnet-4-20250514",
+                "usage" => {"input_tokens" => 1, "output_tokens" => 1}
+              }))
+          end
+
+          provider.send_message(prompt: "prompt", mode: :text, skills: [:code_review])
+        end
+
         it "raises AuthenticationError on 401 from API" do
           http_response = instance_double(Net::HTTPOK,
             code: "401",

--- a/spec/agent_harness/providers/anthropic_spec.rb
+++ b/spec/agent_harness/providers/anthropic_spec.rb
@@ -1137,7 +1137,7 @@ RSpec.describe AgentHarness::Providers::Anthropic do
           provider.send_message(prompt: "Hello")
         end
 
-        it "does not convert skill tools into disallowed tools" do
+        it "raises when a skill defines message-mode tools" do
           AgentHarness.configuration.register_tool(:read_file, anthropic: "Read")
           AgentHarness::Skills.register(:code_review, {
             description: "Reviews code",
@@ -1145,13 +1145,12 @@ RSpec.describe AgentHarness::Providers::Anthropic do
             tools: [:read_file]
           })
 
-          allow(mock_executor).to receive(:execute) do |cmd, **_opts|
-            expect(cmd).not_to include("--disallowedTools")
-            expect(cmd).not_to include("--permission-mode")
-            success_result
-          end
-
-          provider.send_message(prompt: "Hello", skills: [:code_review])
+          expect {
+            provider.send_message(prompt: "Hello", skills: [:code_review])
+          }.to raise_error(
+            AgentHarness::ConfigurationError,
+            /does not support message-mode tool injection/
+          )
         end
       end
 

--- a/spec/agent_harness/providers/base_send_chat_message_spec.rb
+++ b/spec/agent_harness/providers/base_send_chat_message_spec.rb
@@ -177,4 +177,52 @@ RSpec.describe AgentHarness::Providers::Base, "#send_chat_message" do
       extensions: [:schema_ext]
     )
   end
+
+  it "prepends skill instructions and skill tools in chat mode" do
+    AgentHarness.configuration.register_tool(
+      :read_file,
+      test_provider: {name: "read_file", description: "Read a file", parameters: {type: "object"}}
+    )
+    AgentHarness::Skills.register(:code_review, {
+      description: "Reviews code",
+      instructions: "Review the code before responding.",
+      tools: [:read_file]
+    })
+
+    transport = instance_double("chat transport")
+    provider.send(:set_chat_transport, transport)
+
+    expect(transport).to receive(:chat) do |messages:, tools:, **|
+      expect(messages.first).to eq({role: "system", content: "Review the code before responding."})
+      expect(tools).to eq([{name: "read_file", description: "Read a file", input_schema: {type: "object"}}])
+
+      AgentHarness::Response.new(
+        output: "done", exit_code: 0, duration: 1.0,
+        provider: :test_provider, model: "test-model"
+      )
+    end
+
+    provider.send_chat_message(
+      conversation: [{role: "user", content: "Hello"}],
+      skills: [:code_review]
+    )
+  end
+
+  it "raises when a skill requires MCP servers in chat mode" do
+    AgentHarness::Skills.register(:repo_access, {
+      description: "Adds repo MCP access",
+      instructions: "Use MCP when needed.",
+      mcp_servers: [{name: "github", transport: "http", url: "https://example.test/mcp"}]
+    })
+
+    transport = instance_double("chat transport")
+    provider.send(:set_chat_transport, transport)
+
+    expect {
+      provider.send_chat_message(
+        conversation: [{role: "user", content: "Hello"}],
+        skills: [:repo_access]
+      )
+    }.to raise_error(AgentHarness::McpUnsupportedError, /Chat mode does not support request-scoped MCP servers/)
+  end
 end

--- a/spec/agent_harness/providers/base_send_chat_message_spec.rb
+++ b/spec/agent_harness/providers/base_send_chat_message_spec.rb
@@ -469,6 +469,23 @@ RSpec.describe AgentHarness::Providers::Base, "#send_chat_message" do
     }.to raise_error(AgentHarness::McpUnsupportedError, /Chat mode does not support request-scoped MCP servers/)
   end
 
+  it "raises when a configured MCP server is present in chat mode" do
+    AgentHarness.configuration.register_mcp_server(
+      :github,
+      transport: "http",
+      url: "https://example.test/mcp"
+    )
+
+    transport = instance_double("chat transport")
+    provider.send(:set_chat_transport, transport)
+
+    expect {
+      provider.send_chat_message(
+        conversation: [{role: "user", content: "Hello"}]
+      )
+    }.to raise_error(AgentHarness::McpUnsupportedError, /Chat mode does not support request-scoped MCP servers/)
+  end
+
   it "raises when skill MCP servers conflict with explicit MCP servers" do
     AgentHarness::Skills.register(:repo_access, {
       description: "Adds repo MCP access",

--- a/spec/agent_harness/providers/base_send_chat_message_spec.rb
+++ b/spec/agent_harness/providers/base_send_chat_message_spec.rb
@@ -469,7 +469,7 @@ RSpec.describe AgentHarness::Providers::Base, "#send_chat_message" do
     }.to raise_error(AgentHarness::McpUnsupportedError, /Chat mode does not support request-scoped MCP servers/)
   end
 
-  it "raises when a configured MCP server is present in chat mode" do
+  it "ignores globally configured MCP servers when chat requests do not opt into MCP" do
     AgentHarness.configuration.register_mcp_server(
       :github,
       transport: "http",
@@ -479,11 +479,21 @@ RSpec.describe AgentHarness::Providers::Base, "#send_chat_message" do
     transport = instance_double("chat transport")
     provider.send(:set_chat_transport, transport)
 
-    expect {
-      provider.send_chat_message(
+    expect(transport).to receive(:chat) do |messages:, tools:, **|
+      expect(messages).to eq([{role: "user", content: "Hello"}])
+      expect(tools).to be_nil
+
+      AgentHarness::Response.new(
+        output: "done", exit_code: 0, duration: 1.0,
+        provider: :test_provider, model: "test-model"
+      )
+    end
+
+    response = provider.send_chat_message(
         conversation: [{role: "user", content: "Hello"}]
       )
-    }.to raise_error(AgentHarness::McpUnsupportedError, /Chat mode does not support request-scoped MCP servers/)
+
+    expect(response.output).to eq("done")
   end
 
   it "raises when skill MCP servers conflict with explicit MCP servers" do

--- a/spec/agent_harness/providers/base_send_chat_message_spec.rb
+++ b/spec/agent_harness/providers/base_send_chat_message_spec.rb
@@ -241,6 +241,55 @@ RSpec.describe AgentHarness::Providers::Base, "#send_chat_message" do
     )
   end
 
+  it "resolves OpenAI-family skill tool mappings for concrete providers" do
+    concrete_provider_class = Class.new(test_provider_class) do
+      class << self
+        def provider_name
+          :github_copilot
+        end
+      end
+
+      def chat_transport_type
+        :openai_compatible
+      end
+    end
+
+    concrete_provider = concrete_provider_class.new(config: config, executor: mock_executor)
+    AgentHarness.configuration.register_tool(
+      :read_file,
+      openai: {name: "read_file", description: "Read a file", parameters: {type: "object"}}
+    )
+    AgentHarness::Skills.register(:repo_access, {
+      description: "Adds repo helpers",
+      instructions: "Use repo helpers when needed.",
+      tools: [:read_file]
+    })
+
+    transport = instance_double("chat transport")
+    concrete_provider.send(:set_chat_transport, transport)
+
+    expect(transport).to receive(:chat) do |tools:, **|
+      expect(tools).to eq([{
+        type: "function",
+        function: {
+          name: "read_file",
+          description: "Read a file",
+          parameters: {type: "object"}
+        }
+      }])
+
+      AgentHarness::Response.new(
+        output: "done", exit_code: 0, duration: 1.0,
+        provider: :github_copilot, model: "test-model"
+      )
+    end
+
+    concrete_provider.send_chat_message(
+      conversation: [{role: "user", content: "Hello"}],
+      skills: [:repo_access]
+    )
+  end
+
   it "merges explicit chat tools with provider-specific skill chat tools" do
     explicit_tool = {type: "function", function: {name: "explicit_tool"}}
     AgentHarness::Skills.register(:repo_access, {

--- a/spec/agent_harness/providers/base_send_chat_message_spec.rb
+++ b/spec/agent_harness/providers/base_send_chat_message_spec.rb
@@ -208,6 +208,39 @@ RSpec.describe AgentHarness::Providers::Base, "#send_chat_message" do
     )
   end
 
+  it "normalizes bare skill tool refs for OpenAI-compatible chat transports" do
+    openai_provider_class = Class.new(test_provider_class) do
+      def chat_transport_type
+        :openai_compatible
+      end
+    end
+
+    openai_provider = openai_provider_class.new(config: config, executor: mock_executor)
+    AgentHarness::Skills.register(:repo_access, {
+      description: "Adds repo helpers",
+      instructions: "Use repo helpers when needed.",
+      tools: [:read_file]
+    })
+
+    transport = instance_double("chat transport")
+    openai_provider.send(:set_chat_transport, transport)
+
+    expect(transport).to receive(:chat) do |messages:, tools:, **|
+      expect(messages.first).to eq({role: "system", content: "Use repo helpers when needed."})
+      expect(tools).to eq([{type: "function", function: {name: "read_file"}}])
+
+      AgentHarness::Response.new(
+        output: "done", exit_code: 0, duration: 1.0,
+        provider: :test_provider, model: "test-model"
+      )
+    end
+
+    openai_provider.send_chat_message(
+      conversation: [{role: "user", content: "Hello"}],
+      skills: [:repo_access]
+    )
+  end
+
   it "merges explicit chat tools with provider-specific skill chat tools" do
     explicit_tool = {type: "function", function: {name: "explicit_tool"}}
     AgentHarness::Skills.register(:repo_access, {

--- a/spec/agent_harness/providers/base_send_chat_message_spec.rb
+++ b/spec/agent_harness/providers/base_send_chat_message_spec.rb
@@ -243,6 +243,36 @@ RSpec.describe AgentHarness::Providers::Base, "#send_chat_message" do
     )
   end
 
+  it "does not double-merge provider-specific skill chat tools when tools are omitted" do
+    AgentHarness::Skills.register(:repo_access, {
+      description: "Adds repo helpers",
+      instructions: "Use repo helpers when needed.",
+      providers: {
+        all: {
+          chat_tools: [{type: "function", function: {name: "skill_tool"}}]
+        }
+      }
+    })
+
+    transport = instance_double("chat transport")
+    provider.send(:set_chat_transport, transport)
+
+    expect(transport).to receive(:chat) do |messages:, tools:, **|
+      expect(messages.first).to eq({role: "system", content: "Use repo helpers when needed."})
+      expect(tools).to eq([{type: "function", function: {name: "skill_tool"}}])
+
+      AgentHarness::Response.new(
+        output: "done", exit_code: 0, duration: 1.0,
+        provider: :test_provider, model: "test-model"
+      )
+    end
+
+    provider.send_chat_message(
+      conversation: [{role: "user", content: "Hello"}],
+      skills: [:repo_access]
+    )
+  end
+
   it "prefers explicit chat tools over runtime chat_tools while still merging skill chat tools" do
     explicit_tool = {type: "function", function: {name: "explicit_tool"}}
     runtime = AgentHarness::ProviderRuntime.new(

--- a/spec/agent_harness/providers/base_send_chat_message_spec.rb
+++ b/spec/agent_harness/providers/base_send_chat_message_spec.rb
@@ -208,6 +208,39 @@ RSpec.describe AgentHarness::Providers::Base, "#send_chat_message" do
     )
   end
 
+  it "preserves structured system message content when prepending skill instructions" do
+    AgentHarness::Skills.register(:code_review, {
+      description: "Reviews code",
+      instructions: "Review the code before responding."
+    })
+
+    transport = instance_double("chat transport")
+    provider.send(:set_chat_transport, transport)
+
+    expect(transport).to receive(:chat) do |messages:, **|
+      expect(messages.first).to eq({
+        role: "system",
+        content: [
+          {type: "text", text: "Review the code before responding.\n\n"},
+          {type: "text", text: "Keep JSON schema"}
+        ]
+      })
+
+      AgentHarness::Response.new(
+        output: "done", exit_code: 0, duration: 1.0,
+        provider: :test_provider, model: "test-model"
+      )
+    end
+
+    provider.send_chat_message(
+      conversation: [
+        {role: "system", content: [{type: "text", text: "Keep JSON schema"}]},
+        {role: "user", content: "Hello"}
+      ],
+      skills: [:code_review]
+    )
+  end
+
   it "normalizes bare skill tool refs for OpenAI-compatible chat transports" do
     openai_provider_class = Class.new(test_provider_class) do
       def chat_transport_type

--- a/spec/agent_harness/providers/base_send_chat_message_spec.rb
+++ b/spec/agent_harness/providers/base_send_chat_message_spec.rb
@@ -243,6 +243,45 @@ RSpec.describe AgentHarness::Providers::Base, "#send_chat_message" do
     )
   end
 
+  it "prefers explicit chat tools over runtime chat_tools while still merging skill chat tools" do
+    explicit_tool = {type: "function", function: {name: "explicit_tool"}}
+    runtime = AgentHarness::ProviderRuntime.new(
+      chat_tools: [{type: "function", function: {name: "runtime_tool"}}]
+    )
+    AgentHarness::Skills.register(:repo_access, {
+      description: "Adds repo helpers",
+      instructions: "Use repo helpers when needed.",
+      providers: {
+        all: {
+          chat_tools: [{type: "function", function: {name: "skill_tool"}}]
+        }
+      }
+    })
+
+    transport = instance_double("chat transport")
+    provider.send(:set_chat_transport, transport)
+
+    expect(transport).to receive(:chat) do |messages:, tools:, **|
+      expect(messages.first).to eq({role: "system", content: "Use repo helpers when needed."})
+      expect(tools).to eq([
+        explicit_tool,
+        {type: "function", function: {name: "skill_tool"}}
+      ])
+
+      AgentHarness::Response.new(
+        output: "done", exit_code: 0, duration: 1.0,
+        provider: :test_provider, model: "test-model"
+      )
+    end
+
+    provider.send_chat_message(
+      conversation: [{role: "user", content: "Hello"}],
+      tools: [explicit_tool],
+      provider_runtime: runtime,
+      skills: [:repo_access]
+    )
+  end
+
   it "raises when explicit chat tools conflict with provider-specific skill chat tools" do
     explicit_tool = {type: "function", function: {name: "shared_tool"}}
     AgentHarness::Skills.register(:repo_access, {
@@ -283,5 +322,31 @@ RSpec.describe AgentHarness::Providers::Base, "#send_chat_message" do
         skills: [:repo_access]
       )
     }.to raise_error(AgentHarness::McpUnsupportedError, /Chat mode does not support request-scoped MCP servers/)
+  end
+
+  it "raises when skill MCP servers conflict with explicit MCP servers" do
+    AgentHarness::Skills.register(:repo_access, {
+      description: "Adds repo MCP access",
+      instructions: "Use MCP when needed.",
+      mcp_servers: [{name: "github", transport: "http", url: "https://example.test/skill-mcp"}]
+    })
+
+    capable_provider_class = Class.new(test_provider_class) do
+      def capabilities
+        super.merge(mcp: true)
+      end
+    end
+    capable_provider = capable_provider_class.new(config: config, executor: mock_executor)
+
+    expect {
+      capable_provider.send_message(
+        prompt: "Hello",
+        mcp_servers: [{name: "github", transport: "http", url: "https://example.test/explicit-mcp"}],
+        skills: [:repo_access]
+      )
+    }.to raise_error(
+      AgentHarness::ConfigurationError,
+      /MCP server name conflict across explicit and skill servers: github \(explicit, skill: repo_access\)/
+    )
   end
 end

--- a/spec/agent_harness/providers/base_send_chat_message_spec.rb
+++ b/spec/agent_harness/providers/base_send_chat_message_spec.rb
@@ -208,6 +208,65 @@ RSpec.describe AgentHarness::Providers::Base, "#send_chat_message" do
     )
   end
 
+  it "merges explicit chat tools with provider-specific skill chat tools" do
+    explicit_tool = {type: "function", function: {name: "explicit_tool"}}
+    AgentHarness::Skills.register(:repo_access, {
+      description: "Adds repo helpers",
+      instructions: "Use repo helpers when needed.",
+      providers: {
+        all: {
+          chat_tools: [{type: "function", function: {name: "skill_tool"}}]
+        }
+      }
+    })
+
+    transport = instance_double("chat transport")
+    provider.send(:set_chat_transport, transport)
+
+    expect(transport).to receive(:chat) do |messages:, tools:, **|
+      expect(messages.first).to eq({role: "system", content: "Use repo helpers when needed."})
+      expect(tools).to eq([
+        explicit_tool,
+        {type: "function", function: {name: "skill_tool"}}
+      ])
+
+      AgentHarness::Response.new(
+        output: "done", exit_code: 0, duration: 1.0,
+        provider: :test_provider, model: "test-model"
+      )
+    end
+
+    provider.send_chat_message(
+      conversation: [{role: "user", content: "Hello"}],
+      tools: [explicit_tool],
+      skills: [:repo_access]
+    )
+  end
+
+  it "raises when explicit chat tools conflict with provider-specific skill chat tools" do
+    explicit_tool = {type: "function", function: {name: "shared_tool"}}
+    AgentHarness::Skills.register(:repo_access, {
+      description: "Adds repo helpers",
+      instructions: "Use repo helpers when needed.",
+      providers: {
+        all: {
+          chat_tools: [{type: "function", function: {name: "shared_tool"}}]
+        }
+      }
+    })
+
+    transport = instance_double("chat transport")
+    provider.send(:set_chat_transport, transport)
+
+    expect {
+      provider.send_chat_message(
+        conversation: [{role: "user", content: "Hello"}],
+        tools: [explicit_tool],
+        skills: [:repo_access]
+      )
+    }.to raise_error(AgentHarness::ConfigurationError, /shared_tool/)
+  end
+
   it "raises when a skill requires MCP servers in chat mode" do
     AgentHarness::Skills.register(:repo_access, {
       description: "Adds repo MCP access",

--- a/spec/agent_harness/providers/base_send_message_spec.rb
+++ b/spec/agent_harness/providers/base_send_message_spec.rb
@@ -156,6 +156,58 @@ RSpec.describe AgentHarness::Providers::Base, "#send_message" do
       expect(response.output).to eq("response output [extended]")
     end
 
+    it "prepends skill instructions and merges provider runtime overrides" do
+      AgentHarness::Skills.register(:code_review, {
+        description: "Reviews code",
+        instructions: "Review the changed files before answering.",
+        providers: {
+          all: {
+            model: "skill-model",
+            flags: ["--from-skill"],
+            env: {"SKILL_ENV" => "1"}
+          }
+        }
+      })
+
+      expect(mock_executor).to receive(:execute) do |command, env:, **|
+        expect(command).to include("Review the changed files before answering.\n\nHello")
+        expect(env).to include("SKILL_ENV" => "1")
+
+        AgentHarness::CommandExecutor::Result.new(
+          stdout: "response output",
+          stderr: "",
+          exit_code: 0,
+          duration: 1.0
+        )
+      end
+
+      response = provider.send_message(prompt: "Hello", skills: [:code_review])
+      expect(response.model).to eq("skill-model")
+    end
+
+    it "merges skill mcp servers into message-mode options" do
+      AgentHarness::Skills.register(:repo_access, {
+        description: "Adds repo MCP access",
+        instructions: "Use MCP when needed.",
+        mcp_servers: [{name: "github", transport: "stdio", command: "npx", args: ["server-github"]}]
+      })
+
+      capable_provider_class = Class.new(test_provider_class) do
+        def capabilities
+          super.merge(mcp: true)
+        end
+      end
+      capable_provider = capable_provider_class.new(config: config, executor: mock_executor)
+
+      expect(capable_provider).to receive(:build_command).and_wrap_original do |original, prompt, options|
+        expect(prompt).to include("Use MCP when needed.")
+        expect(options[:mcp_servers].map(&:name)).to eq(["github"])
+        original.call(prompt, options)
+      end
+
+      capable_provider.send_message(prompt: "Hello", skills: [:repo_access])
+    end
+
     it "rejects extensions with tools in message mode" do
       # Use a provider that supports tool_use so capability validation passes
       # and the message-mode rejection is what fires.

--- a/spec/agent_harness/providers/base_send_message_spec.rb
+++ b/spec/agent_harness/providers/base_send_message_spec.rb
@@ -208,6 +208,33 @@ RSpec.describe AgentHarness::Providers::Base, "#send_message" do
       capable_provider.send_message(prompt: "Hello", skills: [:repo_access])
     end
 
+    it "raises a skill-aware error when multiple skills define the same MCP server name" do
+      AgentHarness::Skills.register(:repo_access, {
+        description: "Adds repo MCP access",
+        instructions: "Use repo MCP when needed.",
+        mcp_servers: [{name: "github", transport: "stdio", command: "npx", args: ["repo-server"]}]
+      })
+      AgentHarness::Skills.register(:docs_access, {
+        description: "Adds docs MCP access",
+        instructions: "Use docs MCP when needed.",
+        mcp_servers: [{name: "github", transport: "stdio", command: "npx", args: ["docs-server"]}]
+      })
+
+      capable_provider_class = Class.new(test_provider_class) do
+        def capabilities
+          super.merge(mcp: true)
+        end
+      end
+      capable_provider = capable_provider_class.new(config: config, executor: mock_executor)
+
+      expect {
+        capable_provider.send_message(prompt: "Hello", skills: %i[repo_access docs_access])
+      }.to raise_error(
+        AgentHarness::ConfigurationError,
+        /MCP server name conflict across explicit and skill servers: github \(skill: repo_access, skill: docs_access\)/
+      )
+    end
+
     it "rejects extensions with tools in message mode" do
       # Use a provider that supports tool_use so capability validation passes
       # and the message-mode rejection is what fires.

--- a/spec/agent_harness/providers/base_send_message_spec.rb
+++ b/spec/agent_harness/providers/base_send_message_spec.rb
@@ -264,6 +264,21 @@ RSpec.describe AgentHarness::Providers::Base, "#send_message" do
       )
     end
 
+    it "raises when a skill defines message-mode tools but the provider does not support tool injection" do
+      AgentHarness::Skills.register(:code_tools, {
+        description: "Adds coding tools",
+        instructions: "Use coding tools.",
+        tools: [{name: "lint"}]
+      })
+
+      expect {
+        provider.send_message(prompt: "Hello", skills: [:code_tools])
+      }.to raise_error(
+        AgentHarness::ConfigurationError,
+        /does not support message-mode tool injection/
+      )
+    end
+
     it "rejects extensions with tools in message mode" do
       # Use a provider that supports tool_use so capability validation passes
       # and the message-mode rejection is what fires.

--- a/spec/agent_harness/providers/base_send_message_spec.rb
+++ b/spec/agent_harness/providers/base_send_message_spec.rb
@@ -208,6 +208,35 @@ RSpec.describe AgentHarness::Providers::Base, "#send_message" do
       capable_provider.send_message(prompt: "Hello", skills: [:repo_access])
     end
 
+    it "preserves configured MCP servers when skills add request-scoped MCP servers" do
+      AgentHarness.configuration.register_mcp_server(
+        :filesystem,
+        transport: "stdio",
+        command: "npx",
+        args: ["server-filesystem"]
+      )
+      AgentHarness::Skills.register(:repo_access, {
+        description: "Adds repo MCP access",
+        instructions: "Use MCP when needed.",
+        mcp_servers: [{name: "github", transport: "stdio", command: "npx", args: ["server-github"]}]
+      })
+
+      capable_provider_class = Class.new(test_provider_class) do
+        def capabilities
+          super.merge(mcp: true)
+        end
+      end
+      capable_provider = capable_provider_class.new(config: config, executor: mock_executor)
+
+      expect(capable_provider).to receive(:build_command).and_wrap_original do |original, prompt, options|
+        expect(prompt).to include("Use MCP when needed.")
+        expect(options[:mcp_servers].map(&:name)).to eq(%w[filesystem github])
+        original.call(prompt, options)
+      end
+
+      capable_provider.send_message(prompt: "Hello", skills: [:repo_access])
+    end
+
     it "raises a skill-aware error when multiple skills define the same MCP server name" do
       AgentHarness::Skills.register(:repo_access, {
         description: "Adds repo MCP access",

--- a/spec/agent_harness/providers/base_spec.rb
+++ b/spec/agent_harness/providers/base_spec.rb
@@ -92,6 +92,27 @@ RSpec.describe AgentHarness::Providers::Base do
         "Sub-agent role: code_reviewer\nDescription: Reviews code\n\nFollow these sub-agent instructions exactly:\nReview the provided changes\n\nUser task:\nHello"
       ])
     end
+
+    it "applies skill instructions and runtime overrides to the planned command" do
+      AgentHarness::Skills.register(:code_review, {
+        description: "Reviews code",
+        instructions: "Review the changed files before answering.",
+        providers: {
+          all: {
+            flags: ["--from-skill"],
+            env: {"SKILL_ENV" => "1"}
+          }
+        }
+      })
+
+      plan = provider.plan_execution(prompt: "Hello", skills: [:code_review])
+
+      expect(plan).to eq(
+        command: ["echo", "Review the changed files before answering.\n\nHello"],
+        env: {"SKILL_ENV" => "1"},
+        preparation: nil
+      )
+    end
   end
 
   describe "#name" do

--- a/spec/agent_harness/providers/base_spec.rb
+++ b/spec/agent_harness/providers/base_spec.rb
@@ -113,6 +113,12 @@ RSpec.describe AgentHarness::Providers::Base do
         preparation: nil
       )
     end
+
+    it "preserves configuration errors for unknown skills" do
+      expect {
+        provider.plan_execution(prompt: "Hello", skills: [:missing_skill])
+      }.to raise_error(AgentHarness::ConfigurationError, /Unknown skill: missing_skill/)
+    end
   end
 
   describe "#name" do

--- a/spec/agent_harness/providers/chat_capability_spec.rb
+++ b/spec/agent_harness/providers/chat_capability_spec.rb
@@ -159,14 +159,17 @@ RSpec.describe "Provider chat capability" do
         )
       end
 
-      it "prefers explicit tools over runtime chat_tools" do
+      it "merges explicit tools with runtime chat_tools" do
         runtime = AgentHarness::ProviderRuntime.new(
           chat_tools: [{type: "function", function: {name: "runtime_tool"}}]
         )
         explicit_tools = [{type: "function", function: {name: "explicit_tool"}}]
 
         expect(mock_transport).to receive(:chat).with(
-          hash_including(tools: explicit_tools)
+          hash_including(tools: [
+            {type: "function", function: {name: "explicit_tool"}},
+            {type: "function", function: {name: "runtime_tool"}}
+          ])
         ).and_return(response)
 
         provider.send_chat_message(

--- a/spec/agent_harness/providers/chat_capability_spec.rb
+++ b/spec/agent_harness/providers/chat_capability_spec.rb
@@ -159,17 +159,14 @@ RSpec.describe "Provider chat capability" do
         )
       end
 
-      it "merges explicit tools with runtime chat_tools" do
+      it "prefers explicit tools over runtime chat_tools" do
         runtime = AgentHarness::ProviderRuntime.new(
           chat_tools: [{type: "function", function: {name: "runtime_tool"}}]
         )
         explicit_tools = [{type: "function", function: {name: "explicit_tool"}}]
 
         expect(mock_transport).to receive(:chat).with(
-          hash_including(tools: [
-            {type: "function", function: {name: "explicit_tool"}},
-            {type: "function", function: {name: "runtime_tool"}}
-          ])
+          hash_including(tools: explicit_tools)
         ).and_return(response)
 
         provider.send_chat_message(

--- a/spec/agent_harness/providers/cursor_spec.rb
+++ b/spec/agent_harness/providers/cursor_spec.rb
@@ -377,6 +377,12 @@ RSpec.describe AgentHarness::Providers::Cursor do
         provider.send_message(prompt: "Hello", skills: [:code_review])
       end
 
+      it "preserves configuration errors for unknown skills" do
+        expect {
+          provider.send_message(prompt: "Hello", skills: [:missing_skill])
+        }.to raise_error(AgentHarness::ConfigurationError, /Unknown skill: missing_skill/)
+      end
+
       it "passes through execution hooks" do
         allow(mock_executor).to receive(:execute).and_return(
           AgentHarness::CommandExecutor::Result.new(
@@ -639,6 +645,12 @@ RSpec.describe AgentHarness::Providers::Cursor do
           env: {"CURSOR_SKILL_ENV" => "1"},
           preparation: nil
         )
+      end
+
+      it "preserves configuration errors for unknown skills" do
+        expect {
+          provider.plan_execution(prompt: "Hello", skills: [:missing_skill])
+        }.to raise_error(AgentHarness::ConfigurationError, /Unknown skill: missing_skill/)
       end
     end
 

--- a/spec/agent_harness/providers/cursor_spec.rb
+++ b/spec/agent_harness/providers/cursor_spec.rb
@@ -345,6 +345,38 @@ RSpec.describe AgentHarness::Providers::Cursor do
         provider.send_message(prompt: "Hello", timeout: 60)
       end
 
+      it "prepends skill instructions and merges skill runtime overrides" do
+        AgentHarness::Skills.register(:code_review, {
+          description: "Reviews code",
+          instructions: "Review the changed files before answering.",
+          providers: {
+            all: {
+              env: {"CURSOR_SKILL_ENV" => "1"},
+              flags: ["--skill-flag"]
+            }
+          }
+        })
+
+        allow(mock_executor).to receive(:execute).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: "ok",
+            stderr: "",
+            exit_code: 0,
+            duration: 1.0
+          )
+        )
+
+        expect(mock_executor).to receive(:execute).with(
+          [described_class.binary_name, "-p", "--skill-flag"],
+          hash_including(
+            env: {"CURSOR_SKILL_ENV" => "1"},
+            stdin_data: "Review the changed files before answering.\n\nHello"
+          )
+        )
+
+        provider.send_message(prompt: "Hello", skills: [:code_review])
+      end
+
       it "passes through execution hooks" do
         allow(mock_executor).to receive(:execute).and_return(
           AgentHarness::CommandExecutor::Result.new(
@@ -585,6 +617,28 @@ RSpec.describe AgentHarness::Providers::Cursor do
         plan = provider.plan_execution(prompt: "Hello", provider_runtime: runtime)
 
         expect(plan[:command]).to eq([described_class.binary_name, "-p", "--verbose"])
+      end
+
+      it "applies skill runtime overrides to the planned command" do
+        AgentHarness::Skills.register(:code_review, {
+          description: "Reviews code",
+          instructions: "Review the changed files before answering.",
+          providers: {
+            all: {
+              env: {"CURSOR_SKILL_ENV" => "1"},
+              flags: ["--skill-flag"]
+            }
+          }
+        })
+        expect(mock_executor).not_to receive(:execute)
+
+        plan = provider.plan_execution(prompt: "Hello", skills: [:code_review])
+
+        expect(plan).to eq(
+          command: [described_class.binary_name, "-p", "--skill-flag"],
+          env: {"CURSOR_SKILL_ENV" => "1"},
+          preparation: nil
+        )
       end
     end
 

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -1194,6 +1194,51 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         provider.send_message(prompt: "Hello", provider_runtime: runtime)
       end
 
+      it "prepends skill instructions and merges skill runtime overrides" do
+        AgentHarness::Skills.register(:code_review, {
+          description: "Reviews code",
+          instructions: "Review the changed files before answering.",
+          providers: {
+            all: {
+              env: {"COPILOT_SKILL_ENV" => "1"},
+              model: "gpt-4o-mini"
+            }
+          }
+        })
+        jsonl_output = [
+          {"text" => "response"},
+          {"usage" => {"input_tokens" => 10, "output_tokens" => 5}}
+        ].map { |o| JSON.generate(o) }.join("\n")
+
+        allow(mock_executor).to receive(:execute).with(
+          ["github-copilot-cli", "--version"],
+          timeout: 5,
+          env: {"COPILOT_SKILL_ENV" => "1"}
+        ).and_return(version_result)
+
+        expect(mock_executor).to receive(:execute).with(
+          [
+            "github-copilot-cli",
+            "-p",
+            "Review the changed files before answering.\n\nHello",
+            "--output-format",
+            "json",
+            "--model",
+            "gpt-4o-mini"
+          ],
+          hash_including(env: {"COPILOT_SKILL_ENV" => "1"})
+        ).and_return(
+          AgentHarness::CommandExecutor::Result.new(
+            stdout: jsonl_output,
+            stderr: "",
+            exit_code: 0,
+            duration: 1.0
+          )
+        )
+
+        provider.send_message(prompt: "Hello", skills: [:code_review])
+      end
+
       it "uses the remaining request timeout budget for the prompt command and includes probe time in duration" do
         allow(mock_executor).to receive(:execute).with(
           ["github-copilot-cli", "--version"],
@@ -3180,6 +3225,39 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         expect(plan).to eq(
           command: ["github-copilot-cli", "-p", "Hello", "-s"],
           env: {},
+          preparation: nil
+        )
+      end
+
+      it "applies skill instructions and runtime overrides to the planned command" do
+        AgentHarness::Skills.register(:code_review, {
+          description: "Reviews code",
+          instructions: "Review the changed files before answering.",
+          providers: {
+            all: {
+              env: {"COPILOT_SKILL_ENV" => "1"},
+              model: "gpt-4o-mini"
+            }
+          }
+        })
+        provider.instance_variable_set(:@copilot_cli_versions, {
+          provider.send(:version_probe_cache_key, {"COPILOT_SKILL_ENV" => "1"}) => Gem::Version.new("0.0.422")
+        })
+        expect(mock_executor).not_to receive(:execute)
+
+        plan = provider.plan_execution(prompt: "Hello", skills: [:code_review])
+
+        expect(plan).to eq(
+          command: [
+            "github-copilot-cli",
+            "-p",
+            "Review the changed files before answering.\n\nHello",
+            "--output-format",
+            "json",
+            "--model",
+            "gpt-4o-mini"
+          ],
+          env: {"COPILOT_SKILL_ENV" => "1"},
           preparation: nil
         )
       end

--- a/spec/agent_harness/providers/github_copilot_spec.rb
+++ b/spec/agent_harness/providers/github_copilot_spec.rb
@@ -1239,6 +1239,12 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
         provider.send_message(prompt: "Hello", skills: [:code_review])
       end
 
+      it "preserves configuration errors for unknown skills" do
+        expect {
+          provider.send_message(prompt: "Hello", skills: [:missing_skill])
+        }.to raise_error(AgentHarness::ConfigurationError, /Unknown skill: missing_skill/)
+      end
+
       it "uses the remaining request timeout budget for the prompt command and includes probe time in duration" do
         allow(mock_executor).to receive(:execute).with(
           ["github-copilot-cli", "--version"],
@@ -3260,6 +3266,12 @@ RSpec.describe AgentHarness::Providers::GithubCopilot do
           env: {"COPILOT_SKILL_ENV" => "1"},
           preparation: nil
         )
+      end
+
+      it "preserves configuration errors for unknown skills" do
+        expect {
+          provider.plan_execution(prompt: "Hello", skills: [:missing_skill])
+        }.to raise_error(AgentHarness::ConfigurationError, /Unknown skill: missing_skill/)
       end
     end
 

--- a/spec/agent_harness/skill_spec.rb
+++ b/spec/agent_harness/skill_spec.rb
@@ -57,6 +57,29 @@ RSpec.describe AgentHarness::Skill do
       )
     end
 
+    it "applies provider-family overrides to concrete providers" do
+      skill = described_class.from_hash(
+        name: "code-review",
+        description: "Review code",
+        instructions: "Inspect the diff",
+        providers: {
+          openai: {
+            flags: ["--openai-family"],
+            env: {"OPENAI_FAMILY" => "1"}
+          },
+          github_copilot: {
+            model: "gpt-4o"
+          }
+        }
+      )
+
+      expect(skill.provider_override_for(:github_copilot)).to eq(
+        flags: ["--openai-family"],
+        env: {"OPENAI_FAMILY" => "1"},
+        model: "gpt-4o"
+      )
+    end
+
     it "requires the name, description, and instructions" do
       expect {
         described_class.from_hash(description: "Missing name", instructions: "Body")

--- a/spec/agent_harness/skill_spec.rb
+++ b/spec/agent_harness/skill_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe AgentHarness::Skill do
+  describe ".from_hash" do
+    it "builds a canonical skill definition" do
+      skill = described_class.from_hash(
+        name: "code-review",
+        description: "Review code",
+        instructions: "Inspect the diff",
+        trigger: "when reviewing code",
+        tools: [:read_file],
+        mcp_servers: [{name: "github", transport: "http", url: "https://example.test/mcp"}],
+        providers: {
+          all: {flags: ["--verbose"]},
+          codex: {model: "gpt-5-codex"}
+        }
+      )
+
+      expect(skill.name).to eq(:code_review)
+      expect(skill.description).to eq("Review code")
+      expect(skill.instructions).to eq("Inspect the diff")
+      expect(skill.trigger).to eq("when reviewing code")
+      expect(skill.tools).to eq([:read_file])
+      expect(skill.mcp_servers).to eq([{name: "github", transport: "http", url: "https://example.test/mcp"}])
+      expect(skill.provider_override_for(:codex)).to eq(flags: ["--verbose"], model: "gpt-5-codex")
+    end
+
+    it "requires the name, description, and instructions" do
+      expect {
+        described_class.from_hash(description: "Missing name", instructions: "Body")
+      }.to raise_error(AgentHarness::ConfigurationError, /name is required/)
+    end
+
+    it "validates provider references" do
+      expect {
+        described_class.from_hash(
+          name: "bad-provider",
+          description: "Bad",
+          instructions: "Body",
+          providers: {unknown_provider: {model: "x"}}
+        )
+      }.to raise_error(AgentHarness::ConfigurationError, /Unknown provider/)
+    end
+  end
+
+  describe ".load_file" do
+    it "loads markdown frontmatter and body" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "SKILL.md")
+        File.write(path, <<~MARKDOWN)
+          ---
+          name: code-review
+          description: Review code
+          providers:
+            codex:
+              flags:
+                - --full-auto
+          ---
+          Review the pull request carefully.
+        MARKDOWN
+
+        skill = described_class.load_file(path)
+        expect(skill.name).to eq(:code_review)
+        expect(skill.instructions).to eq("Review the pull request carefully.")
+        expect(skill.provider_override_for(:codex)).to eq(flags: ["--full-auto"])
+        expect(skill.source_path).to eq(path)
+      end
+    end
+
+    it "rejects markdown without frontmatter" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "SKILL.md")
+        File.write(path, "# No frontmatter")
+
+        expect {
+          described_class.load_file(path)
+        }.to raise_error(AgentHarness::ConfigurationError, /must begin with YAML frontmatter/)
+      end
+    end
+  end
+end

--- a/spec/agent_harness/skill_spec.rb
+++ b/spec/agent_harness/skill_spec.rb
@@ -25,6 +25,38 @@ RSpec.describe AgentHarness::Skill do
       expect(skill.provider_override_for(:codex)).to eq(flags: ["--verbose"], model: "gpt-5-codex")
     end
 
+    it "deep merges provider-specific runtime overrides with the shared baseline" do
+      skill = described_class.from_hash(
+        name: "code-review",
+        description: "Review code",
+        instructions: "Inspect the diff",
+        providers: {
+          all: {
+            env: {"A" => "1"},
+            flags: ["--shared"],
+            metadata: {tier: "shared"},
+            unset_env: ["OLD_TOKEN"],
+            chat_tools: [{name: "shared_tool"}]
+          },
+          codex: {
+            env: {"B" => "2"},
+            flags: ["--provider"],
+            metadata: {mode: "provider"},
+            unset_env: ["LEGACY_TOKEN"],
+            chat_tools: [{name: "provider_tool"}]
+          }
+        }
+      )
+
+      expect(skill.provider_override_for(:codex)).to eq(
+        env: {"A" => "1", "B" => "2"},
+        flags: ["--shared", "--provider"],
+        metadata: {tier: "shared", mode: "provider"},
+        unset_env: ["OLD_TOKEN", "LEGACY_TOKEN"],
+        chat_tools: [{name: "shared_tool"}, {name: "provider_tool"}]
+      )
+    end
+
     it "requires the name, description, and instructions" do
       expect {
         described_class.from_hash(description: "Missing name", instructions: "Body")

--- a/spec/agent_harness/skills_spec.rb
+++ b/spec/agent_harness/skills_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AgentHarness::Skills do
   end
 
   describe ".discover" do
-    it "loads skills from global, shared, and project directories with project precedence" do
+    it "loads skills from home, shared, and project skill directories with project precedence" do
       Dir.mktmpdir do |home|
         Dir.mktmpdir do |cwd|
           write_skill(

--- a/spec/agent_harness/skills_spec.rb
+++ b/spec/agent_harness/skills_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe AgentHarness::Skills do
+  def write_skill(root, folder, body)
+    skill_dir = File.join(root, folder)
+    FileUtils.mkdir_p(skill_dir)
+    File.write(File.join(skill_dir, "SKILL.md"), body)
+  end
+
+  describe ".discover" do
+    it "loads skills from global, shared, and project directories with project precedence" do
+      Dir.mktmpdir do |home|
+        Dir.mktmpdir do |cwd|
+          write_skill(
+            File.join(home, ".agent-harness", "skills"),
+            "code-review",
+            <<~MARKDOWN
+              ---
+              name: code-review
+              description: Global review
+              ---
+              Global instructions
+            MARKDOWN
+          )
+          write_skill(
+            File.join(cwd, ".agents", "skills"),
+            "shared-review",
+            <<~MARKDOWN
+              ---
+              name: shared-review
+              description: Shared review
+              ---
+              Shared instructions
+            MARKDOWN
+          )
+          write_skill(
+            File.join(cwd, ".agent-harness", "skills"),
+            "code-review",
+            <<~MARKDOWN
+              ---
+              name: code-review
+              description: Project review
+              ---
+              Project instructions
+            MARKDOWN
+          )
+
+          skills = described_class.discover(cwd: cwd, home: home)
+          names = skills.map(&:name)
+
+          expect(names).to include(:code_review, :shared_review)
+          expect(described_class.find(:code_review, cwd: cwd, home: home).description).to eq("Project review")
+        end
+      end
+    end
+
+    it "supports programmatic registration overriding discovered skills" do
+      Dir.mktmpdir do |home|
+        Dir.mktmpdir do |cwd|
+          write_skill(
+            File.join(cwd, ".agent-harness", "skills"),
+            "code-review",
+            <<~MARKDOWN
+              ---
+              name: code-review
+              description: Project review
+              ---
+              Project instructions
+            MARKDOWN
+          )
+
+          described_class.register(:code_review, {
+            description: "Registered review",
+            instructions: "Registered instructions"
+          })
+
+          skill = described_class.find(:code_review, cwd: cwd, home: home)
+          expect(skill.description).to eq("Registered review")
+          expect(skill.instructions).to eq("Registered instructions")
+        end
+      end
+    end
+  end
+end

--- a/spec/agent_harness/skills_spec.rb
+++ b/spec/agent_harness/skills_spec.rb
@@ -54,6 +54,28 @@ RSpec.describe AgentHarness::Skills do
       end
     end
 
+    it "finds skills using hyphenated names" do
+      Dir.mktmpdir do |home|
+        Dir.mktmpdir do |cwd|
+          write_skill(
+            File.join(cwd, ".agent-harness", "skills"),
+            "code-review",
+            <<~MARKDOWN
+              ---
+              name: code-review
+              description: Review skill
+              ---
+              Review instructions
+            MARKDOWN
+          )
+
+          skill = described_class.find("code-review", cwd: cwd, home: home)
+          expect(skill.name).to eq(:code_review)
+          expect(skill.description).to eq("Review skill")
+        end
+      end
+    end
+
     it "supports programmatic registration overriding discovered skills" do
       Dir.mktmpdir do |home|
         Dir.mktmpdir do |cwd|

--- a/spec/agent_harness/sub_agent_translator_spec.rb
+++ b/spec/agent_harness/sub_agent_translator_spec.rb
@@ -115,6 +115,13 @@ RSpec.describe AgentHarness::SubAgentTranslator do
       expect(translated[:format]).to eq(:adk)
     end
 
+    it "uses provider-family tool mappings for OpenAI-family concrete providers" do
+      translated = described_class.for_provider(:github_copilot, config)
+
+      expect(translated[:provider]).to eq(:github_copilot)
+      expect(translated[:definition][:tools]).to eq([{type: "function", name: "read_file"}])
+    end
+
     it "accepts a Hash instead of SubAgentConfig" do
       translated = described_class.for_provider(:anthropic, {
         name: "test_agent",

--- a/spec/agent_harness_spec.rb
+++ b/spec/agent_harness_spec.rb
@@ -39,6 +39,19 @@ RSpec.describe AgentHarness do
 
       expect(AgentHarness.configuration.default_provider).to eq(:cursor)
     end
+
+    it "clears registered skills" do
+      AgentHarness::Skills.register(:code_review, {
+        description: "Review code",
+        instructions: "Body"
+      })
+
+      AgentHarness.reset!
+
+      expect {
+        AgentHarness::Skills.find(:code_review)
+      }.to raise_error(AgentHarness::ConfigurationError, /Unknown skill/)
+    end
   end
 
   describe ".token_tracker" do


### PR DESCRIPTION
## Summary

Implemented the provider-agnostic skills system and committed it as `81dd837` (`Add provider-agnostic skills system`).

The change adds `AgentHarness::Skill` and `AgentHarness::Skills` for `SKILL.md` frontmatter parsing, discovery from `~/.agent-harness/skills`, `.agents/skills`, and `.agent-harness/skills`, programmatic registration, caching, and validation. It also wires skills into `Providers::Base` so `send_message` and `send_chat_message` can apply skill instructions, merge MCP servers, translate skill tools for chat transports, and fold provider-specific overrides into `ProviderRuntime`. I also added `ProviderRuntime#merge` and specs covering parsing, discovery precedence, runtime merging, and request-time application.

Verification passed:
- `bundle install`
- `bundle exec rubocop`
- `bundle exec rspec`
- `git commit` succeeded with hooks enabled

The collaborator comment was actionable only insofar as the prior run had stopped short; this pass completes the implementation and lands it in git.

---

Closes #161