### PR TITLE
feat: suppress Claude CLI .mcp.json auto-discovery when no MCP servers configured

### DIFF
--- a/lib/agent_harness/providers/anthropic.rb
+++ b/lib/agent_harness/providers/anthropic.rb
@@ -183,7 +183,12 @@ module AgentHarness
         def parse_cli_json_envelope(json_string)
           return nil if json_string.nil? || json_string.empty?
 
-          parsed = JSON.parse(json_string)
+          cleaned = json_string.lines.reject { |line|
+            line.include?('"type":"session.') || line.include?('"type": "session.')
+          }.join.strip
+          return nil if cleaned.empty?
+
+          parsed = JSON.parse(cleaned)
           return nil unless parsed.is_a?(Hash) && parsed.key?("result")
 
           output = parsed["result"]
@@ -415,8 +420,6 @@ module AgentHarness
       end
 
       def build_mcp_flags(mcp_servers, working_dir: nil)
-        return [] if mcp_servers.empty?
-
         config_path = write_mcp_config_file(mcp_servers, working_dir: working_dir)
         ["--mcp-config", config_path]
       end
@@ -601,10 +604,10 @@ module AgentHarness
           cmd += dangerous_mode_flags
         end
 
-        # Add MCP server flags (validated/normalized by Base#send_message)
-        if options[:mcp_servers]&.any?
-          cmd += build_mcp_flags(options[:mcp_servers])
-        end
+        # Add MCP server flags (validated/normalized by Base#send_message).
+        # Always pass --mcp-config, even with an empty server list, to suppress
+        # the Claude CLI's auto-discovery of .mcp.json in the working directory.
+        cmd += build_mcp_flags(options[:mcp_servers] || [])
 
         # Add custom flags from config
         cmd += @config.default_flags if @config.default_flags&.any?
@@ -720,9 +723,18 @@ module AgentHarness
       def parse_json_output(output)
         return nil if output.nil? || output.empty?
 
-        JSON.parse(output)
+        cleaned = strip_claude_streaming_events(output)
+        return nil if cleaned.empty?
+
+        JSON.parse(cleaned)
       rescue JSON::ParserError
         nil
+      end
+
+      def strip_claude_streaming_events(output)
+        output.lines.reject { |line|
+          line.include?('"type":"session.') || line.include?('"type": "session.')
+        }.join.strip
       end
 
       # Delegate to class-level implementations so both instance and class

--- a/spec/agent_harness/mcp_integration_spec.rb
+++ b/spec/agent_harness/mcp_integration_spec.rb
@@ -201,15 +201,22 @@ RSpec.describe "MCP Server Integration" do
     end
 
     context "without MCP servers" do
-      it "does not include --mcp-config flag" do
+      it "includes --mcp-config with an empty config to suppress auto-discovery" do
         allow(mock_executor).to receive(:execute).and_return(success_result)
 
-        expect(mock_executor).to receive(:execute).with(
-          satisfy { |cmd| !cmd.include?("--mcp-config") },
-          anything
-        )
+        config_content = nil
+        allow(mock_executor).to receive(:execute) do |cmd, **_opts|
+          idx = cmd.index("--mcp-config")
+          if idx
+            config_content = JSON.parse(File.read(cmd[idx + 1]))
+          end
+          success_result
+        end
 
         provider.send_message(prompt: "Hello")
+
+        expect(config_content).not_to be_nil
+        expect(config_content["mcpServers"]).to eq({})
       end
 
       it "uses globally configured MCP servers when request options omit them" do

--- a/spec/agent_harness/providers/anthropic_spec.rb
+++ b/spec/agent_harness/providers/anthropic_spec.rb
@@ -72,6 +72,44 @@ RSpec.describe AgentHarness::Providers::Anthropic do
     it "returns nil for JSON without a result field" do
       expect(described_class.parse_cli_json_envelope('{"foo":"bar"}')).to be_nil
     end
+
+    it "strips streaming session events before parsing" do
+      envelope = [
+        '{"type":"session.mcp_servers_loading","server":"playwright"}',
+        '{"type":"session.mcp_servers_loaded"}',
+        JSON.generate({
+          "type" => "result",
+          "result" => "analysis result",
+          "usage" => {"input_tokens" => 10, "output_tokens" => 5}
+        })
+      ].join("\n")
+
+      parsed = described_class.parse_cli_json_envelope(envelope)
+
+      expect(parsed[:output]).to eq("analysis result")
+      expect(parsed[:tokens]).to eq({input: 10, output: 5, total: 15})
+    end
+
+    it "strips truncated streaming session events before parsing" do
+      envelope = [
+        '{"type":"session.mcp_servers_loa',
+        JSON.generate({
+          "type" => "result",
+          "result" => "analysis result",
+          "usage" => {"input_tokens" => 10, "output_tokens" => 5}
+        })
+      ].join("\n")
+
+      parsed = described_class.parse_cli_json_envelope(envelope)
+
+      expect(parsed[:output]).to eq("analysis result")
+    end
+
+    it "returns nil when only streaming events are present" do
+      output = '{"type":"session.mcp_servers_loading"}'
+
+      expect(described_class.parse_cli_json_envelope(output)).to be_nil
+    end
   end
 
   describe ".install_contract" do
@@ -113,7 +151,8 @@ RSpec.describe AgentHarness::Providers::Anthropic do
 
       expect(contract.dig(:install, :post_install_binary_path)).to eq(contract[:binary_paths].first)
       expect(command.first(contract_build_command.length)).to eq(contract_build_command)
-      expect(command[contract_build_command.length]).to eq("prompt")
+      expect(command).to include("--mcp-config")
+      expect(command.last).to eq("prompt")
     end
 
     it "does not include a root-only copy step in the install command" do
@@ -793,6 +832,49 @@ RSpec.describe AgentHarness::Providers::Anthropic do
 
           response = provider.send_message(prompt: "Hello")
           expect(response.error).to include("Some other error occurred")
+        end
+
+        it "strips streaming session events and parses the envelope" do
+          stdout = [
+            '{"type":"session.mcp_servers_loading","server":"playwright"}',
+            '{"type":"session.mcp_servers_loaded"}',
+            JSON.generate({
+              "result" => "analysis result",
+              "usage" => {"input_tokens" => 10, "output_tokens" => 5}
+            })
+          ].join("\n")
+
+          allow(mock_executor).to receive(:execute).and_return(
+            AgentHarness::CommandExecutor::Result.new(
+              stdout: stdout,
+              stderr: "",
+              exit_code: 0,
+              duration: 1.0
+            )
+          )
+
+          response = provider.send_message(prompt: "Hello")
+          expect(response.output).to eq("analysis result")
+          expect(response.tokens).to eq({input: 10, output: 5, total: 15})
+        end
+
+        it "handles truncated streaming events mixed with the envelope" do
+          stdout = '{"type":"session.mcp_servers_loa' + "\n" + JSON.generate({
+            "result" => "analysis result",
+            "usage" => {"input_tokens" => 10, "output_tokens" => 5}
+          })
+
+          allow(mock_executor).to receive(:execute).and_return(
+            AgentHarness::CommandExecutor::Result.new(
+              stdout: stdout,
+              stderr: "",
+              exit_code: 0,
+              duration: 1.0
+            )
+          )
+
+          response = provider.send_message(prompt: "Hello")
+          expect(response.output).to eq("analysis result")
         end
       end
 


### PR DESCRIPTION
## Summary

Suppress Claude CLI `.mcp.json` auto-discovery when no MCP servers are configured, preventing streaming session events from contaminating `--output-format=json` output. This fixes a production failure where ~15+ consecutive agent runs returned `"LLM returned invalid analysis JSON"` because the CLI auto-discovered a Playwright `.mcp.json` in the workspace and emitted `session.mcp_servers_loading` events to stdout.

## Changes

### Provider logic (`lib/agent_harness/providers/anthropic.rb`)

- **`build_command`**: Always passes `--mcp-config` via `build_mcp_flags` instead of conditionally — ensures the CLI receives an explicit MCP configuration even when no servers are needed
- **`build_mcp_flags`**: Removed early return for empty server lists; now writes a `{"mcpServers":{}}` tempfile that tells the CLI "no MCP servers, don't auto-discover"
- **`parse_json_output` / `parse_cli_json_envelope`**: Added `strip_claude_streaming_events` as defense-in-depth — rejects lines matching `"type":"session.` before attempting JSON parse, so even if streaming events leak through in other scenarios, parsing still succeeds

### Tests

- Updated MCP integration test to verify `--mcp-config` is present with empty `{"mcpServers":{}}` when no servers are configured
- Updated contract test to account for `--mcp-config` always being in the command
- Added 5 new tests covering streaming event stripping in both `parse_cli_json_envelope` and `parse_response`

## Design Decisions

- **Empty config tempfile over `--no-mcp` flag**: The Claude CLI does not currently support a `--no-mcp` flag. Passing `--mcp-config` with an empty `{"mcpServers":{}}` is the least invasive approach that works with the current CLI and explicitly communicates intent.
- **Defense-in-depth stripping**: Even with the empty config fix, streaming events could reappear from other sources (e.g., global MCP config, future CLI changes). Stripping `session.*` lines before JSON parsing prevents this entire class of failure without masking real errors.
- **Stripping applies to both parse paths**: Both `parse_json_output` (single-result mode) and `parse_cli_json_envelope` (conversation mode) are protected, since either could encounter auto-discovery output depending on CLI invocation flags.

---

Closes #225