### PR TITLE
fix(anthropic): --mcp-config space-form swallows the positional prompt (variadic flag)

### DIFF
--- a/lib/agent_harness/providers/anthropic.rb
+++ b/lib/agent_harness/providers/anthropic.rb
@@ -421,7 +421,7 @@ module AgentHarness
 
       def build_mcp_flags(mcp_servers, working_dir: nil)
         config_path = write_mcp_config_file(mcp_servers, working_dir: working_dir)
-        ["--mcp-config", config_path]
+        ["--mcp-config=#{config_path}"]
       end
 
       def supports_tool_control?

--- a/spec/agent_harness/mcp_integration_spec.rb
+++ b/spec/agent_harness/mcp_integration_spec.rb
@@ -2,8 +2,21 @@
 
 RSpec.describe "MCP Server Integration" do
   def extract_mcp_config_path(cmd)
-    flag = cmd.find { |arg| arg.start_with?("--mcp-config=") }
-    flag&.delete_prefix("--mcp-config=")
+    inline_flag = cmd.find { |arg| arg.start_with?("--mcp-config=") }
+    return inline_flag.delete_prefix("--mcp-config=") if inline_flag
+
+    flag_index = cmd.index("--mcp-config")
+    cmd[flag_index + 1] if flag_index
+  end
+
+  describe "#extract_mcp_config_path" do
+    it "extracts the path from the inline flag form" do
+      expect(extract_mcp_config_path(["claude", "--mcp-config=/tmp/mcp.json", "prompt"])).to eq("/tmp/mcp.json")
+    end
+
+    it "extracts the path from the space-separated flag form" do
+      expect(extract_mcp_config_path(["codex", "--mcp-config", "/tmp/mcp.json", "prompt"])).to eq("/tmp/mcp.json")
+    end
   end
 
   describe "Anthropic provider with MCP servers" do

--- a/spec/agent_harness/mcp_integration_spec.rb
+++ b/spec/agent_harness/mcp_integration_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe "MCP Server Integration" do
+  def extract_mcp_config_path(cmd)
+    flag = cmd.find { |arg| arg.start_with?("--mcp-config=") }
+    flag&.delete_prefix("--mcp-config=")
+  end
+
   describe "Anthropic provider with MCP servers" do
     let(:config) do
       AgentHarness::ProviderConfig.new(:claude).tap do |c|
@@ -39,7 +44,7 @@ RSpec.describe "MCP Server Integration" do
         allow(mock_executor).to receive(:execute).and_return(success_result)
 
         expect(mock_executor).to receive(:execute).with(
-          array_including("--mcp-config"),
+          array_including(a_string_starting_with("--mcp-config=")),
           anything
         )
 
@@ -49,10 +54,8 @@ RSpec.describe "MCP Server Integration" do
       it "generates a valid MCP config file" do
         config_content = nil
         allow(mock_executor).to receive(:execute) do |cmd, **_opts|
-          idx = cmd.index("--mcp-config")
-          if idx
-            config_content = JSON.parse(File.read(cmd[idx + 1]))
-          end
+          config_path = extract_mcp_config_path(cmd)
+          config_content = JSON.parse(File.read(config_path)) if config_path
           success_result
         end
 
@@ -91,10 +94,8 @@ RSpec.describe "MCP Server Integration" do
       it "generates config with url for HTTP servers" do
         config_content = nil
         allow(mock_executor).to receive(:execute) do |cmd, **_opts|
-          idx = cmd.index("--mcp-config")
-          if idx
-            config_content = JSON.parse(File.read(cmd[idx + 1]))
-          end
+          config_path = extract_mcp_config_path(cmd)
+          config_content = JSON.parse(File.read(config_path)) if config_path
           success_result
         end
 
@@ -126,10 +127,8 @@ RSpec.describe "MCP Server Integration" do
       it "includes both servers in config" do
         config_content = nil
         allow(mock_executor).to receive(:execute) do |cmd, **_opts|
-          idx = cmd.index("--mcp-config")
-          if idx
-            config_content = JSON.parse(File.read(cmd[idx + 1]))
-          end
+          config_path = extract_mcp_config_path(cmd)
+          config_content = JSON.parse(File.read(config_path)) if config_path
           success_result
         end
 
@@ -172,8 +171,7 @@ RSpec.describe "MCP Server Integration" do
       it "cleans up MCP config tempfiles after execution" do
         config_path = nil
         allow(mock_executor).to receive(:execute) do |cmd, **_opts|
-          idx = cmd.index("--mcp-config")
-          config_path = cmd[idx + 1] if idx
+          config_path = extract_mcp_config_path(cmd)
           success_result
         end
 
@@ -186,8 +184,7 @@ RSpec.describe "MCP Server Integration" do
       it "cleans up tempfiles even when execution raises" do
         config_path = nil
         allow(mock_executor).to receive(:execute) do |cmd, **_opts|
-          idx = cmd.index("--mcp-config")
-          config_path = cmd[idx + 1] if idx
+          config_path = extract_mcp_config_path(cmd)
           raise StandardError, "execution failed"
         end
 
@@ -206,10 +203,8 @@ RSpec.describe "MCP Server Integration" do
 
         config_content = nil
         allow(mock_executor).to receive(:execute) do |cmd, **_opts|
-          idx = cmd.index("--mcp-config")
-          if idx
-            config_content = JSON.parse(File.read(cmd[idx + 1]))
-          end
+          config_path = extract_mcp_config_path(cmd)
+          config_content = JSON.parse(File.read(config_path)) if config_path
           success_result
         end
 
@@ -231,8 +226,8 @@ RSpec.describe "MCP Server Integration" do
 
         config_content = nil
         allow(mock_executor).to receive(:execute) do |cmd, **_opts|
-          idx = cmd.index("--mcp-config")
-          config_content = JSON.parse(File.read(cmd[idx + 1])) if idx
+          config_path = extract_mcp_config_path(cmd)
+          config_content = JSON.parse(File.read(config_path)) if config_path
           success_result
         end
 
@@ -519,8 +514,7 @@ RSpec.describe "MCP Server Integration" do
           write_result
         else
           # Second call is the actual command
-          idx = cmd.index("--mcp-config")
-          config_path = cmd[idx + 1] if idx
+          config_path ||= extract_mcp_config_path(cmd)
           success_result
         end
       end
@@ -546,7 +540,7 @@ RSpec.describe "MCP Server Integration" do
           container_path = cmd[2]
           write_result
         else
-          # Second call: actual command
+          # Second call is the actual command
           success_result
         end
       end

--- a/spec/agent_harness/providers/anthropic_spec.rb
+++ b/spec/agent_harness/providers/anthropic_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe AgentHarness::Providers::Anthropic do
 
       expect(contract.dig(:install, :post_install_binary_path)).to eq(contract[:binary_paths].first)
       expect(command.first(contract_build_command.length)).to eq(contract_build_command)
-      expect(command).to include("--mcp-config")
+      expect(command).to include(a_string_starting_with("--mcp-config="))
       expect(command.last).to eq("prompt")
     end
 


### PR DESCRIPTION
## Summary

Changed Anthropic to emit `--mcp-config=PATH` in [lib/agent_harness/providers/anthropic.rb](/workspace/lib/agent_harness/providers/anthropic.rb:422), which prevents Claude’s variadic `--mcp-config <configs...>` flag from swallowing the positional prompt. I updated the Anthropic command-contract spec and the MCP integration specs to assert and parse the inline flag form in [spec/agent_harness/providers/anthropic_spec.rb](/workspace/spec/agent_harness/providers/anthropic_spec.rb:154) and [spec/agent_harness/mcp_integration_spec.rb](/workspace/spec/agent_harness/mcp_integration_spec.rb:3).

Verification passed with `bundle exec rubocop` and `bundle exec rspec`. The commit is `481d734` with message `fix(anthropic): use equals form for mcp config`.

---

Closes #229