### PR TITLE
fix(kilocode): bump Kilocode CLI from 7.1.3 to 7.4.16 — missing glm-5.x model catalog

### DIFF
--- a/lib/agent_harness/providers/kilocode.rb
+++ b/lib/agent_harness/providers/kilocode.rb
@@ -10,7 +10,7 @@ module AgentHarness
     # Provides integration with the Kilocode CLI tool.
     class Kilocode < Base
       PACKAGE_NAME = "@kilocode/cli"
-      DEFAULT_VERSION = "7.1.3"
+      DEFAULT_VERSION = "7.4.16"
       SUPPORTED_VERSION_REQUIREMENT = "= #{DEFAULT_VERSION}"
       STRUCTURED_EVENT_TYPES = %w[text error step_finish result usage].freeze
       # Kilo CLI (an OpenCode fork) ships the same external_directory

--- a/spec/agent_harness/providers/kilocode_spec.rb
+++ b/spec/agent_harness/providers/kilocode_spec.rb
@@ -22,18 +22,18 @@ RSpec.describe AgentHarness::Providers::Kilocode do
         package: "@kilocode/cli"
       })
       expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.1.3"]
+        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.4.16"]
       )
       expect(contract[:binary_name]).to eq("kilo")
-      expect(contract[:default_version]).to eq("7.1.3")
-      expect(contract[:supported_version_requirement]).to eq("= 7.1.3")
+      expect(contract[:default_version]).to eq("7.4.16")
+      expect(contract[:supported_version_requirement]).to eq("= 7.4.16")
     end
 
     it "can render an install command for an explicitly supported target" do
-      contract = described_class.installation_contract(version: "7.1.3")
+      contract = described_class.installation_contract(version: "7.4.16")
 
       expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.1.3"]
+        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.4.16"]
       )
     end
 
@@ -68,10 +68,10 @@ RSpec.describe AgentHarness::Providers::Kilocode do
     end
 
     it "normalizes padded version strings in the install command" do
-      contract = described_class.installation_contract(version: " 7.1.3 ")
+      contract = described_class.installation_contract(version: " 7.4.16 ")
 
       expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.1.3"]
+        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.4.16"]
       )
     end
   end
@@ -79,13 +79,13 @@ RSpec.describe AgentHarness::Providers::Kilocode do
   describe ".install_command" do
     it "returns the install command for the default supported version" do
       expect(described_class.install_command).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.1.3"]
+        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.4.16"]
       )
     end
 
     it "supports an explicit supported version" do
-      expect(described_class.install_command(version: "7.1.3")).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.1.3"]
+      expect(described_class.install_command(version: "7.4.16")).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.4.16"]
       )
     end
   end

--- a/spec/agent_harness/providers/registry_spec.rb
+++ b/spec/agent_harness/providers/registry_spec.rb
@@ -336,7 +336,7 @@ RSpec.describe AgentHarness::Providers::Registry do
         package: "@kilocode/cli"
       })
       expect(contract[:binary_name]).to eq("kilo")
-      expect(contract[:default_version]).to eq("7.1.3")
+      expect(contract[:default_version]).to eq("7.4.16")
     end
 
     it "falls back to the legacy provider install contract API when needed" do
@@ -350,10 +350,10 @@ RSpec.describe AgentHarness::Providers::Registry do
     end
 
     it "forwards target selection options to the provider" do
-      contract = registry.installation_contract(:kilocode, version: "7.1.3")
+      contract = registry.installation_contract(:kilocode, version: "7.4.16")
 
       expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.1.3"]
+        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.4.16"]
       )
     end
 
@@ -569,12 +569,12 @@ RSpec.describe AgentHarness::Providers::Registry do
         provider: :kilocode,
         source_type: :npm,
         package_name: "@kilocode/cli",
-        default_version: "7.1.3",
-        resolved_version: "7.1.3",
-        supported_version_requirement: "= 7.1.3",
+        default_version: "7.4.16",
+        resolved_version: "7.4.16",
+        supported_version_requirement: "= 7.4.16",
         binary_name: "kilo",
-        install_command: ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.1.3"],
-        install_command_string: "npm install -g --ignore-scripts @kilocode/cli@7.1.3"
+        install_command: ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.4.16"],
+        install_command_string: "npm install -g --ignore-scripts @kilocode/cli@7.4.16"
       )
     end
 


### PR DESCRIPTION
## Summary

fix(kilocode): bump Kilocode CLI from 7.1.3 to 7.4.16 — missing glm-5.x model catalog

See #315 for context.

---

Closes #315