### PR TITLE
fix(release): require conventional PR titles for release-please

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+
+- Describe the change.
+- Keep the PR title in Conventional Commit format because merge commits on `main` feed release-please.
+
+## Release Notes
+
+- Confirm the PR title starts with a conventional type such as `fix:`, `feat:`, `refactor:`, or `docs:`.
+- If the merge should not create a release entry, say why here.


### PR DESCRIPTION
## Summary

Add a pull request template that reminds contributors to keep PR titles in Conventional Commit format.

`agent-harness` is currently using merge commits on `main`, so the merged PR title becomes part of the commit history that release-please scans. This gives us a releasable `fix:` commit now and reduces the chance of future non-conventional merges blocking release-please again.

## Why now

Recent unreleased commits on `main` after `v0.18.1` are non-conventional (`Add ...`, `Remove ...`, `Classify ...`), so release-please has not been opening a release PR from those merges.

## Expected outcome

After this PR merges, release-please should open the next release PR from the current `main` head, and future contributors will get an explicit reminder about title format.