### PR TITLE
fix: --disallowedTools varargs consumes prompt argument on Claude CLI v2.1.92+

### DIFF
--- a/lib/agent_harness/providers/anthropic.rb
+++ b/lib/agent_harness/providers/anthropic.rb
@@ -787,7 +787,7 @@ module AgentHarness
 
         return [] if tool_names.empty?
 
-        flags = tool_names.flat_map { |tool| ["--disallowedTools", tool] }
+        flags = ["--disallowedTools=#{tool_names.join(",")}"]
         flags = ["--permission-mode", "plan"] + flags unless skip_permission_mode
         flags
       end

--- a/spec/agent_harness/providers/anthropic_spec.rb
+++ b/spec/agent_harness/providers/anthropic_spec.rb
@@ -1080,9 +1080,12 @@ RSpec.describe AgentHarness::Providers::Anthropic do
 
         it "includes --disallowedTools for all CLI tools" do
           allow(mock_executor).to receive(:execute) do |cmd, **_opts|
+            disallowed_flag = cmd.find { |arg| arg.start_with?("--disallowedTools=") }
+            expect(disallowed_flag).not_to be_nil, "Expected command to include --disallowedTools= flag"
+            tool_list = disallowed_flag.sub("--disallowedTools=", "").split(",")
             AgentHarness::Providers::Anthropic::ALL_CLI_TOOLS.each do |tool|
-              expect(cmd).to include("--disallowedTools", tool),
-                "Expected command to include --disallowedTools #{tool}"
+              expect(tool_list).to include(tool),
+                "Expected --disallowedTools to include #{tool}"
             end
             success_result
           end
@@ -1094,8 +1097,10 @@ RSpec.describe AgentHarness::Providers::Anthropic do
           expected_tools = %w[Agent Bash Read Edit Write Grep Glob WebFetch WebSearch TodoWrite NotebookEdit]
 
           allow(mock_executor).to receive(:execute) do |cmd, **_opts|
+            disallowed_flag = cmd.find { |arg| arg.start_with?("--disallowedTools=") }
+            tool_list = disallowed_flag.sub("--disallowedTools=", "").split(",")
             expected_tools.each do |tool|
-              expect(cmd).to include(tool)
+              expect(tool_list).to include(tool)
             end
             success_result
           end
@@ -1107,9 +1112,10 @@ RSpec.describe AgentHarness::Providers::Anthropic do
       context "when tools: is an explicit list" do
         it "includes --disallowedTools only for the specified tools" do
           allow(mock_executor).to receive(:execute) do |cmd, **_opts|
-            expect(cmd).to include("--disallowedTools", "Bash")
-            expect(cmd).to include("--disallowedTools", "Read")
-            expect(cmd).not_to include("Edit")
+            disallowed_flag = cmd.find { |arg| arg.start_with?("--disallowedTools=") }
+            expect(disallowed_flag).not_to be_nil
+            expect(disallowed_flag).to eq("--disallowedTools=Bash,Read")
+            expect(cmd.join(" ")).not_to include("Edit")
             success_result
           end
 
@@ -1169,8 +1175,11 @@ RSpec.describe AgentHarness::Providers::Anthropic do
       context "when tools: :none combined with dangerous_mode: true" do
         it "includes --disallowedTools but omits --permission-mode plan" do
           allow(mock_executor).to receive(:execute) do |cmd, **_opts|
+            disallowed_flag = cmd.find { |arg| arg.start_with?("--disallowedTools=") }
+            expect(disallowed_flag).not_to be_nil
+            tool_list = disallowed_flag.sub("--disallowedTools=", "").split(",")
             AgentHarness::Providers::Anthropic::ALL_CLI_TOOLS.each do |tool|
-              expect(cmd).to include("--disallowedTools", tool)
+              expect(tool_list).to include(tool)
             end
             expect(cmd).not_to include("--permission-mode")
             expect(cmd).to include("--dangerously-skip-permissions")


### PR DESCRIPTION
## Summary

Fix `--disallowedTools` flag generation in the Anthropic CLI transport to prevent the prompt argument from being silently consumed by the flag's varargs behavior on Claude CLI v2.1.92+.

## Changes

- **Agent harness / CLI transport**: Changed `build_tool_control_flags` in `lib/agent_harness/providers/anthropic.rb` to emit a single `--disallowedTools=Tool1,Tool2,...` flag with comma-separated values instead of repeated `--disallowedTools Tool` pairs. The repeated-flag form triggers varargs parsing that swallows the trailing prompt argument, causing all `--print` invocations with tool restrictions to fail with exit code 1.

## Design Decisions

- **Comma-joined `=` syntax over repeated flags**: The Claude CLI treats `--disallowedTools` as a variadic positional consumer (`<tools...>`), so any tokens after it — including the prompt — are interpreted as tool names. Using `--disallowedTools=Tool1,Tool2` with `=` separating the flag from its value avoids this entirely and is the documented approach for varargs flags in this CLI. This is a one-line behavioral fix with no API surface change.
- **Scope of impact**: This bug silently broke 13 callers in Paid that use `tools: :none` or explicit tool restriction lists (issue analysis, prompt evolution, PR description generation, etc.), all of which route through the CLI transport's `build_command`.

---

Closes #212