### PR TITLE
fix(kilocode): bump Kilocode CLI from 7.1.3 to 7.4.16 — missing glm-5.x model catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,15 +205,15 @@ metadata instead of hardcoding package names, binary names, or supported
 versions out-of-band.
 
 ```ruby
-contract = AgentHarness.provider_installation_contract(:kilocode, version: "7.1.3")
+contract = AgentHarness.provider_installation_contract(:kilocode, version: "7.4.16")
 
 contract
 # {
 #   source: { type: :npm, package: "@kilocode/cli" },
-#   install_command: ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.1.3"],
+#   install_command: ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.4.16"],
 #   binary_name: "kilo",
-#   default_version: "7.1.3",
-#   supported_version_requirement: "= 7.1.3"
+#   default_version: "7.4.16",
+#   supported_version_requirement: "= 7.4.16"
 # }
 ```
 

--- a/lib/agent_harness/providers/kilocode.rb
+++ b/lib/agent_harness/providers/kilocode.rb
@@ -10,7 +10,7 @@ module AgentHarness
     # Provides integration with the Kilocode CLI tool.
     class Kilocode < Base
       PACKAGE_NAME = "@kilocode/cli"
-      DEFAULT_VERSION = "7.1.3"
+      DEFAULT_VERSION = "7.4.16"
       SUPPORTED_VERSION_REQUIREMENT = "= #{DEFAULT_VERSION}"
       STRUCTURED_EVENT_TYPES = %w[text error step_finish result usage].freeze
       # Kilo CLI (an OpenCode fork) ships the same external_directory

--- a/lib/agent_harness/providers/kilocode.rb
+++ b/lib/agent_harness/providers/kilocode.rb
@@ -13,6 +13,14 @@ module AgentHarness
       DEFAULT_VERSION = "7.4.16"
       SUPPORTED_VERSION_REQUIREMENT = "= #{DEFAULT_VERSION}"
       STRUCTURED_EVENT_TYPES = %w[text error step_finish result usage].freeze
+      MODEL_CATALOG = [
+        {name: "glm-5", family: "glm-5", tier: "standard", provider: "kilocode"},
+        {name: "glm-5.1", family: "glm-5.1", tier: "advanced", provider: "kilocode"},
+        {name: "glm-5.2", family: "glm-5.2", tier: "advanced", provider: "kilocode"},
+        {name: "glm-5-turbo", family: "glm-5-turbo", tier: "standard", provider: "kilocode"},
+        {name: "glm-5v-turbo", family: "glm-5v-turbo", tier: "standard", provider: "kilocode"}
+      ].map(&:freeze).freeze
+      MODEL_FAMILY_PATTERN = /\Aglm-5(?:[.-][\w.-]+)?\z/i
       # Kilo CLI (an OpenCode fork) ships the same external_directory
       # permission category as OpenCode, defaulting to "ask" for anything
       # outside the project dir. In non-interactive execution there is no
@@ -73,7 +81,20 @@ module AgentHarness
 
         def discover_models
           return [] unless available?
-          []
+
+          MODEL_CATALOG.map(&:dup)
+        end
+
+        def model_family(provider_model_name)
+          provider_model_name.to_s
+        end
+
+        def provider_model_name(family_name)
+          family_name.to_s
+        end
+
+        def supports_model_family?(family_name)
+          MODEL_FAMILY_PATTERN.match?(family_name.to_s)
         end
 
         def installation_contract(version: DEFAULT_VERSION)

--- a/lib/agent_harness/providers/kilocode.rb
+++ b/lib/agent_harness/providers/kilocode.rb
@@ -13,17 +13,32 @@ module AgentHarness
       DEFAULT_VERSION = "7.4.16"
       SUPPORTED_VERSION_REQUIREMENT = "= #{DEFAULT_VERSION}"
       STRUCTURED_EVENT_TYPES = %w[text error step_finish result usage].freeze
-      MODEL_CATALOG = [
-        {name: "glm-5", family: "glm-5", tier: "standard", provider: "kilocode"},
-        {name: "glm-5.1", family: "glm-5.1", tier: "advanced", provider: "kilocode"},
-        {name: "glm-5.2", family: "glm-5.2", tier: "advanced", provider: "kilocode"},
-        {name: "glm-5p1", family: "glm-5p1", tier: "advanced", provider: "kilocode"},
-        {name: "glm-5p1-fast", family: "glm-5p1-fast", tier: "standard", provider: "kilocode"},
-        {name: "glm-5p2", family: "glm-5p2", tier: "advanced", provider: "kilocode"},
-        {name: "glm-5p2-fast", family: "glm-5p2-fast", tier: "standard", provider: "kilocode"},
-        {name: "glm-5-turbo", family: "glm-5-turbo", tier: "standard", provider: "kilocode"},
-        {name: "glm-5v-turbo", family: "glm-5v-turbo", tier: "standard", provider: "kilocode"}
-      ].map(&:freeze).freeze
+      MODEL_NAMES = %w[
+        glm-5
+        glm-5.1
+        glm-5.1-free
+        glm-5.1-thinking
+        glm-5.2
+        glm-5.2-fast
+        glm-5.2-flex
+        glm-5.2-free
+        glm-5.2-nitro
+        glm-5.2-short
+        glm-5.2-short-fast
+        glm-5.2-short-fast-flex
+        glm-5.2-short-flex
+        glm-5p1
+        glm-5p1-fast
+        glm-5p2
+        glm-5p2-fast
+        glm-5v-turbo
+      ].freeze
+      MODEL_CATALOG = MODEL_NAMES.map do |name|
+        tier = name.include?("free") ? "free" : "standard"
+        tier = "advanced" if %w[glm-5.1 glm-5.1-thinking glm-5.2 glm-5p1 glm-5p2].include?(name)
+
+        {name: name, family: name, tier: tier, provider: "kilocode"}.freeze
+      end.freeze
       MODEL_FAMILY_PATTERN = /\Aglm-5(?:[a-z][\w.-]*|[.-][\w.-]+)?\z/i
       # Kilo CLI (an OpenCode fork) ships the same external_directory
       # permission category as OpenCode, defaulting to "ask" for anything

--- a/lib/agent_harness/providers/kilocode.rb
+++ b/lib/agent_harness/providers/kilocode.rb
@@ -17,10 +17,14 @@ module AgentHarness
         {name: "glm-5", family: "glm-5", tier: "standard", provider: "kilocode"},
         {name: "glm-5.1", family: "glm-5.1", tier: "advanced", provider: "kilocode"},
         {name: "glm-5.2", family: "glm-5.2", tier: "advanced", provider: "kilocode"},
+        {name: "glm-5p1", family: "glm-5p1", tier: "advanced", provider: "kilocode"},
+        {name: "glm-5p1-fast", family: "glm-5p1-fast", tier: "standard", provider: "kilocode"},
+        {name: "glm-5p2", family: "glm-5p2", tier: "advanced", provider: "kilocode"},
+        {name: "glm-5p2-fast", family: "glm-5p2-fast", tier: "standard", provider: "kilocode"},
         {name: "glm-5-turbo", family: "glm-5-turbo", tier: "standard", provider: "kilocode"},
         {name: "glm-5v-turbo", family: "glm-5v-turbo", tier: "standard", provider: "kilocode"}
       ].map(&:freeze).freeze
-      MODEL_FAMILY_PATTERN = /\Aglm-5(?:[.-][\w.-]+)?\z/i
+      MODEL_FAMILY_PATTERN = /\Aglm-5(?:[a-z][\w.-]*|[.-][\w.-]+)?\z/i
       # Kilo CLI (an OpenCode fork) ships the same external_directory
       # permission category as OpenCode, defaulting to "ask" for anything
       # outside the project dir. In non-interactive execution there is no

--- a/spec/agent_harness/providers/kilocode_spec.rb
+++ b/spec/agent_harness/providers/kilocode_spec.rb
@@ -105,9 +105,65 @@ RSpec.describe AgentHarness::Providers::Kilocode do
   end
 
   describe ".discover_models" do
+    let(:mock_executor) { instance_double(AgentHarness::CommandExecutor) }
+
+    before do
+      allow(AgentHarness.configuration).to receive(:command_executor).and_return(mock_executor)
+    end
+
+    context "when kilocode is available" do
+      before do
+        allow(mock_executor).to receive(:which).with("kilo").and_return("/usr/local/bin/kilo")
+      end
+
+      it "returns the bundled GLM-5 model catalog" do
+        models = described_class.discover_models
+
+        expect(models).to eq([
+          {name: "glm-5", family: "glm-5", tier: "standard", provider: "kilocode"},
+          {name: "glm-5.1", family: "glm-5.1", tier: "advanced", provider: "kilocode"},
+          {name: "glm-5.2", family: "glm-5.2", tier: "advanced", provider: "kilocode"},
+          {name: "glm-5-turbo", family: "glm-5-turbo", tier: "standard", provider: "kilocode"},
+          {name: "glm-5v-turbo", family: "glm-5v-turbo", tier: "standard", provider: "kilocode"}
+        ])
+      end
+
+      it "returns mutable copies of the catalog entries" do
+        described_class.discover_models.first[:name] = "changed"
+
+        expect(described_class.discover_models.first[:name]).to eq("glm-5")
+      end
+    end
+
     it "returns empty when not available" do
-      allow(described_class).to receive(:available?).and_return(false)
+      allow(mock_executor).to receive(:which).with("kilo").and_return(nil)
+
       expect(described_class.discover_models).to eq([])
+    end
+  end
+
+  describe ".model_family" do
+    it "returns the provider model name unchanged" do
+      expect(described_class.model_family("glm-5.1")).to eq("glm-5.1")
+    end
+  end
+
+  describe ".provider_model_name" do
+    it "returns the family name unchanged" do
+      expect(described_class.provider_model_name("glm-5.2")).to eq("glm-5.2")
+    end
+  end
+
+  describe ".supports_model_family?" do
+    it "returns true for GLM-5 model families" do
+      expect(described_class.supports_model_family?("glm-5")).to be true
+      expect(described_class.supports_model_family?("glm-5.1")).to be true
+      expect(described_class.supports_model_family?("glm-5.2-fast")).to be true
+    end
+
+    it "returns false for non-GLM-5 model families" do
+      expect(described_class.supports_model_family?("glm-4.5")).to be false
+      expect(described_class.supports_model_family?("claude-3-sonnet")).to be false
     end
   end
 

--- a/spec/agent_harness/providers/kilocode_spec.rb
+++ b/spec/agent_harness/providers/kilocode_spec.rb
@@ -22,18 +22,18 @@ RSpec.describe AgentHarness::Providers::Kilocode do
         package: "@kilocode/cli"
       })
       expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.1.3"]
+        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.4.16"]
       )
       expect(contract[:binary_name]).to eq("kilo")
-      expect(contract[:default_version]).to eq("7.1.3")
-      expect(contract[:supported_version_requirement]).to eq("= 7.1.3")
+      expect(contract[:default_version]).to eq("7.4.16")
+      expect(contract[:supported_version_requirement]).to eq("= 7.4.16")
     end
 
     it "can render an install command for an explicitly supported target" do
-      contract = described_class.installation_contract(version: "7.1.3")
+      contract = described_class.installation_contract(version: "7.4.16")
 
       expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.1.3"]
+        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.4.16"]
       )
     end
 
@@ -68,10 +68,10 @@ RSpec.describe AgentHarness::Providers::Kilocode do
     end
 
     it "normalizes padded version strings in the install command" do
-      contract = described_class.installation_contract(version: " 7.1.3 ")
+      contract = described_class.installation_contract(version: " 7.4.16 ")
 
       expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.1.3"]
+        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.4.16"]
       )
     end
   end
@@ -79,13 +79,13 @@ RSpec.describe AgentHarness::Providers::Kilocode do
   describe ".install_command" do
     it "returns the install command for the default supported version" do
       expect(described_class.install_command).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.1.3"]
+        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.4.16"]
       )
     end
 
     it "supports an explicit supported version" do
-      expect(described_class.install_command(version: "7.1.3")).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.1.3"]
+      expect(described_class.install_command(version: "7.4.16")).to eq(
+        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.4.16"]
       )
     end
   end

--- a/spec/agent_harness/providers/kilocode_spec.rb
+++ b/spec/agent_harness/providers/kilocode_spec.rb
@@ -119,17 +119,28 @@ RSpec.describe AgentHarness::Providers::Kilocode do
       it "returns the bundled GLM-5 model catalog" do
         models = described_class.discover_models
 
-        expect(models).to eq([
-          {name: "glm-5", family: "glm-5", tier: "standard", provider: "kilocode"},
-          {name: "glm-5.1", family: "glm-5.1", tier: "advanced", provider: "kilocode"},
-          {name: "glm-5.2", family: "glm-5.2", tier: "advanced", provider: "kilocode"},
-          {name: "glm-5p1", family: "glm-5p1", tier: "advanced", provider: "kilocode"},
-          {name: "glm-5p1-fast", family: "glm-5p1-fast", tier: "standard", provider: "kilocode"},
-          {name: "glm-5p2", family: "glm-5p2", tier: "advanced", provider: "kilocode"},
-          {name: "glm-5p2-fast", family: "glm-5p2-fast", tier: "standard", provider: "kilocode"},
-          {name: "glm-5-turbo", family: "glm-5-turbo", tier: "standard", provider: "kilocode"},
-          {name: "glm-5v-turbo", family: "glm-5v-turbo", tier: "standard", provider: "kilocode"}
+        expect(models.map { |model| model.fetch(:name) }).to eq([
+          "glm-5",
+          "glm-5.1",
+          "glm-5.1-free",
+          "glm-5.1-thinking",
+          "glm-5.2",
+          "glm-5.2-fast",
+          "glm-5.2-flex",
+          "glm-5.2-free",
+          "glm-5.2-nitro",
+          "glm-5.2-short",
+          "glm-5.2-short-fast",
+          "glm-5.2-short-fast-flex",
+          "glm-5.2-short-flex",
+          "glm-5p1",
+          "glm-5p1-fast",
+          "glm-5p2",
+          "glm-5p2-fast",
+          "glm-5v-turbo"
         ])
+        expect(models).to all(include(provider: "kilocode"))
+        expect(models).to all(satisfy { |model| model.fetch(:family) == model.fetch(:name) })
       end
 
       it "returns mutable copies of the catalog entries" do
@@ -168,7 +179,11 @@ RSpec.describe AgentHarness::Providers::Kilocode do
     it "returns true for GLM-5 model families" do
       expect(described_class.supports_model_family?("glm-5")).to be true
       expect(described_class.supports_model_family?("glm-5.1")).to be true
+      expect(described_class.supports_model_family?("glm-5.1-free")).to be true
+      expect(described_class.supports_model_family?("glm-5.1-thinking")).to be true
+      expect(described_class.supports_model_family?("glm-5.2-flex")).to be true
       expect(described_class.supports_model_family?("glm-5.2-fast")).to be true
+      expect(described_class.supports_model_family?("glm-5.2-short-fast-flex")).to be true
       expect(described_class.supports_model_family?("glm-5p1")).to be true
       expect(described_class.supports_model_family?("glm-5p1-fast")).to be true
       expect(described_class.supports_model_family?("glm-5p2")).to be true

--- a/spec/agent_harness/providers/kilocode_spec.rb
+++ b/spec/agent_harness/providers/kilocode_spec.rb
@@ -123,6 +123,10 @@ RSpec.describe AgentHarness::Providers::Kilocode do
           {name: "glm-5", family: "glm-5", tier: "standard", provider: "kilocode"},
           {name: "glm-5.1", family: "glm-5.1", tier: "advanced", provider: "kilocode"},
           {name: "glm-5.2", family: "glm-5.2", tier: "advanced", provider: "kilocode"},
+          {name: "glm-5p1", family: "glm-5p1", tier: "advanced", provider: "kilocode"},
+          {name: "glm-5p1-fast", family: "glm-5p1-fast", tier: "standard", provider: "kilocode"},
+          {name: "glm-5p2", family: "glm-5p2", tier: "advanced", provider: "kilocode"},
+          {name: "glm-5p2-fast", family: "glm-5p2-fast", tier: "standard", provider: "kilocode"},
           {name: "glm-5-turbo", family: "glm-5-turbo", tier: "standard", provider: "kilocode"},
           {name: "glm-5v-turbo", family: "glm-5v-turbo", tier: "standard", provider: "kilocode"}
         ])
@@ -155,15 +159,27 @@ RSpec.describe AgentHarness::Providers::Kilocode do
   end
 
   describe ".supports_model_family?" do
+    it "supports every bundled catalog family" do
+      described_class::MODEL_CATALOG.each do |model|
+        expect(described_class.supports_model_family?(model.fetch(:family))).to be true
+      end
+    end
+
     it "returns true for GLM-5 model families" do
       expect(described_class.supports_model_family?("glm-5")).to be true
       expect(described_class.supports_model_family?("glm-5.1")).to be true
       expect(described_class.supports_model_family?("glm-5.2-fast")).to be true
+      expect(described_class.supports_model_family?("glm-5p1")).to be true
+      expect(described_class.supports_model_family?("glm-5p1-fast")).to be true
+      expect(described_class.supports_model_family?("glm-5p2")).to be true
+      expect(described_class.supports_model_family?("glm-5p2-fast")).to be true
+      expect(described_class.supports_model_family?("glm-5v-turbo")).to be true
     end
 
     it "returns false for non-GLM-5 model families" do
       expect(described_class.supports_model_family?("glm-4.5")).to be false
       expect(described_class.supports_model_family?("claude-3-sonnet")).to be false
+      expect(described_class.supports_model_family?("glm-50")).to be false
     end
   end
 

--- a/spec/agent_harness/providers/registry_spec.rb
+++ b/spec/agent_harness/providers/registry_spec.rb
@@ -336,7 +336,7 @@ RSpec.describe AgentHarness::Providers::Registry do
         package: "@kilocode/cli"
       })
       expect(contract[:binary_name]).to eq("kilo")
-      expect(contract[:default_version]).to eq("7.1.3")
+      expect(contract[:default_version]).to eq("7.4.16")
     end
 
     it "falls back to the legacy provider install contract API when needed" do
@@ -350,10 +350,10 @@ RSpec.describe AgentHarness::Providers::Registry do
     end
 
     it "forwards target selection options to the provider" do
-      contract = registry.installation_contract(:kilocode, version: "7.1.3")
+      contract = registry.installation_contract(:kilocode, version: "7.4.16")
 
       expect(contract[:install_command]).to eq(
-        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.1.3"]
+        ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.4.16"]
       )
     end
 
@@ -569,12 +569,12 @@ RSpec.describe AgentHarness::Providers::Registry do
         provider: :kilocode,
         source_type: :npm,
         package_name: "@kilocode/cli",
-        default_version: "7.1.3",
-        resolved_version: "7.1.3",
-        supported_version_requirement: "= 7.1.3",
+        default_version: "7.4.16",
+        resolved_version: "7.4.16",
+        supported_version_requirement: "= 7.4.16",
         binary_name: "kilo",
-        install_command: ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.1.3"],
-        install_command_string: "npm install -g --ignore-scripts @kilocode/cli@7.1.3"
+        install_command: ["npm", "install", "-g", "--ignore-scripts", "@kilocode/cli@7.4.16"],
+        install_command_string: "npm install -g --ignore-scripts @kilocode/cli@7.4.16"
       )
     end
 

--- a/spec/agent_harness_spec.rb
+++ b/spec/agent_harness_spec.rb
@@ -183,12 +183,12 @@ RSpec.describe AgentHarness do
     end
 
     it "forwards target selection options to the provider registry" do
-      contract = {binary_name: "kilo", default_version: "7.1.3"}
+      contract = {binary_name: "kilo", default_version: "7.4.16"}
 
       expect(AgentHarness::Providers::Registry.instance)
-        .to receive(:installation_contract).with(:kilocode, version: "7.1.3").and_return(contract)
+        .to receive(:installation_contract).with(:kilocode, version: "7.4.16").and_return(contract)
 
-      expect(AgentHarness.provider_installation_contract(:kilocode, version: "7.1.3")).to eq(contract)
+      expect(AgentHarness.provider_installation_contract(:kilocode, version: "7.4.16")).to eq(contract)
     end
   end
 
@@ -288,12 +288,12 @@ RSpec.describe AgentHarness do
     end
 
     it "forwards target selection options to the provider registry" do
-      contract = {binary_name: "kilo", default_version: "7.1.3"}
+      contract = {binary_name: "kilo", default_version: "7.4.16"}
 
       expect(AgentHarness::Providers::Registry.instance)
-        .to receive(:installation_contract).with(:kilocode, version: "7.1.3").and_return(contract)
+        .to receive(:installation_contract).with(:kilocode, version: "7.4.16").and_return(contract)
 
-      expect(AgentHarness.installation_contract(:kilocode, version: "7.1.3")).to eq(contract)
+      expect(AgentHarness.installation_contract(:kilocode, version: "7.4.16")).to eq(contract)
     end
 
     it "returns versioned install metadata for providers with generic contracts" do


### PR DESCRIPTION
## Summary

fix(kilocode): bump Kilocode CLI from 7.1.3 to 7.4.16 — missing glm-5.x model catalog

See #315 for context.

---

Closes #315