### PR TITLE
feat: opencode-ai install contract should support postinstall (native binary download)

### DIFF
--- a/lib/agent_harness/providers/adapter.rb
+++ b/lib/agent_harness/providers/adapter.rb
@@ -22,7 +22,7 @@ module AgentHarness
         source = contract[:source]
         install_command = contract[:install_command]&.dup
 
-        {
+        normalized = {
           provider: provider_name.to_sym,
           source_type: normalize_metadata_source_type(contract[:source_type] || source),
           package_name: metadata_package_name(contract, source),
@@ -35,6 +35,11 @@ module AgentHarness
           install_command: install_command,
           install_command_string: contract[:install_command_string] || install_command&.join(" ")
         }
+
+        normalized[:requires_postinstall] = contract[:requires_postinstall] if contract.key?(:requires_postinstall)
+        normalized[:postinstall_command] = contract[:postinstall_command] if contract.key?(:postinstall_command)
+
+        normalized
       end
 
       def self.normalize_metadata_source_type(source)

--- a/lib/agent_harness/providers/opencode.rb
+++ b/lib/agent_harness/providers/opencode.rb
@@ -14,6 +14,7 @@ module AgentHarness
       SUPPORTED_CLI_REQUIREMENT = Gem::Requirement.new(">= #{SUPPORTED_CLI_VERSION}", "< 1.4.0").freeze
       INSTALL_COMMAND_PREFIX = ["npm", "install", "-g", "--ignore-scripts"].freeze
       SUPPORTED_CLI_VERSIONS = [SUPPORTED_CLI_VERSION].freeze
+      POSTINSTALL_COMMAND = "node $(npm root -g)/opencode-ai/postinstall.mjs"
       VERSION_REQUIREMENT_STRINGS = SUPPORTED_CLI_REQUIREMENT.requirements
         .map { |op, ver| "#{op} #{ver}".freeze }
         .freeze
@@ -89,6 +90,8 @@ module AgentHarness
             binary_name: binary_name,
             install_command_prefix: INSTALL_COMMAND_PREFIX,
             install_command: install_command,
+            requires_postinstall: true,
+            postinstall_command: POSTINSTALL_COMMAND,
             supported_versions: SUPPORTED_CLI_VERSIONS
           }
 

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -31,6 +31,20 @@ RSpec.describe AgentHarness::Providers::Opencode do
       )
     end
 
+    it "declares requires_postinstall as true" do
+      contract = described_class.installation_contract
+
+      expect(contract[:requires_postinstall]).to be true
+    end
+
+    it "exposes a postinstall_command for the trusted native binary download" do
+      contract = described_class.installation_contract
+
+      expect(contract[:postinstall_command]).to eq(
+        "node $(npm root -g)/opencode-ai/postinstall.mjs"
+      )
+    end
+
     it "keeps the runtime binary aligned with the install contract" do
       contract = described_class.installation_contract
 
@@ -43,6 +57,15 @@ RSpec.describe AgentHarness::Providers::Opencode do
       expect(contract[:version]).to eq("1.3.9")
       expect(contract[:install_command]).to eq(
         ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
+      )
+    end
+
+    it "preserves postinstall fields in versioned contracts" do
+      contract = described_class.installation_contract(version: "1.3.9")
+
+      expect(contract[:requires_postinstall]).to be true
+      expect(contract[:postinstall_command]).to eq(
+        "node $(npm root -g)/opencode-ai/postinstall.mjs"
       )
     end
 
@@ -111,6 +134,7 @@ RSpec.describe AgentHarness::Providers::Opencode do
       expect(contract[:package_name]).to be_frozen
       expect(contract[:version]).to be_frozen
       expect(contract[:binary_name]).to be_frozen
+      expect(contract[:postinstall_command]).to be_frozen
       expect { contract[:install_command_prefix] << "opencode-ai" }.to raise_error(FrozenError)
       expect { contract[:install_command] << "opencode-ai" }.to raise_error(FrozenError)
       expect { contract[:supported_versions] << "1.3.1" }.to raise_error(FrozenError)

--- a/spec/agent_harness/providers/registry_spec.rb
+++ b/spec/agent_harness/providers/registry_spec.rb
@@ -353,6 +353,10 @@ RSpec.describe AgentHarness::Providers::Registry do
       expect(contract[:install_command]).to eq(
         ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
       )
+      expect(contract[:requires_postinstall]).to be true
+      expect(contract[:postinstall_command]).to eq(
+        "node $(npm root -g)/opencode-ai/postinstall.mjs"
+      )
     end
 
     it "preserves provider normalization for generic-contract version lookups" do
@@ -366,6 +370,7 @@ RSpec.describe AgentHarness::Providers::Registry do
       expect(contract[:install_command]).to eq(
         ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
       )
+      expect(contract[:requires_postinstall]).to be true
     end
 
     it "returns nil for registered providers without installation contract support" do
@@ -458,6 +463,10 @@ RSpec.describe AgentHarness::Providers::Registry do
       )
       expect(contracts[:opencode][:install_command]).to eq(
         ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.2"]
+      )
+      expect(contracts[:opencode][:requires_postinstall]).to be true
+      expect(contracts[:opencode][:postinstall_command]).to eq(
+        "node $(npm root -g)/opencode-ai/postinstall.mjs"
       )
       expect(contracts[:pi][:install_command]).to eq(
         ["npm", "install", "-g", "--ignore-scripts", "@mariozechner/pi-coding-agent@0.73.0"]


### PR DESCRIPTION
## Summary

OK.

Let me check how the adapter normalization is tested and look at the codex provider for comparison:

Now I have a full picture. Let me implement the changes.

Now update the `build_installation_contract` method to include the new fields:

Now update the `normalize_metadata_installation` method in adapter.rb to pass through the new fields:

Now update the opencode spec to test the new contract fields:

Now add tests for the postinstall fields in the version override test cases:

Now add a deep-freeze test for the new fields:

Now update the registry spec to account for the new fields in the opencode contract:

Now update the `installation_contracts` test for opencode:

Now let's run the tests to see if everything passes:

All 233 tests pass. Now let's run the full test suite and lint:

Let me fix the lint offense and check the test results:

The 1 failure is in `kilocode_spec.rb:3782` which is unrelated to my changes. Let me verify this is a pre-existing failure:

Confirmed - this is a pre-existing failure in the kilocode spec, not related to my changes. Let me restore my changes:

Lint passes with 0 offenses. Tests pass (2323 examples, 1 failure - pre-existing in kilocode, unrelated). Now let me commit:

Commit succeeded. Here's a summary of the changes:

**4 files changed, 42 insertions, 1 deletion:**

1. **`lib/agent_harness/providers/opencode.rb`** - Added `POSTINSTALL_COMMAND` constant and two new fields to the installation contract:
   - `requires_postinstall: true` - flag for consumers to detect postinstall requirement
   - `postinstall_command: "node $(npm root -g)/opencode-ai/postinstall.mjs"` - the trusted postinstall step

2. **`lib/agent_harness/providers/adapter.rb`** - Updated `normalize_metadata_installation` to conditionally pass through `requires_postinstall` and `postinstall_command` when present in the contract

3. **`spec/agent_harness/providers/opencode_spec.rb`** - Added tests for `requires_postinstall`, `postinstall_command`, preservation in versioned contracts, and deep-freeze

4. **`spec/agent_harness/providers/registry_spec.rb`** - Updated registry-level contract expectations to assert the new fields

Downstream consumers like Paid can now detect `requires_postinstall: true` and chain the `postinstall_command` after the `install_command`, keeping `--ignore-scripts` for transitive-dep safety while still running the trusted postinstall step.

---

Closes #223