### PR TITLE
fix: Rate-limit reset parser fabricates far-future resets (year over-bump in parse_resets_date_time)

### DIFF
--- a/lib/agent_harness/providers/rate_limit_reset_parsing.rb
+++ b/lib/agent_harness/providers/rate_limit_reset_parsing.rb
@@ -87,10 +87,13 @@ module AgentHarness
         meridiem = match[5].downcase
         hour = to_24h(hour, meridiem)
 
-        year = Time.now.utc.year
-        year += 1 if month < Time.now.utc.month
+        now = Time.now.utc
+        candidate = Time.utc(now.year, month, day, hour, minute)
+        candidate = Time.utc(now.year + 1, month, day, hour, minute) if candidate <= now - 7200
 
-        Time.utc(year, month, day, hour, minute)
+        return nil if candidate >= now + 8 * 86_400
+
+        candidate
       end
 
       def to_24h(hour, meridiem)

--- a/lib/agent_harness/providers/rate_limit_reset_parsing.rb
+++ b/lib/agent_harness/providers/rate_limit_reset_parsing.rb
@@ -89,11 +89,13 @@ module AgentHarness
 
         now = Time.now.utc
         candidate = Time.utc(now.year, month, day, hour, minute)
-        candidate = Time.utc(now.year + 1, month, day, hour, minute) if candidate <= now - 7200
+        candidate = Time.utc(now.year + 1, month, day, hour, minute) if candidate < now - 7200
 
         return nil if candidate >= now + 8 * 86_400
 
         candidate
+      rescue ArgumentError
+        nil
       end
 
       def to_24h(hour, meridiem)

--- a/spec/agent_harness/providers/rate_limit_reset_parsing_spec.rb
+++ b/spec/agent_harness/providers/rate_limit_reset_parsing_spec.rb
@@ -121,10 +121,13 @@ RSpec.describe AgentHarness::Providers::RateLimitResetParsing do
         expect(provider.parse_rate_limit_reset("resets Xyz 15, 5pm (UTC)")).to be_nil
       end
 
+      it "returns nil for an impossible date like Feb 31" do
+        expect(provider.parse_rate_limit_reset("resets Feb 31, 5pm (UTC)")).to be_nil
+      end
+
       it "returns nil when month is far in the past (beyond 8-day ceiling)" do
         past_month = Time.now.utc.month - 2
         past_month += 12 if past_month < 1
-        return if past_month == Time.now.utc.month
 
         month_name = Date::ABBR_MONTHNAMES[past_month]
         result = provider.parse_rate_limit_reset("resets #{month_name} 15, 5pm (UTC)")
@@ -177,6 +180,11 @@ RSpec.describe AgentHarness::Providers::RateLimitResetParsing do
         it "returns candidate within grace window even if slightly in the past" do
           result = provider.parse_rate_limit_reset("resets Jun 2, 11am (UTC)")
           expect(result).to eq(Time.utc(2026, 6, 2, 11, 0, 0))
+        end
+
+        it "returns candidate at exactly the 2-hour grace boundary" do
+          result = provider.parse_rate_limit_reset("resets Jun 2, 10am (UTC)")
+          expect(result).to eq(Time.utc(2026, 6, 2, 10, 0, 0))
         end
 
         it "returns a UTC time" do

--- a/spec/agent_harness/providers/rate_limit_reset_parsing_spec.rb
+++ b/spec/agent_harness/providers/rate_limit_reset_parsing_spec.rb
@@ -117,48 +117,104 @@ RSpec.describe AgentHarness::Providers::RateLimitResetParsing do
     end
 
     context "resets at date and time (UTC)" do
-      it "parses 'resets Jan 15, 5pm (UTC)'" do
-        result = provider.parse_rate_limit_reset("resets Jan 15, 5pm (UTC)")
-        expect(result.utc?).to be true
-        expect(result.month).to eq(1)
-        expect(result.day).to eq(15)
-        expect(result.hour).to eq(17)
-        expect(result.min).to eq(0)
-      end
-
-      it "parses 'resets Mar 1, 9:30am (UTC)'" do
-        result = provider.parse_rate_limit_reset("resets Mar 1, 9:30am (UTC)")
-        expect(result.month).to eq(3)
-        expect(result.day).to eq(1)
-        expect(result.hour).to eq(9)
-        expect(result.min).to eq(30)
-      end
-
-      it "parses without comma after day" do
-        result = provider.parse_rate_limit_reset("resets Jan 15 5pm (UTC)")
-        expect(result.month).to eq(1)
-        expect(result.day).to eq(15)
-        expect(result.hour).to eq(17)
-      end
-
-      it "parses uppercase month abbreviation (case insensitive)" do
-        result = provider.parse_rate_limit_reset("resets JAN 15, 5pm (UTC)")
-        expect(result.month).to eq(1)
-        expect(result.day).to eq(15)
-        expect(result.hour).to eq(17)
-      end
-
       it "returns nil for invalid month abbreviation" do
         expect(provider.parse_rate_limit_reset("resets Xyz 15, 5pm (UTC)")).to be_nil
       end
 
-      it "advances year when month is in the past" do
-        past_month = Time.now.utc.month - 1
-        return if past_month < 1 # skip in January
+      it "returns nil when month is far in the past (beyond 8-day ceiling)" do
+        past_month = Time.now.utc.month - 2
+        past_month += 12 if past_month < 1
+        return if past_month == Time.now.utc.month
 
         month_name = Date::ABBR_MONTHNAMES[past_month]
         result = provider.parse_rate_limit_reset("resets #{month_name} 15, 5pm (UTC)")
-        expect(result.year).to eq(Time.now.utc.year + 1)
+        expect(result).to be_nil
+      end
+
+      it "returns nil for a date more than 8 days in the future" do
+        future_month = Time.now.utc.month + 1
+        future_month -= 12 if future_month > 12
+        month_name = Date::ABBR_MONTHNAMES[future_month]
+        result = provider.parse_rate_limit_reset("resets #{month_name} 15, 5pm (UTC)")
+        expect(result).to be_nil
+      end
+
+      context "when now is 2026-06-02 12:00 UTC" do
+        before do
+          allow(Time).to receive(:now).and_return(Time.utc(2026, 6, 2, 12, 0, 0))
+        end
+
+        it "parses a near-future date in the same month" do
+          result = provider.parse_rate_limit_reset("resets Jun 4, 10pm (UTC)")
+          expect(result).to eq(Time.utc(2026, 6, 4, 22, 0, 0))
+        end
+
+        it "parses a near-future date within 8 days" do
+          result = provider.parse_rate_limit_reset("resets Jun 9, 10pm (UTC)")
+          expect(result).to eq(Time.utc(2026, 6, 9, 22, 0, 0))
+        end
+
+        it "parses without comma after day" do
+          result = provider.parse_rate_limit_reset("resets Jun 4 10pm (UTC)")
+          expect(result).to eq(Time.utc(2026, 6, 4, 22, 0))
+        end
+
+        it "parses uppercase month abbreviation (case insensitive)" do
+          result = provider.parse_rate_limit_reset("resets JUN 4, 10pm (UTC)")
+          expect(result).to eq(Time.utc(2026, 6, 4, 22, 0, 0))
+        end
+
+        it "returns nil for a date exactly 8 days from now (at the boundary)" do
+          result = provider.parse_rate_limit_reset("resets Jun 10, 12pm (UTC)")
+          expect(result).to be_nil
+        end
+
+        it "returns nil for a past month that would be almost a year away with year+1" do
+          result = provider.parse_rate_limit_reset("resets Apr 6, 10pm (UTC)")
+          expect(result).to be_nil
+        end
+
+        it "returns candidate within grace window even if slightly in the past" do
+          result = provider.parse_rate_limit_reset("resets Jun 2, 11am (UTC)")
+          expect(result).to eq(Time.utc(2026, 6, 2, 11, 0, 0))
+        end
+
+        it "returns a UTC time" do
+          result = provider.parse_rate_limit_reset("resets Jun 4, 5pm (UTC)")
+          expect(result.utc?).to be true
+          expect(result.hour).to eq(17)
+          expect(result.min).to eq(0)
+        end
+      end
+
+      context "when now is 2026-01-14 12:00 UTC" do
+        before do
+          allow(Time).to receive(:now).and_return(Time.utc(2026, 1, 14, 12, 0, 0))
+        end
+
+        it "parses 'resets Jan 15, 5pm (UTC)' as tomorrow" do
+          result = provider.parse_rate_limit_reset("resets Jan 15, 5pm (UTC)")
+          expect(result.month).to eq(1)
+          expect(result.day).to eq(15)
+          expect(result.hour).to eq(17)
+          expect(result.min).to eq(0)
+        end
+
+        it "parses 'resets Mar 1, 9:30am (UTC)' as nil (beyond 8 days)" do
+          result = provider.parse_rate_limit_reset("resets Mar 1, 9:30am (UTC)")
+          expect(result).to be_nil
+        end
+      end
+
+      context "when now is 2026-12-28 12:00 UTC" do
+        before do
+          allow(Time).to receive(:now).and_return(Time.utc(2026, 12, 28, 12, 0, 0))
+        end
+
+        it "resolves a January date from late December within 8 days" do
+          result = provider.parse_rate_limit_reset("resets Jan 3, 5pm (UTC)")
+          expect(result).to eq(Time.utc(2027, 1, 3, 17, 0, 0))
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Fixes a year-calculation bug in `parse_resets_date_time` that fabricated far-future rate-limit resets, silently disabling runners for up to 10 months. The broken heuristic (`year += 1 if month < current_month`) assumed any earlier calendar month must be next year, which is invalid for rate-limit resets that are always within days.

## Changes

### Rate limit reset parsing (`lib/agent_harness/providers/rate_limit_reset_parsing.rb`)
- Replaced the broken year-bump heuristic with nearest-future-occurrence resolution: builds the candidate date in the current year and only rolls forward one year if the candidate is more than 2 hours in the past
- Added an 8-day sanity ceiling — parsed resets beyond 8 days return `nil`, causing callers to fall back to default backoff instead of trusting a bogus far-future timestamp

### Tests (`spec/agent_harness/providers/rate_limit_reset_parsing_spec.rb`)
- Replaced time-dependent assertions with stubbed `Time.now` for deterministic behavior
- Added coverage for the reproduction case (e.g., parsing "resets Apr 6, 10pm (UTC)" in June now returns `nil`)
- Added tests for the 8-day ceiling, 2-hour grace window, and year-end rollover edge cases

## Design Decisions

- **2-hour grace window instead of exact boundary**: A small past-tolerance avoids flapping when a reset time is moments ago due to clock skew or processing delay. Two hours is generous enough for real-world drift without accepting stale resets.
- **8-day ceiling**: Rate-limit resets are at most weekly in practice (Codex). Returning `nil` for anything beyond 8 days ensures that even if year resolution is somehow wrong, the damage is bounded — callers use their default backoff rather than parking a runner for months.
- **Fix in the shared module**: The bug lives in `RateLimitResetParsing`, which is used across providers, so the fix protects all current and future providers.

---

Closes #231