### PR TITLE
Fix #217: Recognize DeepSeek 'Insufficient Balance' as a quota error in ProviderSupport classification patterns

### DIFF
--- a/lib/agent_harness/providers/adapter.rb
+++ b/lib/agent_harness/providers/adapter.rb
@@ -838,6 +838,7 @@ module AgentHarness
           quota: [
             /requires more credits/i,
             /insufficient credits/i,
+            /insufficient balance/i,
             /credit.*exceeded/i,
             /spend limit.*reached/i,
             /billing.*limit/i,


### PR DESCRIPTION
## Summary

DeepSeek emits `Error: Insufficient Balance` when an account runs out of funds, but `ProviderSupport`'s `:quota` classification patterns don't match this wording — so balance-exhaustion failures get misclassified as "agent had nothing to say" and incorrectly trigger `paid-needs-input` labeling and collaborator clarification requests. This change adds the missing pattern so DeepSeek billing failures are correctly recognized as quota errors.

## Changes

- **Providers / error classification**: Added `/insufficient balance/i` to the `:quota` group in `lib/agent_harness/providers/adapter.rb:841`, sitting alongside the existing `/insufficient credits/i` sibling pattern.

## Design Decisions

- Added the pattern to the base adapter's shared `:quota` group rather than introducing a DeepSeek-specific provider adapter — the wording is a natural sibling to existing quota phrases, and a dedicated adapter isn't warranted for a single regex.
- Once a release containing this fix is published, the downstream stopgap in Paid's `SUPPLEMENTARY_ERROR_PATTERNS` can be removed (tracked separately in Paid).

---

Closes #217