### PR TITLE
Fix #173: Smoke test contract timeout (30s) overrides caller timeout, breaking slow models

### DIFF
--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -324,7 +324,17 @@ module AgentHarness
         # contract[:timeout]. When the provider overrides #smoke_test without
         # publishing a contract, forward the validated health-check timeout so
         # the override can honour it instead of running without any limit.
-        smoke_timeout = smoke_contract ? nil : timeout
+        # However, when the caller explicitly provides a timeout that exceeds
+        # the contract timeout, honour the caller's intent so slow models
+        # are not prematurely killed by the contract default.
+        contract_timeout = smoke_contract&.dig(:timeout)
+        smoke_timeout = if contract_timeout && timeout && timeout > contract_timeout
+          timeout
+        elsif smoke_contract
+          nil
+        else
+          timeout
+        end
         smoke = provider_instance.smoke_test(timeout: smoke_timeout, provider_runtime: provider_runtime)
         unless smoke[:ok]
           return build_result(

--- a/lib/agent_harness/provider_health_check.rb
+++ b/lib/agent_harness/provider_health_check.rb
@@ -328,7 +328,8 @@ module AgentHarness
         # the contract timeout, honour the caller's intent so slow models
         # are not prematurely killed by the contract default.
         contract_timeout = smoke_contract&.dig(:timeout)
-        smoke_timeout = if contract_timeout && timeout && timeout > contract_timeout
+        valid_contract_timeout = contract_timeout.is_a?(Numeric) && contract_timeout.positive?
+        smoke_timeout = if valid_contract_timeout && timeout && timeout > contract_timeout
           timeout
         elsif smoke_contract
           nil

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -1072,6 +1072,51 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
       end
     end
 
+    context "when caller timeout exceeds contract timeout" do
+      let(:provider_class) do
+        Class.new(AgentHarness::Providers::Base) do
+          class << self
+            attr_reader :last_timeout
+
+            def provider_name
+              :test_provider
+            end
+
+            def binary_name
+              "test-cli"
+            end
+
+            def available?
+              true
+            end
+
+            def smoke_test_contract
+              {prompt: "Reply with exactly OK.", expected_output: "OK", timeout: 30, require_output: true}
+            end
+          end
+
+          def smoke_test(timeout: nil, provider_runtime: nil)
+            self.class.instance_variable_set(:@last_timeout, timeout)
+            {ok: true, status: "ok", message: "Smoke test passed", error_category: nil}
+          end
+        end
+      end
+
+      before do
+        registry.register(:test_provider, provider_class)
+        allow(AgentHarness::Authentication).to receive(:auth_status)
+          .with(:test_provider)
+          .and_return({valid: true, expires_at: nil, error: nil})
+      end
+
+      it "forwards the caller timeout to smoke_test when it exceeds the contract timeout" do
+        described_class.check(:test_provider, timeout: 60)
+
+        # smoke_test receives 60 because 60 > contract timeout (30)
+        expect(provider_class.last_timeout).to eq(60)
+      end
+    end
+
     context "when a local CommandExecutor subclass is provided explicitly" do
       let(:logging_executor_class) do
         Class.new(AgentHarness::CommandExecutor) do

--- a/spec/agent_harness/provider_health_check_spec.rb
+++ b/spec/agent_harness/provider_health_check_spec.rb
@@ -1117,6 +1117,52 @@ RSpec.describe AgentHarness::ProviderHealthCheck do
       end
     end
 
+    context "when the smoke test contract timeout is malformed" do
+      let(:provider_class) do
+        Class.new(AgentHarness::Providers::Base) do
+          class << self
+            attr_reader :last_timeout
+
+            def provider_name
+              :test_provider
+            end
+
+            def binary_name
+              "test-cli"
+            end
+
+            def available?
+              true
+            end
+
+            def smoke_test_contract
+              {prompt: "Reply with exactly OK.", expected_output: "OK", timeout: "30", require_output: true}
+            end
+          end
+
+          def smoke_test(timeout: nil, provider_runtime: nil)
+            self.class.instance_variable_set(:@last_timeout, timeout)
+            {ok: true, status: "ok", message: "Smoke test passed", error_category: nil}
+          end
+        end
+      end
+
+      before do
+        registry.register(:test_provider, provider_class)
+        allow(AgentHarness::Authentication).to receive(:auth_status)
+          .with(:test_provider)
+          .and_return({valid: true, expires_at: nil, error: nil})
+      end
+
+      it "treats the contract timeout as absent and avoids comparing incompatible types" do
+        expect { described_class.check(:test_provider, timeout: 60) }.not_to raise_error
+
+        # smoke_test receives nil so the contract remains the source of truth
+        # when it exists, even if its timeout metadata is malformed.
+        expect(provider_class.last_timeout).to be_nil
+      end
+    end
+
     context "when a local CommandExecutor subclass is provided explicitly" do
       let(:logging_executor_class) do
         Class.new(AgentHarness::CommandExecutor) do


### PR DESCRIPTION
## Summary

OK

Commit succeeded. Here's what was done:

**Problem:** `ProviderHealthCheck#perform_check` passed `nil` as the smoke timeout when a contract existed, causing `Adapter#smoke_test` to always use the contract's 30-second default — even when the caller explicitly requested more time (e.g., 60s for slow models).

**Fix** in `provider_health_check.rb:323-333`: Changed the `smoke_timeout` logic to forward the caller's timeout when it exceeds the contract timeout, while preserving the existing behavior (contract default) when the caller's timeout is smaller or absent.

**Test:** Added a new test case verifying that when the caller timeout (60s) exceeds the contract timeout (30s), the caller's timeout is forwarded to `smoke_test`.

---

Closes #173