### PR TITLE
fix: Bump opencode-ai past 1.3.2 so zai_coding/glm models are recognized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 * add runner model compatibility contract (`AgentHarness.model_compatibility`) with structured `ModelCompatibility::Result` outcomes. Codex exposes static facts for CLI-gated models (e.g. `gpt-5.5` requires Codex CLI `>= 0.116.0`), a baseline supported-model list, supported auth modes, and a `DEFAULT_COMPATIBLE_MODEL_ID` fallback so downstream orchestrators can validate tier/model assignments before scheduling agent runs ([#259](https://github.com/viamin/agent-harness/issues/259)).
 * **auth:** add provider-owned PKCE code-exchange API for Claude OAuth (`AgentHarness::Authentication.exchange_code`). Takes an authorization code plus PKCE verifier (and `redirect_uri`/`client_id`), posts an `authorization_code` grant to the Claude token endpoint, and persists the resulting access/refresh tokens in the native `claudeAiOauth` shape. Adds `exchange_code_supported?` and a `code_exchange` key to `auth_capabilities` ([#266](https://github.com/viamin/agent-harness/issues/266)).
 
+## [0.32.0](https://github.com/viamin/agent-harness/compare/agent-harness/v0.31.1...agent-harness/v0.32.0) (2026-07-29)
+
+### Features
+
+* bump the OpenCode install contract to `opencode-ai@1.18.9` and widen the supported CLI requirement to `>= 1.18.9, < 2.0.0` so downstream runner images can consume GLM-capable OpenCode releases ([#316](https://github.com/viamin/agent-harness/issues/316)).
+
 ## [0.31.1](https://github.com/viamin/agent-harness/compare/agent-harness/v0.31.0...agent-harness/v0.31.1) (2026-07-20)
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    agent-harness (0.31.1)
+    agent-harness (0.32.0)
       logger (>= 1.6, < 2.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -301,10 +301,10 @@ opencode_install
 # => {
 #      source: :npm,
 #      package_name: "opencode-ai",
-#      version: "1.3.2",
-#      version_requirement: [">= 1.3.2", "< 1.4.0"],
+#      version: "1.18.9",
+#      version_requirement: [">= 1.18.9", "< 2.0.0"],
 #      binary_name: "opencode",
-#      install_command: ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.2"]
+#      install_command: ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.18.9"]
 #    }
 
 aider_install

--- a/lib/agent_harness/providers/opencode.rb
+++ b/lib/agent_harness/providers/opencode.rb
@@ -10,8 +10,8 @@ module AgentHarness
     # Provides integration with the OpenCode CLI tool.
     class Opencode < Base
       CLI_PACKAGE = "opencode-ai"
-      SUPPORTED_CLI_VERSION = "1.3.2"
-      SUPPORTED_CLI_REQUIREMENT = Gem::Requirement.new(">= #{SUPPORTED_CLI_VERSION}", "< 1.4.0").freeze
+      SUPPORTED_CLI_VERSION = "1.18.9"
+      SUPPORTED_CLI_REQUIREMENT = Gem::Requirement.new(">= #{SUPPORTED_CLI_VERSION}", "< 2.0.0").freeze
       INSTALL_COMMAND_PREFIX = ["npm", "install", "-g", "--ignore-scripts"].freeze
       # Allowlist of external_directory patterns auto-approved in
       # non-interactive execution. See the DEFAULT_PERMISSION_RULE comment

--- a/lib/agent_harness/version.rb
+++ b/lib/agent_harness/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AgentHarness
-  VERSION = "0.31.1"
+  VERSION = "0.32.0"
 end

--- a/spec/agent_harness/providers/opencode_spec.rb
+++ b/spec/agent_harness/providers/opencode_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe AgentHarness::Providers::Opencode do
       expect(contract).to include(
         source: :npm,
         package_name: "opencode-ai",
-        version: "1.3.2",
+        version: "1.18.9",
         binary_name: "opencode"
       )
-      expect(contract[:package]).to eq("opencode-ai@1.3.2")
-      expect(contract[:supported_versions]).to eq(["1.3.2"])
-      expect(contract[:version_requirement]).to eq([">= 1.3.2", "< 1.4.0"])
+      expect(contract[:package]).to eq("opencode-ai@1.18.9")
+      expect(contract[:supported_versions]).to eq(["1.18.9"])
+      expect(contract[:version_requirement]).to eq([">= 1.18.9", "< 2.0.0"])
       expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.2"]
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.18.9"]
       )
     end
 
@@ -52,16 +52,16 @@ RSpec.describe AgentHarness::Providers::Opencode do
     end
 
     it "supports explicit versions within the advertised requirement" do
-      contract = described_class.installation_contract(version: "1.3.9")
+      contract = described_class.installation_contract(version: "1.18.10")
 
-      expect(contract[:version]).to eq("1.3.9")
+      expect(contract[:version]).to eq("1.18.10")
       expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.18.10"]
       )
     end
 
     it "preserves postinstall fields in versioned contracts" do
-      contract = described_class.installation_contract(version: "1.3.9")
+      contract = described_class.installation_contract(version: "1.18.10")
 
       expect(contract[:requires_postinstall]).to be true
       expect(contract[:postinstall_command]).to eq(
@@ -76,23 +76,23 @@ RSpec.describe AgentHarness::Providers::Opencode do
     it "reuses the default frozen install contract for explicit default versions" do
       default_contract = described_class.installation_contract
 
-      expect(described_class.installation_contract(version: "1.3.2")).to equal(default_contract)
-      expect(described_class.installation_contract(version: " 1.3.2 ")).to equal(default_contract)
+      expect(described_class.installation_contract(version: "1.18.9")).to equal(default_contract)
+      expect(described_class.installation_contract(version: " 1.18.9 ")).to equal(default_contract)
     end
 
     it "normalizes surrounding whitespace in supported explicit versions" do
-      contract = described_class.installation_contract(version: " 1.3.9 ")
+      contract = described_class.installation_contract(version: " 1.18.10 ")
 
-      expect(contract[:version]).to eq("1.3.9")
-      expect(contract[:package]).to eq("opencode-ai@1.3.9")
+      expect(contract[:version]).to eq("1.18.10")
+      expect(contract[:package]).to eq("opencode-ai@1.18.10")
       expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.18.10"]
       )
     end
 
     it "rejects versions outside the advertised requirement" do
       expect {
-        described_class.installation_contract(version: "1.4.0")
+        described_class.installation_contract(version: "2.0.0")
       }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version/)
     end
 
@@ -137,40 +137,40 @@ RSpec.describe AgentHarness::Providers::Opencode do
       expect(contract[:postinstall_command]).to be_frozen
       expect { contract[:install_command_prefix] << "opencode-ai" }.to raise_error(FrozenError)
       expect { contract[:install_command] << "opencode-ai" }.to raise_error(FrozenError)
-      expect { contract[:supported_versions] << "1.3.1" }.to raise_error(FrozenError)
-      expect { contract[:version_requirement] << ">= 1.3.1" }.to raise_error(FrozenError)
+      expect { contract[:supported_versions] << "1.18.8" }.to raise_error(FrozenError)
+      expect { contract[:version_requirement] << ">= 1.18.8" }.to raise_error(FrozenError)
     end
   end
 
   describe ".install_command" do
     it "builds the default install command from the contract" do
       expect(described_class.install_command).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.2"]
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.18.9"]
       )
     end
 
     it "supports explicit version overrides" do
-      expect(described_class.install_command(version: "1.3.9")).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
+      expect(described_class.install_command(version: "1.18.10")).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.18.10"]
       )
     end
 
     it "reuses the default frozen install command for explicit default versions" do
       default_install_command = described_class.install_command
 
-      expect(described_class.install_command(version: "1.3.2")).to equal(default_install_command)
-      expect(described_class.install_command(version: " 1.3.2 ")).to equal(default_install_command)
+      expect(described_class.install_command(version: "1.18.9")).to equal(default_install_command)
+      expect(described_class.install_command(version: " 1.18.9 ")).to equal(default_install_command)
     end
 
     it "normalizes surrounding whitespace in explicit version overrides" do
-      expect(described_class.install_command(version: " 1.3.9 ")).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
+      expect(described_class.install_command(version: " 1.18.10 ")).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.18.10"]
       )
     end
 
     it "rejects unsupported version overrides" do
       expect {
-        described_class.install_command(version: "1.3.1")
+        described_class.install_command(version: "1.18.8")
       }.to raise_error(ArgumentError, /Unsupported OpenCode CLI version/)
     end
 

--- a/spec/agent_harness/providers/registry_spec.rb
+++ b/spec/agent_harness/providers/registry_spec.rb
@@ -358,15 +358,15 @@ RSpec.describe AgentHarness::Providers::Registry do
     end
 
     it "forwards target selection options to providers with generic contracts" do
-      contract = registry.installation_contract(:opencode, version: "1.3.9")
+      contract = registry.installation_contract(:opencode, version: "1.18.10")
 
       expect(contract).to include(
         package_name: "opencode-ai",
-        version: "1.3.9",
+        version: "1.18.10",
         binary_name: "opencode"
       )
       expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.18.10"]
       )
       expect(contract[:requires_postinstall]).to be true
       expect(contract[:postinstall_command]).to eq(
@@ -375,15 +375,15 @@ RSpec.describe AgentHarness::Providers::Registry do
     end
 
     it "preserves provider normalization for generic-contract version lookups" do
-      contract = registry.installation_contract(:opencode, version: " 1.3.9 ")
+      contract = registry.installation_contract(:opencode, version: " 1.18.10 ")
 
       expect(contract).to include(
         package_name: "opencode-ai",
-        version: "1.3.9",
+        version: "1.18.10",
         binary_name: "opencode"
       )
       expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.18.10"]
       )
       expect(contract[:requires_postinstall]).to be true
     end
@@ -472,7 +472,7 @@ RSpec.describe AgentHarness::Providers::Registry do
         ["uv", "tool", "install", "--force", "--python", "python3.12", "--with", "pip", "aider-chat==0.86.2"]
       )
       expect(contracts[:opencode][:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.2"]
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.18.9"]
       )
       expect(contracts[:opencode][:requires_postinstall]).to be true
       expect(contracts[:opencode][:postinstall_command]).to eq(

--- a/spec/agent_harness_spec.rb
+++ b/spec/agent_harness_spec.rb
@@ -297,15 +297,15 @@ RSpec.describe AgentHarness do
     end
 
     it "returns versioned install metadata for providers with generic contracts" do
-      contract = AgentHarness.installation_contract(:opencode, version: "1.3.9")
+      contract = AgentHarness.installation_contract(:opencode, version: "1.18.10")
 
       expect(contract).to include(
         package_name: "opencode-ai",
-        version: "1.3.9",
+        version: "1.18.10",
         binary_name: "opencode"
       )
       expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.18.10"]
       )
     end
 
@@ -339,15 +339,15 @@ RSpec.describe AgentHarness do
     end
 
     it "preserves provider normalization for generic-contract version lookups" do
-      contract = AgentHarness.installation_contract(:opencode, version: " 1.3.9 ")
+      contract = AgentHarness.installation_contract(:opencode, version: " 1.18.10 ")
 
       expect(contract).to include(
         package_name: "opencode-ai",
-        version: "1.3.9",
+        version: "1.18.10",
         binary_name: "opencode"
       )
       expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.3.9"]
+        ["npm", "install", "-g", "--ignore-scripts", "opencode-ai@1.18.10"]
       )
     end
   end


### PR DESCRIPTION
## Summary

Bump opencode-ai past 1.3.2 so zai_coding/glm models are recognized

See #316 for context.

---

Closes #316